### PR TITLE
MCP registry readiness: streamable-http transport, OCI package, auto-…

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,30 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        run: ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ docs/config/commands.mdx
 docs/config/ec2-ollama.mdx
 docs/config/mcp-registry.mdx
 docs/config/new-release.mdx
+docs/plans/
 
 # mcp-publisher tokens
 .mcpregistry_github_token

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+LABEL io.modelcontextprotocol.server.name="io.github.datris/datris"
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "datris-mcp-server"
 version = "1.4.4"
-description = "MCP server for the Datris AI Agent-Native Data Platform"
+description = "MCP server for AI-driven data pipeline operations — ingest, validate, transform, analyze, and query data. 32 tools covering ETL, AI data quality, vector search, PostgreSQL, MongoDB, Kafka, S3/MinIO, HashiCorp Vault, Qdrant, Weaviate, Milvus, Chroma, pgvector."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [
     {name = "Datris", email = "info@datris.ai"}
 ]
-keywords = ["mcp", "datris", "data-platform", "ai-agent", "model-context-protocol"]
+keywords = ["mcp", "datris", "data-platform", "ai-agent", "model-context-protocol", "etl", "data-quality", "vector-search", "postgresql", "mongodb", "kafka", "qdrant", "weaviate", "milvus", "chroma", "pgvector", "minio", "hashicorp-vault"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -2,10 +2,11 @@
 """
 Datris MCP Server
 
-A thin REST API client that exposes the Datris platform as MCP tools so AI agents
-(Claude, Cursor, etc.) can natively interact with the platform — discover data,
-create pipelines, upload files, monitor jobs, search vector databases, query
-structured data, and answer questions with AI.
+MCP server for AI-driven data platform operations — ingest, validate, transform,
+analyze, and query data from enterprise sources. 32 tools covering ETL orchestration,
+AI-generated data quality rules (Python codegen via LLM), vector database search,
+and secrets-managed connectivity. Supports PostgreSQL, MongoDB, Kafka, S3/MinIO,
+HashiCorp Vault, and vector stores (Qdrant, Weaviate, Milvus, Chroma, pgvector).
 
 Usage:
     pip install -r requirements.txt
@@ -15,6 +16,9 @@ Usage:
 
     # SSE mode (for Docker / remote agents)
     python server.py --sse --port 3000
+
+    # Streamable HTTP mode (for Smithery / remote clients)
+    python server.py --streamable-http --port 3000
 """
 
 import argparse
@@ -1335,15 +1339,49 @@ async def run_sse(port: int):
     await srv.serve()
 
 
+async def run_streamable_http(port: int):
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    import contextlib
+    import uvicorn
+
+    session_manager = StreamableHTTPSessionManager(app=server, json_response=False, stateless=True)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        async with session_manager.run():
+            yield
+
+    async def app(scope, receive, send):
+        if scope["type"] == "lifespan":
+            from starlette.applications import Starlette
+            starlette_app = Starlette(lifespan=lifespan)
+            await starlette_app(scope, receive, send)
+            return
+        if scope["type"] == "http":
+            path = scope.get("path", "")
+            if path == "/mcp":
+                await session_manager.handle_request(scope, receive, send)
+                return
+        await send({"type": "http.response.start", "status": 404, "headers": []})
+        await send({"type": "http.response.body", "body": b"Not Found"})
+
+    config = uvicorn.Config(app, host="0.0.0.0", port=port, lifespan="on")
+    srv = uvicorn.Server(config)
+    await srv.serve()
+
+
 def main():
     import asyncio
 
     parser = argparse.ArgumentParser(description="Datris MCP Server")
     parser.add_argument("--sse", action="store_true", help="Run in SSE mode (default: stdio)")
-    parser.add_argument("--port", type=int, default=3000, help="SSE port (default: 3000)")
+    parser.add_argument("--streamable-http", action="store_true", help="Run in Streamable HTTP mode")
+    parser.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
     args = parser.parse_args()
 
-    if args.sse:
+    if args.streamable_http:
+        asyncio.run(run_streamable_http(args.port))
+    elif args.sse:
         asyncio.run(run_sse(args.port))
     else:
         asyncio.run(run_stdio())

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.datris/datris",
   "title": "Datris",
-  "description": "AI Agent-Native Data Platform — ingest, validate, transform, query, and search data.",
+  "description": "MCP server for AI-driven data platform operations — ingest, validate, transform, analyze, and query data from enterprise sources. 32 tools covering ETL orchestration, AI-generated data quality rules (Python codegen via LLM), vector database search, and secrets-managed connectivity. Supports PostgreSQL, MongoDB, Kafka, S3/MinIO, HashiCorp Vault, and vector stores (Qdrant, Weaviate, Milvus, Chroma, pgvector). Open source (AGPL), installable via uvx datris-mcp-server.",
   "repository": {
     "url": "https://github.com/datris/datris-platform-oss",
     "source": "github"
@@ -15,6 +15,31 @@
       "version": "1.4.4",
       "transport": {
         "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PIPELINE_URL",
+          "description": "URL of the Datris pipeline server",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PIPELINE_API_KEY",
+          "description": "API key for the Datris pipeline server (if key validation is enabled)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/datrisai/datris-mcp-server:1.4.4",
+      "version": "1.4.4",
+      "runtimeHint": "docker",
+      "transport": {
+        "type": "sse"
       },
       "environmentVariables": [
         {


### PR DESCRIPTION
…publish workflow, vertical-rich descriptions

- Add streamable-http transport to MCP server (--streamable-http flag) for Smithery/Kong compatibility
- Add OCI Docker package entry to server.json alongside PyPI
- Add MCP registry LABEL to mcp-server/Dockerfile for OCI verification
- Create mcp-registry-publish.yml GitHub Actions workflow (OIDC, auto-publishes on tag push)
- Update server.json and pyproject.toml descriptions with specific verticals (PostgreSQL, MongoDB, Kafka, S3/MinIO, Vault, Qdrant, Weaviate, Milvus, Chroma, pgvector)
- Expand pyproject.toml keywords for PyPI discoverability
- Gitignore docs/plans/