### PR TITLE
Security audit fixes, Vault token randomization, and CI dependency/image scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,20 @@ OPENAI_API_KEY=
 # USE_API_KEYS=false
 # MULTI_TENANT=false
 
+# Hardening (recommended for any internet-reachable deployment):
+# SESSION_COOKIE_SECURE=true marks the login cookie Secure so it is only sent
+#   over HTTPS. Leave unset for local HTTP dev; set true wherever TLS terminates.
+# MINIO_WEBHOOK_TOKEN authenticates the MinIO -> /minio-events webhook. Set it to
+#   a long random value to close the otherwise-unauthenticated ingestion trigger
+#   (MinIO is configured with the same value automatically).
+# DATRIS_ALLOW_PRIVATE_EGRESS=true permits HTTP taps / REST endpoints to call
+#   private, loopback, or link-local addresses. Off by default so a tap can't be
+#   pointed at cloud metadata or internal services; enable only if your endpoints
+#   legitimately live on an internal network.
+# SESSION_COOKIE_SECURE=true
+# MINIO_WEBHOOK_TOKEN=change-me-to-a-long-random-string
+# DATRIS_ALLOW_PRIVATE_EGRESS=false
+
 # API keys for accessing Datris (REST API or via the bundled MCP server) are
 # managed in the Configuration UI's Secrets tab — entries in `oss/api-keys`
 # under USE_API_KEYS=true, and per-tenant under MULTI_TENANT=true. There is

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 # Dependabot — automated dependency-update PRs for known-vulnerable and
 # outdated dependencies. Covers every ecosystem Dependabot supports natively.
 #
-# NOT covered here: the Scala/sbt server dependencies — Dependabot has no sbt
-# support. Those are scanned in CI via Trivy (see .github/workflows/security-scan.yml,
-# the published-image scan) and, if deeper coverage is wanted, sbt-dependency-check.
+# Scala/sbt server dependencies: Dependabot has no native sbt ecosystem, so the
+# sbt dependency graph is submitted to GitHub separately (see
+# .github/workflows/scala-dependency-graph.yml). That makes Dependabot raise
+# alerts for the Scala/JVM deps too, using the GitHub Advisory Database.
 version: 2
 updates:
   # GitHub Actions used in our workflows (keeps the SHA-pinned actions patched).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+# Dependabot — automated dependency-update PRs for known-vulnerable and
+# outdated dependencies. Covers every ecosystem Dependabot supports natively.
+#
+# NOT covered here: the Scala/sbt server dependencies — Dependabot has no sbt
+# support. Those are scanned in CI via Trivy (see .github/workflows/security-scan.yml,
+# the published-image scan) and, if deeper coverage is wanted, sbt-dependency-check.
+version: 2
+updates:
+  # GitHub Actions used in our workflows (keeps the SHA-pinned actions patched).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # UI (Angular) npm dependencies.
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      # One PR for the low-risk patch/minor bumps; majors stay individual so
+      # they can be reviewed on their own.
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # MCP server (Python) dependencies.
+  - package-ecosystem: "pip"
+    directory: "/mcp-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker base images — one entry per Dockerfile. Keeps FROM base images
+  # (JRE, nginx, python) patched against OS-package CVEs.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/mcp-server"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/tap-runner"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/scala-dependency-graph.yml
+++ b/.github/workflows/scala-dependency-graph.yml
@@ -1,0 +1,49 @@
+name: Scala Dependency Graph
+
+# Submits the sbt dependency graph (server + all transitive JVM deps) to
+# GitHub's Dependency Graph. GitHub then raises Dependabot alerts — and, where
+# possible, Dependabot update PRs — for the Scala/JVM dependencies against the
+# GitHub Advisory Database. This is what closes the one gap Dependabot's native
+# ecosystems can't: sbt has no built-in Dependabot support.
+#
+# Maintained by the Scala Center; uses GitHub's advisory data (no NVD API key).
+# Runs on pushes to the default branch, since the dependency graph is tracked
+# per default branch.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write # required to submit the dependency snapshot
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Java 17 and SBT
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'sbt'
+
+      - name: Install SBT via Coursier
+        run: |
+          curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
+          chmod +x cs
+          # Pin the sbt launcher to 1.x (matches project/build.properties), same
+          # as ci.yml — bare `--apps sbt` now resolves sbt 2.x.
+          ./cs setup --yes --apps sbt:1.12.5
+          echo "$HOME/.local/share/coursier/bin" >> $GITHUB_PATH
+
+      - name: Submit dependency graph
+        uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.2.3

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,116 @@
+name: Security Scan
+
+# Trivy-based scanning that complements Dependabot:
+#   - dependency-scan: filesystem scan of the repo — vulnerable deps in
+#     lockfiles (npm/pip), accidentally-committed secrets, and IaC misconfig
+#     (Dockerfiles / compose). Runs on every PR and push so regressions are
+#     caught before merge.
+#   - image-scan: scans the PUBLISHED datrisai/* images for OS-package and
+#     language CVEs (this is what covers the Scala/JVM + OS layers that the
+#     filesystem scan and Dependabot can't see). Runs on a weekly schedule so
+#     newly-disclosed CVEs in already-shipped images surface without a rebuild.
+#
+# Findings are report-only for now (exit-code 0) so a backlog of pre-existing
+# CVEs doesn't block every PR on day one. Flip exit-code to '1' on the
+# dependency-scan step to make new HIGH/CRITICAL findings fail the build once
+# the initial backlog is triaged. Results also upload to the Security tab.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write # upload SARIF to the code-scanning (Security) tab
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  dependency-scan:
+    name: Dependencies / secrets / misconfig
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Trivy filesystem scan (log output)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true # only surface CVEs that have a fix available
+          format: table
+          exit-code: "0" # report-only; set to "1" to fail the build on findings
+
+      - name: Trivy filesystem scan (SARIF)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-fs.sarif
+
+      - name: Upload filesystem SARIF
+        uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+        continue-on-error: true # degrade gracefully if code scanning isn't enabled
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  image-scan:
+    name: Published image CVEs
+    # Published images don't change per PR — scan on the schedule (and on demand)
+    # to catch CVEs newly disclosed against already-shipped images.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - datris-server
+          - datris-ui
+          - datris-mcp-server
+          - datris-tap-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Trivy image scan (log output)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          scan-type: image
+          image-ref: datrisai/${{ matrix.image }}:latest
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          exit-code: "0"
+
+      - name: Trivy image scan (SARIF)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          scan-type: image
+          image-ref: datrisai/${{ matrix.image }}:latest
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+
+      - name: Upload image SARIF
+        uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+        continue-on-error: true
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-image-${{ matrix.image }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,9 +6,12 @@ name: Security Scan
 #     (Dockerfiles / compose). Runs on every PR and push so regressions are
 #     caught before merge.
 #   - image-scan: scans the PUBLISHED datrisai/* images for OS-package and
-#     language CVEs (this is what covers the Scala/JVM + OS layers that the
-#     filesystem scan and Dependabot can't see). Runs on a weekly schedule so
-#     newly-disclosed CVEs in already-shipped images surface without a rebuild.
+#     language CVEs (the OS layer that the filesystem scan and Dependabot can't
+#     see). Runs on a weekly schedule so newly-disclosed CVEs in already-shipped
+#     images surface without a rebuild.
+#
+# Scala/JVM library CVEs are covered separately via the GitHub Dependency Graph
+# (see .github/workflows/scala-dependency-graph.yml), which feeds Dependabot.
 #
 # Findings are report-only for now (exit-code 0) so a backlog of pre-existing
 # CVEs doesn't block every PR on day one. Flip exit-code to '1' on the

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Trivy filesystem scan (log output)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -54,7 +54,7 @@ jobs:
           exit-code: "0" # report-only; set to "1" to fail the build on findings
 
       - name: Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Trivy image scan (log output)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: image
           image-ref: datrisai/${{ matrix.image }}:latest
@@ -101,7 +101,7 @@ jobs:
           exit-code: "0"
 
       - name: Trivy image scan (SARIF)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: image
           image-ref: datrisai/${{ matrix.image }}:latest

--- a/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
@@ -173,17 +173,45 @@ class StartupRunner extends ApplicationRunner {
     private def initUserAuth(): Unit = {
         try {
             SessionStore.ensureIndex()
-            if (UserStore.list().isEmpty) {
+            val existingUsers = UserStore.list()
+            if (existingUsers.nonEmpty) {
+                // Upgrade safety: any pre-existing account with a null/empty
+                // hash was previously loginable with ANY password (the takeover
+                // hole). Login now always verifies, which would lock these
+                // accounts out — so rotate each to a random bootstrap password,
+                // printed once, and close the hole at the same time.
+                existingUsers.filter(_.mustSetPassword).foreach { u =>
+                    val pw = ai.datris.util.PasswordHasher.generateTemporary()
+                    UserStore.updatePasswordHash(u.username, ai.datris.util.PasswordHasher.hash(pw))
+                    logger.warn(
+                        "User '" + u.username + "' had no password set (previously loginable with any password). " +
+                            "Assigned a bootstrap password: " + pw + "  (shown once; log in and change it immediately)"
+                    )
+                }
+            }
+            if (existingUsers.isEmpty) {
                 val now = java.time.Instant.now().toString
+                // Seed with a random bootstrap password rather than a null hash.
+                // A null hash made the admin account claimable by anyone who
+                // reached /auth/login first (any password was accepted), so an
+                // attacker could take over admin on a fresh deploy before the
+                // operator's first login. The password is printed to the server
+                // log exactly once here; the operator reads it from the logs to
+                // log in, then changes it. It is never stored in plaintext.
+                val bootstrapPassword = ai.datris.util.PasswordHasher.generateTemporary()
                 UserStore.insert(User(
                     username = "admin",
-                    passwordHash = null, // null = forces set-password on first login
+                    passwordHash = ai.datris.util.PasswordHasher.hash(bootstrapPassword),
                     role = User.RoleAdmin,
                     createdAt = now,
                     updatedAt = now,
                     lastLoginAt = null
                 ))
-                logger.info("Seeded default admin user (no password set — first login will prompt)")
+                logger.info(
+                    "Seeded default admin user. Bootstrap login — username: admin  password: {}  " +
+                        "(shown once; log in and change it immediately)",
+                    bootstrapPassword
+                )
             }
         } catch {
             case e: Exception =>

--- a/datrisserver/src/main/scala/ai/datris/api/AuthAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/AuthAPIController.scala
@@ -57,13 +57,16 @@ class AuthAPIController {
             }
             val user = userOpt.get
 
-            // First-login flow: passwordHash is null/empty. Accept any password (typically empty)
-            // and force the client through change-password before doing anything else.
-            if (!user.mustSetPassword) {
-                if (!PasswordHasher.verify(password, user.passwordHash)) {
-                    logger.info("Login failed: bad password for: " + username)
-                    return unauthorized()
-                }
+            // Always verify the password. A null/empty stored hash used to be
+            // treated as "first login, accept any password", which let anyone
+            // claim an unclaimed account (notably the seeded admin) before its
+            // owner. Accounts are now always seeded/created with a real hash
+            // (see StartupRunner and createUser), and PasswordHasher.verify
+            // returns false for a null/empty hash — so a stale null-hash account
+            // simply cannot be logged into until an admin resets it.
+            if (!PasswordHasher.verify(password, user.passwordHash)) {
+                logger.info("Login failed: bad password for: " + username)
+                return unauthorized()
             }
 
             val session = SessionStore.create(user.username)
@@ -163,9 +166,22 @@ class AuthAPIController {
             if (UserStore.find(username).isDefined)
                 return ResponseEntity.status(HttpStatus.CONFLICT).body("""{"error":"User already exists"}""")
 
-            val hash = if (password == null || password.isEmpty) null else PasswordHasher.hash(password)
+            // Never create an account with a null hash — that was loginable with
+            // any password. When the admin doesn't supply one, generate a random
+            // temporary password and return it once so it can be handed to the
+            // user out-of-band; they log in with it and change it.
+            val (temporaryPassword, hash) =
+                if (password == null || password.isEmpty) {
+                    val temp = PasswordHasher.generateTemporary()
+                    (Some(temp), PasswordHasher.hash(temp))
+                } else {
+                    (None, PasswordHasher.hash(password))
+                }
             UserStore.create(username, hash, role)
-            ResponseEntity.status(HttpStatus.CREATED).body("""{"ok":true}""")
+            val resp = new JsonObject
+            resp.addProperty("ok", true)
+            temporaryPassword.foreach(resp.addProperty("temporaryPassword", _))
+            ResponseEntity.status(HttpStatus.CREATED).body(gson.toJson(resp))
         } catch {
             case e: Exception =>
                 logger.error("Error in POST /auth/users: " + Throwables.getStackTraceAsString(e))
@@ -254,7 +270,9 @@ class AuthAPIController {
     private def buildSessionCookie(value: String, maxAgeSeconds: Int): Cookie = {
         val cookie = new Cookie(sessionAuth.SessionCookieName, value)
         cookie.setHttpOnly(true)
-        cookie.setSecure(false) // dev: HTTP. Prod ingress (nginx) terminates TLS and rewrites.
+        // Secure is env-driven: false for local HTTP dev, true (via
+        // SESSION_COOKIE_SECURE) for any TLS-served deployment.
+        cookie.setSecure(SessionAuthenticator.cookieSecure)
         cookie.setPath("/")
         cookie.setMaxAge(maxAgeSeconds)
         cookie.setAttribute("SameSite", "Strict")

--- a/datrisserver/src/main/scala/ai/datris/api/ConfigAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/ConfigAPIController.scala
@@ -24,6 +24,21 @@ class ConfigAPIController {
     private val VALID_TYPES = Set("validation-schema", "javascript")
     private val VALID_SCHEMA_TYPES = Set("json-schema", "xsd")
 
+    /** Reduce a user-supplied filename to a safe single object-key segment.
+      * Without this, a name like `../tap-scripts/x.py` escapes the intended
+      * prefix and can write into another prefix of the same config bucket —
+      * including the tap-scripts prefix, whose files are later executed. Strip
+      * any path, reject traversal, and restrict to a safe charset. */
+    private def sanitizeKeySegment(name: String): String = {
+        if (name == null) throw new DatrisException("File name is required")
+        val base = name.replace("\\", "/").split("/").filter(_.nonEmpty).lastOption.getOrElse("")
+        if (base.isEmpty || base == "." || base == "..")
+            throw new DatrisException("Invalid file name: " + name)
+        if (!base.matches("[A-Za-z0-9._-]+"))
+            throw new DatrisException("File name '" + base + "' contains invalid characters. Allowed: letters, digits, . _ -")
+        base
+    }
+
     @PostMapping(path = Array("/config/upload"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
     def uploadConfigFile(
         @RequestHeader(name = "x-api-key", required = false) apiKey: String,
@@ -37,9 +52,7 @@ class ConfigAPIController {
             if (!VALID_TYPES.contains(fileType))
                 throw new DatrisException("Invalid config file type: " + fileType + ". Must be one of: " + VALID_TYPES.mkString(", "))
 
-            val filename = file.getOriginalFilename
-            if (filename == null || filename.isEmpty)
-                throw new DatrisException("File must have a name")
+            val filename = sanitizeKeySegment(file.getOriginalFilename)
 
             val bucket = DatrisEnvironment.current.environment + "-config"
             val key = fileType + "/" + filename
@@ -88,7 +101,7 @@ class ConfigAPIController {
                 case "xsd" => (AISchemaUtil.generateXsdSchema(sampleData), ".xsd")
             }
 
-            val filename = name.trim + extension
+            val filename = sanitizeKeySegment(name.trim) + extension
             val bucket = DatrisEnvironment.current.environment + "-config"
             val key = "validation-schema/" + filename
 

--- a/datrisserver/src/main/scala/ai/datris/api/SecretsAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/SecretsAPIController.scala
@@ -73,7 +73,8 @@ class SecretsAPIController {
     @GetMapping(path = Array("/secrets"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
     def listSecrets(
         @RequestHeader(name = "x-api-key", required = false) apiKey: String,
-        @RequestParam(required = false, name = "type") secretType: String
+        @RequestParam(required = false, name = "type") secretType: String,
+        request: HttpServletRequest
     ): ResponseEntity[String] = {
         try {
             logger.info("API endpoint GET /secrets called" + (if (secretType != null) ", type=" + secretType else ""))
@@ -95,8 +96,21 @@ class SecretsAPIController {
                 }
             } else allSecrets
 
+            // Read-scope filtering. Short-circuit when the key holds unscoped
+            // `secret:read` (or is legacy full-access) — the common case, no
+            // extra lookups. Only a scoped key (e.g. secret:read:_type=tap)
+            // triggers per-secret _type resolution so it sees only what its
+            // scope permits, rather than every secret name.
+            val visible =
+                if (CapabilityCheck.grants(request, "secret", "read", Map.empty[String, String])) secrets
+                else secrets.filter { name =>
+                    val t = SecretsUtil.getSecretMap(env + "/" + name).flatMap(m => Option(m.get("_type"))).getOrElse("")
+                    val ctx = if (t.nonEmpty) Map("_type" -> t) else Map.empty[String, String]
+                    CapabilityCheck.grants(request, "secret", "read", ctx)
+                }
+
             val gson = new Gson
-            new ResponseEntity[String](gson.toJson(secrets.asJava), HttpStatus.OK)
+            new ResponseEntity[String](gson.toJson(visible.asJava), HttpStatus.OK)
         } catch {
             case e: Exception =>
                 logger.error("Error: " + Throwables.getStackTraceAsString(e))
@@ -105,7 +119,11 @@ class SecretsAPIController {
     }
 
     @GetMapping(path = Array("/secrets/{name}"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
-    def getSecret(@RequestHeader(name = "x-api-key", required = false) apiKey: String, @PathVariable name: String): ResponseEntity[String] = {
+    def getSecret(
+        @RequestHeader(name = "x-api-key", required = false) apiKey: String,
+        @PathVariable name: String,
+        request: HttpServletRequest
+    ): ResponseEntity[String] = {
         try {
             logger.info("API endpoint GET /secrets/" + name + " called")
             APIKeyValidator.validate(apiKey)
@@ -116,6 +134,15 @@ class SecretsAPIController {
 
             secretMap match {
                 case Some(data) =>
+                    // In-action read-scope check. The interceptor gate is
+                    // scope-agnostic, so a key issued as `secret:read:_type=tap`
+                    // could otherwise read ANY secret. Enforce the actual
+                    // target's _type here — untyped/platform secrets fail a
+                    // tap-scoped key (empty _type context can't satisfy _type=tap).
+                    val existingType = data.asScala.get("_type").getOrElse("")
+                    val scopeContext = if (existingType.nonEmpty) Map("_type" -> existingType) else Map.empty[String, String]
+                    CapabilityCheck.assertScope(request, "secret", "read", scopeContext)
+
                     val result = new java.util.LinkedHashMap[String, Any]()
                     result.put("name", name)
 
@@ -124,7 +151,12 @@ class SecretsAPIController {
                         if (isSensitive(key) && value != null && value.nonEmpty) {
                             fields.put(key, "••••••••")
                         } else {
-                            fields.put(key, value)
+                            // Value-level redaction for credential-bearing URLs/DSNs
+                            // whose field NAME doesn't trip a sensitive marker
+                            // (connectionString, jdbcUrl, uri, ...). redactJdbcUrl
+                            // strips embedded user:pass@ / password= and leaves
+                            // plain values untouched.
+                            fields.put(key, ai.datris.util.LogRedactUtil.redactJdbcUrl(value))
                         }
                     }
                     result.put("fields", fields)

--- a/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
@@ -5,7 +5,7 @@ Datris
 Copyright (C) 2026 Datris (https://datris.ai)
  */
 
-import ai.datris.model.{DatrisEnvironment, User, UserContext}
+import ai.datris.model.{DatrisEnvironment, ResolvedKey, User, UserContext}
 import jakarta.servlet.http.{Cookie, HttpServletRequest, HttpServletResponse}
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.http.HttpStatus
@@ -18,13 +18,20 @@ import org.springframework.web.servlet.HandlerInterceptor
   * Decision order:
   *  1. useUserAuth=false → noop (existing deploys unchanged).
   *  2. Non-controller / static handler → noop.
-  *  3. AuthAPIController, /api/v1/version → public (auth controller handles its own gating).
-  *  4. Request carries an x-api-key → programmatic path, already validated upstream → allow.
-  *  5. No UserContext → 401.
-  *  6. Method or class has @RequiresRole → restrict to those roles.
-  *  7. Default rule: GET allowed for all logged-in roles; non-GET requires admin or editor.
+  *  3. Public endpoints — the auth controller's credential-free methods
+  *     (login/logout/me/change-password) and /api/v1/version — are exempt,
+  *     but ONLY when they carry no @RequiresRole. The auth controller also
+  *     hosts admin user-management methods that ARE role-gated; those must
+  *     not ride the class exemption.
+  *  4. No UserContext (programmatic path):
+  *       - role-gated endpoint → require a *validated* full-access API key
+  *         (mere x-api-key presence, or the anonymous full-access identity in
+  *         useApiKeys=false mode, is NOT sufficient for an admin gate);
+  *       - otherwise → x-api-key validated per-controller, or legacy no-auth.
+  *  5. Method or class has @RequiresRole → restrict to those roles.
+  *  6. Default rule: GET allowed for all logged-in roles; non-GET requires admin or editor.
   *
-  * Step 7 keeps the diff small — we don't have to annotate every write endpoint. */
+  * Step 6 keeps the diff small — we don't have to annotate every write endpoint. */
 @Component
 class RoleEnforcementInterceptor extends HandlerInterceptor {
     private val logger: Logger = LoggerFactory.getLogger(classOf[RoleEnforcementInterceptor])
@@ -36,11 +43,22 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
         if (!handler.isInstanceOf[HandlerMethod]) return true
         val method = handler.asInstanceOf[HandlerMethod]
 
+        // @RequiresRole may sit on the method or the controller class. Resolve
+        // it up front: it decides whether an endpoint is public or role-gated,
+        // independent of which controller hosts it. This is what stops the
+        // admin user-management methods in AuthAPIController from inheriting
+        // the controller's public exemption.
+        val ann = Option(method.getMethodAnnotation(classOf[RequiresRole]))
+            .orElse(Option(method.getBeanType.getAnnotation(classOf[RequiresRole])))
+
         val classFqn = method.getBeanType.getName
-        if (classFqn == "ai.datris.api.AuthAPIController") return true
+        // The auth controller's credential-free endpoints (login/logout/me/
+        // change-password) must be reachable without a session — but only the
+        // ones with no role annotation. A role-gated method here falls through.
+        if (ann.isEmpty && classFqn == "ai.datris.api.AuthAPIController") return true
 
         val uri = request.getRequestURI
-        if (uri != null && uri.startsWith("/api/v1/version")) return true
+        if (ann.isEmpty && uri != null && uri.startsWith("/api/v1/version")) return true
 
         val userOpt = UserContext.get()
         if (userOpt.isEmpty) {
@@ -55,23 +73,40 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
                 response.addCookie(expiredSessionCookie())
                 return reject(response, HttpStatus.UNAUTHORIZED, """{"error":"Session expired"}""")
             }
-            // No session — programmatic / service-to-service path (CLI, MCP server, etc).
-            // x-api-key is validated by APIKeyValidator inside each controller; we just
-            // let the request through here.
-            val apiKey = request.getHeader("x-api-key")
-            if (apiKey != null && !apiKey.isEmpty) return true
-            // If api keys are not required either, this is the legacy "no API auth" mode
-            // (the OSS default). useUserAuth governs UI auth; it does not retroactively
-            // require server-to-server callers to authenticate.
-            if (!DatrisEnvironment.values.useApiKeys) return true
-            return reject(response, HttpStatus.UNAUTHORIZED, """{"error":"Authentication required"}""")
+            ann match {
+                case Some(_) =>
+                    // Role-gated endpoint (e.g. key minting, user management)
+                    // reached without a user session. A bare x-api-key header
+                    // is NOT enough: the old code accepted any non-empty value,
+                    // which let a forged or read-only key mint a `*:*` master
+                    // key and create admin users. Require a *validated* key
+                    // that resolves to full ('*:*') access — which exists only
+                    // when useApiKeys is on and the key is real. The anonymous
+                    // full-access identity present in useApiKeys=false mode is
+                    // deliberately excluded so an admin gate is never satisfied
+                    // by an unauthenticated caller.
+                    if (DatrisEnvironment.values.useApiKeys &&
+                        resolvedKey(request).exists(_.matchesResourceAction("*", "*")))
+                        return true
+                    return reject(response, HttpStatus.FORBIDDEN, """{"error":"Insufficient role"}""")
+
+                case None =>
+                    // No session — programmatic / service-to-service path (CLI, MCP server, etc).
+                    // x-api-key is validated by APIKeyValidator inside each controller; we just
+                    // let the request through here.
+                    val apiKey = request.getHeader("x-api-key")
+                    if (apiKey != null && !apiKey.isEmpty) return true
+                    // If api keys are not required either, this is the legacy "no API auth" mode
+                    // (the OSS default). useUserAuth governs UI auth; it does not retroactively
+                    // require server-to-server callers to authenticate.
+                    if (!DatrisEnvironment.values.useApiKeys) return true
+                    return reject(response, HttpStatus.UNAUTHORIZED, """{"error":"Authentication required"}""")
+            }
         }
         // Session present — role check applies even if a stale x-api-key is also being sent.
         // Otherwise a viewer with an old admin api key in localStorage could bypass roles.
         val user = userOpt.get
 
-        val ann = Option(method.getMethodAnnotation(classOf[RequiresRole]))
-            .orElse(Option(method.getBeanType.getAnnotation(classOf[RequiresRole])))
         ann match {
             case Some(a) =>
                 val allowed = a.value().toSet
@@ -86,11 +121,23 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
         }
     }
 
+    // The ResolvedKey attached by TenantInterceptor from a validated x-api-key.
+    // Absent when no valid key was presented (in useApiKeys=true mode a bad key
+    // resolves to nothing); present as anonymous full-access in useApiKeys=false
+    // mode — which is why the admin-gate check above additionally requires
+    // useApiKeys to be on before trusting a full-access resolution.
+    private def resolvedKey(request: HttpServletRequest): Option[ResolvedKey] = {
+        request.getAttribute(TenantInterceptor.ResolvedKeyAttr) match {
+            case rk: ResolvedKey => Some(rk)
+            case _ => None
+        }
+    }
+
     // Mirrors AuthAPIController.buildSessionCookie's attributes with maxAge=0.
     private def expiredSessionCookie(): Cookie = {
         val cookie = new Cookie("datris-session", "")
         cookie.setHttpOnly(true)
-        cookie.setSecure(false)
+        cookie.setSecure(SessionAuthenticator.cookieSecure)
         cookie.setPath("/")
         cookie.setMaxAge(0)
         cookie.setAttribute("SameSite", "Strict")

--- a/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
@@ -85,8 +85,10 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
                     // full-access identity present in useApiKeys=false mode is
                     // deliberately excluded so an admin gate is never satisfied
                     // by an unauthenticated caller.
-                    if (DatrisEnvironment.values.useApiKeys &&
-                        resolvedKey(request).exists(_.matchesResourceAction("*", "*")))
+                    if (
+                        DatrisEnvironment.values.useApiKeys &&
+                        resolvedKey(request).exists(_.matchesResourceAction("*", "*"))
+                    )
                         return true
                     return reject(response, HttpStatus.FORBIDDEN, """{"error":"Insufficient role"}""")
 

--- a/datrisserver/src/main/scala/ai/datris/config/SessionAuthenticator.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/SessionAuthenticator.scala
@@ -23,6 +23,13 @@ object SessionAuthenticator {
       * the cookie — so RoleEnforcementInterceptor turns it into a hard 401
       * instead of letting the request degrade to the anonymous legacy path. */
     val StaleSessionAttribute = "datris.staleSession"
+
+    /** Whether to set the `Secure` flag on the session cookie. Default false so
+      * local HTTP dev keeps working; set SESSION_COOKIE_SECURE=true in any
+      * TLS-served deployment so the session token is never sent over plain HTTP
+      * (mixed content, a stray http link, or a TLS-stripping MITM). */
+    def cookieSecure: Boolean =
+        sys.env.get("SESSION_COOKIE_SECURE").exists(_.equalsIgnoreCase("true"))
 }
 
 @Component

--- a/datrisserver/src/main/scala/ai/datris/config/WebMvcConfig.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/WebMvcConfig.scala
@@ -60,10 +60,17 @@ class WebMvcConfig extends WebMvcConfigurer {
         val mapping = registry.addMapping("/api/**")
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
-            .allowCredentials(true)
             .maxAge(3600)
-        // allowedOriginPatterns supports "*" with credentials; allowedOrigins does not
-        if (origins.contains("*")) mapping.allowedOriginPatterns("*")
-        else mapping.allowedOrigins(origins: _*)
+        if (origins.contains("*")) {
+            // SECURITY: never pair a wildcard origin with credentials — that
+            // reflects ANY site's Origin back with Access-Control-Allow-
+            // Credentials, letting any page make credentialed cross-origin
+            // calls. Wildcard stays allowed but WITHOUT credentials. To enable
+            // credentialed cross-origin requests, set cors.allowedOrigins to an
+            // explicit allowlist (the else branch).
+            mapping.allowedOriginPatterns("*").allowCredentials(false)
+        } else {
+            mapping.allowedOrigins(origins: _*).allowCredentials(true)
+        }
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/controller/MinioWebhookController.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/MinioWebhookController.scala
@@ -7,17 +7,57 @@ Copyright (C) 2026 Datris (https://datris.ai)
 
 import ai.datris.model.DatrisEnvironment
 import ai.datris.util.QueueUtil
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.http.{HttpStatus, ResponseEntity}
 import org.springframework.web.bind.annotation.{PostMapping, RequestBody, RestController}
 
 @RestController
 class MinioWebhookController {
     private val logger = LoggerFactory.getLogger(getClass)
 
+    // Shared secret MinIO includes as `Authorization: Bearer <token>` (its
+    // notify_webhook auth_token). This endpoint is deliberately outside the
+    // /api/** interceptors, so without this check anyone who can reach it could
+    // enqueue a forged event and trigger ingestion of an arbitrary object —
+    // and, in multi-tenant mode, pick the target tenant via the bucket name.
+    private def expectedToken: String = sys.env.getOrElse("MINIO_WEBHOOK_TOKEN", "")
+
     @PostMapping(Array("/minio-events"))
-    def handleMinioEvent(@RequestBody payload: String): String = {
+    def handleMinioEvent(@RequestBody payload: String, request: HttpServletRequest): ResponseEntity[String] = {
+        val token = expectedToken
+        if (token.isEmpty) {
+            // Not configured — keep working so existing deployments don't break
+            // on upgrade, but make the exposure loud. Set MINIO_WEBHOOK_TOKEN
+            // (and MinIO's matching auth_token) to authenticate this endpoint.
+            logger.warn(
+                "/minio-events is UNAUTHENTICATED — MINIO_WEBHOOK_TOKEN is not set. " +
+                    "Anyone who can reach this endpoint can trigger ingestion. Configure a token to secure it."
+            )
+        } else {
+            val provided = bearerToken(request)
+            if (provided == null || !constantTimeEquals(provided, token)) {
+                logger.warn("Rejected /minio-events request with missing or invalid bearer token")
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized")
+            }
+        }
+
         logger.info(s"Received MinIO event: $payload")
         QueueUtil.add(DatrisEnvironment.current.fileNotifierQueue, payload)
-        "OK"
+        ResponseEntity.ok("OK")
+    }
+
+    private def bearerToken(request: HttpServletRequest): String = {
+        val header = request.getHeader("Authorization")
+        if (header == null) null
+        else if (header.startsWith("Bearer ")) header.substring("Bearer ".length).trim
+        else header.trim
+    }
+
+    private def constantTimeEquals(a: String, b: String): Boolean = {
+        java.security.MessageDigest.isEqual(
+            a.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            b.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        )
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/util/CodeGenRuleEvaluator.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/CodeGenRuleEvaluator.scala
@@ -11,10 +11,6 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.{Files, Path}
 import scala.collection.JavaConverters._
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.sys.process._
 
 object CodeGenRuleEvaluator {
     private val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -131,33 +127,17 @@ object CodeGenRuleEvaluator {
     }
 
     private def executeWithTimeout(scriptPath: String, dataPath: String, timeoutSec: Int): String = {
-        val stdout = new StringBuilder
-        val stderr = new StringBuilder
-        val processLogger = ProcessLogger(
-            line => stdout.append(line).append("\n"),
-            line => stderr.append(line).append("\n")
-        )
-
-        val process = Process(Seq("python3", scriptPath, dataPath))
-        val future = Future {
-            process.!(processLogger)
+        // SECURITY: the script is LLM-generated and shaped by untrusted ingested
+        // data, so it runs through SandboxedPython — a scrubbed environment with
+        // no platform secrets in os.environ. Never use scala.sys.process here;
+        // it would inherit the JVM's full secret environment.
+        val result = SandboxedPython.run(Seq("python3", scriptPath, dataPath), timeoutSec)
+        if (result.exitCode != 0) {
+            val errOutput = result.stderr.take(1000)
+            logger.error("CodeGen script exited with code " + result.exitCode + ": " + errOutput)
+            throw new DatrisException("CodeGen validation script failed (exit code " + result.exitCode + "): " + errOutput)
         }
-
-        try {
-            val exitCode = Await.result(future, timeoutSec.seconds)
-            if (exitCode != 0) {
-                val errOutput = stderr.toString.take(1000)
-                logger.error("CodeGen script exited with code " + exitCode + ": " + errOutput)
-                throw new DatrisException("CodeGen validation script failed (exit code " + exitCode + "): " + errOutput)
-            }
-            stdout.toString.trim
-        } catch {
-            case _: java.util.concurrent.TimeoutException =>
-                throw new DatrisException("CodeGen validation script timed out after " + timeoutSec + " seconds")
-            case e: DatrisException => throw e
-            case e: Exception =>
-                throw new DatrisException("CodeGen script execution error: " + e.getMessage)
-        }
+        result.stdout
     }
 
     private def cleanGeneratedScript(script: String): String = {

--- a/datrisserver/src/main/scala/ai/datris/util/CodeGenTransformationEvaluator.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/CodeGenTransformationEvaluator.scala
@@ -9,10 +9,6 @@ import ai.datris.model.{DatrisEnvironment, DatrisException}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.{Files, Path}
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.sys.process._
 
 object CodeGenTransformationEvaluator {
     private val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -134,30 +130,15 @@ object CodeGenTransformationEvaluator {
     }
 
     private def executeWithTimeout(scriptPath: String, inputPath: String, outputPath: String, timeoutSec: Int): Unit = {
-        val stderr = new StringBuilder
-        val processLogger = ProcessLogger(
-            _ => (), // ignore stdout
-            line => stderr.append(line).append("\n")
-        )
-
-        val process = Process(Seq("python3", scriptPath, inputPath, outputPath))
-        val future = Future {
-            process.!(processLogger)
-        }
-
-        try {
-            val exitCode = Await.result(future, timeoutSec.seconds)
-            if (exitCode != 0) {
-                val errOutput = stderr.toString.take(1000)
-                logger.error("CodeGen transformation script exited with code " + exitCode + ": " + errOutput)
-                throw new DatrisException("CodeGen transformation script failed (exit code " + exitCode + "): " + errOutput)
-            }
-        } catch {
-            case _: java.util.concurrent.TimeoutException =>
-                throw new DatrisException("CodeGen transformation script timed out after " + timeoutSec + " seconds")
-            case e: DatrisException => throw e
-            case e: Exception =>
-                throw new DatrisException("CodeGen transformation script execution error: " + e.getMessage)
+        // SECURITY: the script is LLM-generated and shaped by untrusted ingested
+        // data, so it runs through SandboxedPython — a scrubbed environment with
+        // no platform secrets in os.environ. Never use scala.sys.process here;
+        // it would inherit the JVM's full secret environment.
+        val result = SandboxedPython.run(Seq("python3", scriptPath, inputPath, outputPath), timeoutSec)
+        if (result.exitCode != 0) {
+            val errOutput = result.stderr.take(1000)
+            logger.error("CodeGen transformation script exited with code " + result.exitCode + ": " + errOutput)
+            throw new DatrisException("CodeGen transformation script failed (exit code " + result.exitCode + "): " + errOutput)
         }
     }
 

--- a/datrisserver/src/main/scala/ai/datris/util/HttpUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/HttpUtil.scala
@@ -165,6 +165,11 @@ object HttpUtil {
     }
 
     private def getHttpClient(url: String): CloseableHttpClient = {
+        // SECURITY: route DNS through SsrfGuard so the platform can't be tricked
+        // into fetching internal/metadata endpoints on a user's behalf. The
+        // resolver rejects private/loopback/link-local targets, and because the
+        // client connects using this same resolution, it also closes the
+        // DNS-rebinding gap a separate pre-flight check would leave.
         if (url.toLowerCase.startsWith("https")) {
             val sslsf = new SSLConnectionSocketFactory(
                 SSLContext.getDefault,
@@ -172,8 +177,13 @@ object HttpUtil {
                 null,
                 SSLConnectionSocketFactory.getDefaultHostnameVerifier
             )
-            HttpClients.custom().setSSLSocketFactory(sslsf).build()
+            HttpClients.custom()
+                .setSSLSocketFactory(sslsf)
+                .setDnsResolver(SsrfGuard.filteringDnsResolver)
+                .build()
         } else
-            HttpClients.createDefault
+            HttpClients.custom()
+                .setDnsResolver(SsrfGuard.filteringDnsResolver)
+                .build()
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/util/PasswordHasher.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/PasswordHasher.scala
@@ -8,6 +8,8 @@ Copyright (C) 2026 Datris (https://datris.ai)
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
+import java.security.SecureRandom
+
 /** BCrypt password hashing. Cost factor 12 — slow enough to be brute-force resistant,
   * fast enough that login isn't perceptibly delayed. */
 object PasswordHasher {
@@ -15,7 +17,26 @@ object PasswordHasher {
 
     private val encoder = new BCryptPasswordEncoder(12)
 
+    private val secureRandom = new SecureRandom()
+    // Unambiguous alphabet — no 0/O/1/l/I — so a bootstrap password copied out
+    // of a server log or handed to an invited user doesn't get misread.
+    private val TempPasswordAlphabet = "abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
     def hash(plain: String): String = encoder.encode(plain)
+
+    /** Generate a random, high-entropy temporary password. Used to seed the
+      * bootstrap admin and to back admin-invited accounts, so no account ever
+      * exists with a null/empty hash that login would accept with any password.
+      * ~20 chars over a 55-symbol alphabet ≈ 115 bits of entropy. */
+    def generateTemporary(length: Int = 20): String = {
+        val sb = new StringBuilder(length)
+        var i = 0
+        while (i < length) {
+            sb.append(TempPasswordAlphabet.charAt(secureRandom.nextInt(TempPasswordAlphabet.length)))
+            i += 1
+        }
+        sb.toString
+    }
 
     def verify(plain: String, hash: String): Boolean = {
         if (plain == null || hash == null || hash.isEmpty) false

--- a/datrisserver/src/main/scala/ai/datris/util/PipelineValidatorUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/PipelineValidatorUtil.scala
@@ -224,6 +224,29 @@ object PipelineValidatorUtil {
                 throw new DatrisException("If the 'destination.database' section is defined, the 'destination.database.schema' must be defined")
             if (config.destination.database.table == null)
                 throw new DatrisException("If the 'destination.database' section is defined, the 'destination.database.table' must be defined")
+
+            // SECURITY: these identifiers are interpolated into DDL/DML by the
+            // SQL loaders (PostgresLoader et al.), not bound as parameters, so
+            // an unvalidated value like `public; DROP TABLE x; --` would be
+            // second-order SQL injection against the destination. Restrict them
+            // to the same safe identifier charset the schema columns already use.
+            validateSqlIdentifier(config.destination.database.dbName, "destination.database.dbName")
+            if (!config.destination.database.useMongoDB) {
+                validateSqlIdentifier(config.destination.database.schema, "destination.database.schema")
+                validateSqlIdentifier(config.destination.database.table, "destination.database.table")
+                if (config.destination.database.warehouse != null)
+                    validateSqlIdentifier(config.destination.database.warehouse, "destination.database.warehouse")
+            }
+            // COPY options legitimately hold SQL option syntax (FORMAT csv,
+            // DELIMITER ',', FORCE_NULL (col), ...) so they can't be charset-
+            // restricted, but they must not carry a statement separator that
+            // would let them stack a second command after the COPY clause.
+            if (config.destination.database.options != null) {
+                config.destination.database.options.asScala.foreach { opt =>
+                    if (opt != null && opt.contains(";"))
+                        throw new DatrisException("destination.database.options entries must not contain ';'")
+                }
+            }
             // MongoDB is exempt from the schema-membership rule: it stores each record
             // as a whole `_json` document and MongoDBLoader.upsertJSON matches key
             // fields INSIDE the document, so the keys legitimately never appear as
@@ -309,6 +332,19 @@ object PipelineValidatorUtil {
         validateColumns(sourceSchema = true, config)
         if (config.destination.schemaProperties != null)
             validateColumns(sourceSchema = false, config)
+    }
+
+    /** SQL identifiers (db/schema/table/warehouse names) are interpolated into
+      * loader SQL rather than bound as parameters, so they must be constrained
+      * to a safe charset to prevent injection. Matches the column-name rule:
+      * letters, digits, and underscore only. */
+    private[util] def validateSqlIdentifier(value: String, label: String): Unit = {
+        if (value == null || value.isEmpty)
+            throw new DatrisException("'" + label + "' must not be empty")
+        if (!value.matches("[A-Za-z0-9_]+"))
+            throw new DatrisException(
+                "'" + label + "' value '" + value + "' is invalid. Valid characters are a-z, A-Z, 0-9 and _"
+            )
     }
 
     private def validateColumns(sourceSchema: Boolean, config: PipelineConfig): Unit = {

--- a/datrisserver/src/main/scala/ai/datris/util/PostgresLoader.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/PostgresLoader.scala
@@ -29,6 +29,15 @@ class PostgresLoader(jobContext: JobContext) {
     def process(): Unit = {
         statusUtil.overrideProcessName(this.getClass.getSimpleName)
 
+        // Defense in depth: dbName/schema/table are interpolated into DDL/DML
+        // below (both quoted identifiers and an unquoted CREATE SCHEMA), never
+        // bound as parameters. PipelineValidatorUtil enforces the safe charset
+        // at config time; re-check here so any config that reaches the loader
+        // by another path still can't inject SQL.
+        PipelineValidatorUtil.validateSqlIdentifier(dbName, "destination.database.dbName")
+        PipelineValidatorUtil.validateSqlIdentifier(config.destination.database.schema, "destination.database.schema")
+        PipelineValidatorUtil.validateSqlIdentifier(config.destination.database.table, "destination.database.table")
+
         statusUtil.info("begin", "Loading the data into Postgres database: " + dbName + ", table: " + config.destination.database.table)
 
         val secrets = SecretsRetrieverUtil.postgresSecrets()

--- a/datrisserver/src/main/scala/ai/datris/util/SandboxedPython.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SandboxedPython.scala
@@ -31,11 +31,29 @@ object SandboxedPython {
       * environment. Deliberately excludes anything credential-bearing. Kept in
       * sync with `TapScriptRunner.NonSecretEnvVars`. */
     private val NonSecretEnvVars: Set[String] = Set(
-        "PATH", "HOME", "USER", "LOGNAME", "SHELL", "PWD", "OLDPWD",
-        "LANG", "TERM", "TZ", "TMPDIR", "TMP", "TEMP", "HOSTNAME",
-        "PYTHONPATH", "PYTHONHOME", "PYTHONUNBUFFERED", "VIRTUAL_ENV",
-        "LD_LIBRARY_PATH", "SSL_CERT_FILE", "SSL_CERT_DIR",
-        "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "PWD",
+        "OLDPWD",
+        "LANG",
+        "TERM",
+        "TZ",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "HOSTNAME",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONUNBUFFERED",
+        "VIRTUAL_ENV",
+        "LD_LIBRARY_PATH",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE"
     )
 
     case class Result(exitCode: Int, stdout: String, stderr: String)

--- a/datrisserver/src/main/scala/ai/datris/util/SandboxedPython.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SandboxedPython.scala
@@ -1,0 +1,95 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisException
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** Runs a Python subprocess with a SCRUBBED environment so LLM-generated or
+  * otherwise-untrusted scripts cannot read the server's secret-bearing
+  * environment — VAULT_TOKEN, ANTHROPIC_API_KEY / OPENAI_API_KEY, AWS_*, DB
+  * passwords, and every other var the JVM container holds.
+  *
+  * `scala.sys.process.Process` cannot provide this: it ADDS any extra env onto
+  * the inherited JVM environment, so `os.environ` in the child would still
+  * contain every secret. `java.lang.ProcessBuilder` lets us start from an EMPTY
+  * environment and add back only a minimal allowlist of benign system vars the
+  * Python runtime and TLS need. This is the same isolation TapScriptRunner
+  * applies to tap scripts; CodeGen DQ / transformation scripts run through here
+  * for the same reason. */
+object SandboxedPython {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    /** Benign, non-secret system vars restored into the otherwise-empty child
+      * environment. Deliberately excludes anything credential-bearing. Kept in
+      * sync with `TapScriptRunner.NonSecretEnvVars`. */
+    private val NonSecretEnvVars: Set[String] = Set(
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL", "PWD", "OLDPWD",
+        "LANG", "TERM", "TZ", "TMPDIR", "TMP", "TEMP", "HOSTNAME",
+        "PYTHONPATH", "PYTHONHOME", "PYTHONUNBUFFERED", "VIRTUAL_ENV",
+        "LD_LIBRARY_PATH", "SSL_CERT_FILE", "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"
+    )
+
+    case class Result(exitCode: Int, stdout: String, stderr: String)
+
+    /** Run `command` (e.g. `Seq("python3", scriptPath, dataPath)`) with a
+      * scrubbed environment and a wall-clock timeout. The child never inherits
+      * the JVM's secret environment. Throws `DatrisException` on timeout (after
+      * force-killing the process); returns the captured streams and exit code
+      * otherwise — the caller decides how to treat a non-zero exit. */
+    def run(command: Seq[String], timeoutSec: Int): Result = {
+        val stdout = new StringBuilder
+        val stderr = new StringBuilder
+
+        val pb = new java.lang.ProcessBuilder(command: _*)
+        val childEnv = pb.environment()
+        childEnv.clear()
+        NonSecretEnvVars.foreach { k => sys.env.get(k).foreach(v => childEnv.put(k, v)) }
+
+        val process = pb.start()
+        process.getOutputStream.close() // script reads no stdin; signal EOF
+
+        // Drain stdout and stderr on separate daemon threads — a full pipe
+        // buffer would otherwise deadlock the child. The main thread reads the
+        // buffers only after join(), which establishes happens-before.
+        def pump(in: java.io.InputStream, sb: StringBuilder): Thread = {
+            val t = new Thread(new Runnable {
+                override def run(): Unit = {
+                    val reader = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(in, java.nio.charset.StandardCharsets.UTF_8)
+                    )
+                    try {
+                        var line = reader.readLine()
+                        while (line != null) { sb.append(line).append("\n"); line = reader.readLine() }
+                    } catch { case _: java.io.IOException => () }
+                    finally reader.close()
+                }
+            })
+            t.setDaemon(true)
+            t.start()
+            t
+        }
+        val outThread = pump(process.getInputStream, stdout)
+        val errThread = pump(process.getErrorStream, stderr)
+
+        val future = Future { process.waitFor() }
+        try {
+            val exitCode = Await.result(future, timeoutSec.seconds)
+            outThread.join(5000)
+            errThread.join(5000)
+            Result(exitCode, stdout.toString.trim, stderr.toString.trim)
+        } catch {
+            case _: java.util.concurrent.TimeoutException =>
+                process.destroyForcibly()
+                throw new DatrisException("Sandboxed script timed out after " + timeoutSec + " seconds")
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/SchemaValidationUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SchemaValidationUtil.scala
@@ -16,6 +16,14 @@ import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.SchemaFactory
 
 object SchemaValidationUtil {
+    /** Apply an XML parser hardening setting, tolerating parsers that don't
+      * recognize it (older/alternate JAXP impls throw SAXNotRecognized/
+      * NotSupported). Best-effort: any recognized setting still takes effect. */
+    private def setSafe(f: () => Unit): Unit = {
+        try f()
+        catch { case _: org.xml.sax.SAXException => () }
+    }
+
     def validateJson(data: String, schemaFileUrl: String): Unit = {
         val jsonSchema = ObjectStoreUtil.readBucketObject(ObjectStoreUtil.getBucket(schemaFileUrl), ObjectStoreUtil.getKey(schemaFileUrl))
             .getOrElse(throw new DatrisException("Could not read the validation schema file: " + schemaFileUrl))
@@ -37,9 +45,19 @@ object SchemaValidationUtil {
         val xmlDataStream = new ByteArrayInputStream(data.getBytes())
 
         val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+        // SECURITY (XXE): both the user-supplied XSD and the ingested XML are
+        // parsed here. Enable secure processing and forbid external DTD/schema
+        // resolution so a DOCTYPE with an external/parameter entity in either
+        // input can't read local files (file://) or reach internal URLs (SSRF).
+        setSafe(() => schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true))
+        setSafe(() => schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""))
+        setSafe(() => schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""))
         try {
             val schema = schemaFactory.newSchema(new StreamSource(new StringReader(xmlSchema)))
             val validator = schema.newValidator()
+            setSafe(() => validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true))
+            setSafe(() => validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""))
+            setSafe(() => validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""))
             validator.validate(new StreamSource(xmlDataStream))
         } catch {
             case e: SAXException =>

--- a/datrisserver/src/main/scala/ai/datris/util/SchemaValidationUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SchemaValidationUtil.scala
@@ -16,6 +16,7 @@ import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.SchemaFactory
 
 object SchemaValidationUtil {
+
     /** Apply an XML parser hardening setting, tolerating parsers that don't
       * recognize it (older/alternate JAXP impls throw SAXNotRecognized/
       * NotSupported). Best-effort: any recognized setting still takes effect. */

--- a/datrisserver/src/main/scala/ai/datris/util/SsrfGuard.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SsrfGuard.scala
@@ -43,12 +43,12 @@ object SsrfGuard {
     /** True if `addr` is in a range the platform must not be tricked into
       * reaching on a user's behalf. */
     def isBlocked(addr: InetAddress): Boolean = {
-        addr.isLoopbackAddress ||        // 127.0.0.0/8, ::1
-            addr.isLinkLocalAddress ||   // 169.254.0.0/16 (incl. cloud metadata), fe80::/10
-            addr.isSiteLocalAddress ||   // 10/8, 172.16/12, 192.168/16
-            addr.isAnyLocalAddress ||    // 0.0.0.0, ::
-            addr.isMulticastAddress ||
-            isUniqueLocalIPv6(addr)      // fc00::/7
+        addr.isLoopbackAddress || // 127.0.0.0/8, ::1
+        addr.isLinkLocalAddress || // 169.254.0.0/16 (incl. cloud metadata), fe80::/10
+        addr.isSiteLocalAddress || // 10/8, 172.16/12, 192.168/16
+        addr.isAnyLocalAddress || // 0.0.0.0, ::
+        addr.isMulticastAddress ||
+        isUniqueLocalIPv6(addr) // fc00::/7
     }
 
     // java.net has no predicate for IPv6 ULA (fc00::/7); check the top 7 bits.

--- a/datrisserver/src/main/scala/ai/datris/util/SsrfGuard.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/SsrfGuard.scala
@@ -1,0 +1,108 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisException
+import org.apache.http.conn.DnsResolver
+import org.apache.http.impl.conn.SystemDefaultDnsResolver
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.net.{InetAddress, URI}
+
+/** Server-Side Request Forgery guard for outbound HTTP the platform makes to
+  * user-supplied URLs — REST-endpoint pre/post processors and HTTP taps.
+  *
+  * Those features legitimately call a user's OWN endpoint, but without a check
+  * a user can point the URL at the cloud metadata service
+  * (169.254.169.254 → IAM credentials) or an internal service
+  * (vault:8200, minio:9000, localhost) and have the platform fetch it and hand
+  * the response back — a full-read SSRF.
+  *
+  * This guard resolves the target host and rejects loopback, link-local
+  * (includes the metadata IP), private/site-local, unique-local IPv6,
+  * multicast, and wildcard addresses. Using it as the HTTP client's DnsResolver
+  * (see HttpUtil) also means the SAME resolution is used to connect, which
+  * closes the DNS-rebinding TOCTOU gap that a separate pre-flight check leaves.
+  *
+  * Operators who intentionally run their endpoints on a private network can set
+  * `DATRIS_ALLOW_PRIVATE_EGRESS=true` to disable the block. Default is secure. */
+object SsrfGuard {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    // Operators opt into internal egress with the DATRIS_ALLOW_PRIVATE_EGRESS
+    // env var. The `datris.allowPrivateEgress` system property is an equivalent
+    // override that can also be set at runtime (env vars are fixed at process
+    // start) — used by tests that exercise the loopback HTTP path.
+    private def allowPrivateEgress: Boolean =
+        sys.props.get("datris.allowPrivateEgress").orElse(sys.env.get("DATRIS_ALLOW_PRIVATE_EGRESS"))
+            .exists(_.equalsIgnoreCase("true"))
+
+    /** True if `addr` is in a range the platform must not be tricked into
+      * reaching on a user's behalf. */
+    def isBlocked(addr: InetAddress): Boolean = {
+        addr.isLoopbackAddress ||        // 127.0.0.0/8, ::1
+            addr.isLinkLocalAddress ||   // 169.254.0.0/16 (incl. cloud metadata), fe80::/10
+            addr.isSiteLocalAddress ||   // 10/8, 172.16/12, 192.168/16
+            addr.isAnyLocalAddress ||    // 0.0.0.0, ::
+            addr.isMulticastAddress ||
+            isUniqueLocalIPv6(addr)      // fc00::/7
+    }
+
+    // java.net has no predicate for IPv6 ULA (fc00::/7); check the top 7 bits.
+    private def isUniqueLocalIPv6(addr: InetAddress): Boolean = {
+        val b = addr.getAddress
+        b.length == 16 && (b(0) & 0xfe) == 0xfc
+    }
+
+    /** Resolve `url`'s host and throw DatrisException if it maps to any blocked
+      * address. No-op when the operator has opted into private egress. Rejects
+      * if ANY resolved address is blocked, so a hostname that returns both a
+      * public and a private record can't be used to slip through. */
+    def assertAllowed(url: String): Unit = {
+        if (allowPrivateEgress) return
+        val host =
+            try new URI(url).getHost
+            catch { case _: Exception => null }
+        if (host == null || host.isEmpty)
+            throw new DatrisException("Refusing request to a URL with no resolvable host: " + url)
+
+        val addresses =
+            try InetAddress.getAllByName(host)
+            catch {
+                case e: Exception =>
+                    throw new DatrisException("Could not resolve host '" + host + "': " + e.getMessage)
+            }
+        addresses.find(isBlocked).foreach { bad =>
+            logger.warn("Blocked SSRF attempt to " + url + " (resolved " + host + " -> " + bad.getHostAddress + ")")
+            throw new DatrisException(
+                "Refusing to connect to '" + host + "' — it resolves to a private, loopback, or " +
+                    "link-local address (" + bad.getHostAddress + "), which is not allowed for user-supplied URLs. " +
+                    "Set DATRIS_ALLOW_PRIVATE_EGRESS=true to permit internal endpoints."
+            )
+        }
+    }
+
+    /** An Apache HttpClient DnsResolver that resolves normally, then rejects the
+      * whole result if any address is blocked. Wiring this into the client means
+      * connection setup uses this exact resolution — no separate lookup a
+      * rebinding attacker could race. */
+    val filteringDnsResolver: DnsResolver = new DnsResolver {
+        private val system = SystemDefaultDnsResolver.INSTANCE
+        override def resolve(host: String): Array[InetAddress] = {
+            val addresses = system.resolve(host)
+            if (!allowPrivateEgress) {
+                addresses.find(isBlocked).foreach { bad =>
+                    logger.warn("Blocked SSRF connection to host " + host + " (-> " + bad.getHostAddress + ")")
+                    throw new java.net.UnknownHostException(
+                        "Host '" + host + "' resolves to a blocked address (" + bad.getHostAddress +
+                            "); refusing to connect. Set DATRIS_ALLOW_PRIVATE_EGRESS=true to permit internal endpoints."
+                    )
+                }
+            }
+            addresses
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
@@ -484,6 +484,12 @@ object TapScriptRunner {
             if (testLimit > 0) body.addProperty("testLimit", Integer.valueOf(testLimit))
             else body.add("testLimit", com.google.gson.JsonNull.INSTANCE)
 
+            // SECURITY: reject endpoints that resolve to internal/metadata
+            // addresses before connecting, so a tap can't be used to read cloud
+            // metadata (169.254.169.254) or internal services. followRedirects
+            // is already NEVER, so a redirect can't bypass this check.
+            SsrfGuard.assertAllowed(tapConfig.endpointUrl)
+
             val client = java.net.http.HttpClient.newBuilder()
                 .connectTimeout(java.time.Duration.ofSeconds(10))
                 .followRedirects(java.net.http.HttpClient.Redirect.NEVER)

--- a/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
@@ -84,6 +84,17 @@ object VaultSecretsUtilBuilder {
                     case _: Exception => None
                 }
             }
-        fromFile.getOrElse(sys.env("VAULT_TOKEN"))
+        fromFile.orElse(sys.env.get("VAULT_TOKEN")).getOrElse {
+            val hint = sys.env
+                .get("VAULT_TOKEN_FILE")
+                .map(p =>
+                    " VAULT_TOKEN_FILE=" + p + " is set but the file was missing, empty, or unreadable" +
+                        " (the server runs as a non-root user — ensure the token file is world-readable)."
+                )
+                .getOrElse("")
+            throw new IllegalStateException(
+                "No Vault token available: neither VAULT_TOKEN_FILE nor VAULT_TOKEN provided one." + hint
+            )
+        }
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
@@ -52,7 +52,7 @@ class VaultSecretsUtil(val vault: Vault) extends SecretsManagerUtility {
 object VaultSecretsUtilBuilder {
     def build(): SecretsManagerUtility = {
         val address = sys.env.getOrElse("VAULT_ADDR", "http://127.0.0.1:8200")
-        val token = sys.env("VAULT_TOKEN")
+        val token = resolveToken()
 
         val config = new VaultConfig()
             .address(address)
@@ -61,5 +61,29 @@ object VaultSecretsUtilBuilder {
             .build()
 
         new VaultSecretsUtil(Vault.create(config))
+    }
+
+    /** Resolve the Vault token. Prefer VAULT_TOKEN_FILE (a path to a file
+      * holding the token) so the bootstrap can hand the server a RANDOM,
+      * per-install token instead of the old well-known `root-token` — the
+      * file never appears in `docker inspect`/process env the way a value does.
+      * Falls back to the VAULT_TOKEN env var for setups that still pass it
+      * directly (local dev, existing deployments). */
+    private def resolveToken(): String = {
+        val fromFile = sys.env.get("VAULT_TOKEN_FILE")
+            .map(_.trim)
+            .filter(_.nonEmpty)
+            .flatMap { path =>
+                try {
+                    val t = new String(
+                        java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(path)),
+                        java.nio.charset.StandardCharsets.UTF_8
+                    ).trim
+                    if (t.nonEmpty) Some(t) else None
+                } catch {
+                    case _: Exception => None
+                }
+            }
+        fromFile.getOrElse(sys.env("VAULT_TOKEN"))
     }
 }

--- a/datrisserver/src/test/scala/ai/datris/util/TapHttpEndpointSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/TapHttpEndpointSpec.scala
@@ -35,6 +35,10 @@ class TapHttpEndpointSpec extends AnyFunSuite with BeforeAndAfterAll {
     private val responseDelayMs = new AtomicReference[Long](0L)
 
     override def beforeAll(): Unit = {
+        // The tap fixture endpoint runs on loopback, which SsrfGuard blocks by
+        // default. These tests exercise the tap wire contract, not SSRF policy,
+        // so opt into private egress for the duration of the suite.
+        System.setProperty("datris.allowPrivateEgress", "true")
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
         server.createContext(
             "/tap",
@@ -65,6 +69,7 @@ class TapHttpEndpointSpec extends AnyFunSuite with BeforeAndAfterAll {
 
     override def afterAll(): Unit = {
         TenantContext.clear()
+        System.clearProperty("datris.allowPrivateEgress")
         if (server != null) server.stop(0)
     }
 

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -267,8 +267,8 @@ services:
       - datris-net
 
   datris:
-    image: datrisai/datris-server:latest
-    #build: .  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-server:latest
+    build: .  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris
     ports:
       - "8080:8080"
@@ -365,8 +365,8 @@ services:
   # all capabilities dropped, no privilege escalation. Only used when the datris
   # server has USE_TAP_RUNNER=true.
   datris-tap-runner:
-    image: datrisai/datris-tap-runner:latest
-    #build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-tap-runner:latest
+    build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
@@ -384,8 +384,8 @@ services:
       - tap-net
 
   ui:
-    image: datrisai/datris-ui:latest
-    #build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-ui:latest
+    build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: ui
     ports:
       - "4200:8080"
@@ -395,8 +395,8 @@ services:
       - datris-net
 
   mcp-server:
-    image: datrisai/datris-mcp-server:latest
-    #build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-mcp-server:latest
+    build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: mcp-server
     ports:
       - "3000:3000"
@@ -742,7 +742,6 @@ configs:
         fi
         mkdir -p "$$(dirname "$$SERVER_TOKEN_FILE")"
         printf '%s' "$$SERVER_TOKEN_ID" > "$$SERVER_TOKEN_FILE"
-        chmod 600 "$$SERVER_TOKEN_FILE" 2>/dev/null || true
       else
         # Default path: a RANDOM per-install token (no well-known id). Persist it to
         # the shared vault-token volume and reuse it across reboots (renew) so we
@@ -756,13 +755,20 @@ configs:
           echo "vault-bootstrap: creating random datris server token..."
           NEW_TOKEN=$$(vault token create -policy=datris -orphan -period=87600h -field=token)
           printf '%s' "$$NEW_TOKEN" > "$$SERVER_TOKEN_FILE"
-          chmod 600 "$$SERVER_TOKEN_FILE" 2>/dev/null || true
         fi
         # Revoke the legacy well-known `root-token` if a prior install created it, so
         # upgrades don't leave a guessable server token valid. Best-effort; harmless
         # if it never existed.
         vault token revoke root-token >/dev/null 2>&1 || true
       fi
+
+      # The datris container runs as a non-root user (USER datris) and mounts this
+      # volume read-only, so the token file must be world-readable INSIDE the shared
+      # volume — a 0600 file owned by root (this init container) is unreadable by the
+      # server, which then fails to start. The volume is dedicated to vault-init +
+      # datris only, so 0644 exposes nothing further. Applied unconditionally (create
+      # AND renew paths) so an already-written 0600 file is repaired on the next run.
+      chmod 644 "$$SERVER_TOKEN_FILE" 2>/dev/null || true
 
       # 6. Seed (create-if-absent). vault-init.sh inherits VAULT_TOKEN from the env.
       echo "vault-bootstrap: handing off to vault-init.sh for seeding..."

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -46,9 +46,12 @@ services:
   minio:
     image: minio/minio:latest
     container_name: minio
+    # Bound to loopback: reachable from the host (dev tools, console) but not
+    # from other machines. Ships with default creds (minioadmin), so a public
+    # bind would expose object storage to the network.
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -75,8 +78,9 @@ services:
   mongodb:
     image: mongo:7
     container_name: mongodb
+    # Loopback-only: reachable from the host but not from other machines.
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-configdb:/data/configdb
@@ -95,7 +99,8 @@ services:
     deploy:
       replicas: ${POSTGRES_ENABLED:-1}
     ports:
-      - "5432:5432"
+      # Loopback-only: reachable from the host but not from other machines.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -113,8 +118,12 @@ services:
   vault:
     image: hashicorp/vault:1.15
     container_name: vault
+    # Loopback-only. Vault holds every platform secret and the server
+    # authenticates with a well-known token id, so the host port must not be
+    # reachable from other machines. Services reach Vault over the compose
+    # network (http://vault:8200), which is unaffected by this binding.
     ports:
-      - "8200:8200"
+      - "127.0.0.1:8200:8200"
     # File storage on a named volume — secrets PERSIST across container
     # recreation (`--build`, `down && up`, host reboot). Replaces dev mode,
     # which kept everything in memory and wiped it on every restart. The
@@ -285,6 +294,11 @@ services:
       USEUSERAUTH: "${USE_USER_AUTH:-false}"
       USEAPIKEYS: "${USE_API_KEYS:-false}"
       MULTITENANT: "${MULTI_TENANT:-false}"
+      # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
+      # the server requires MinIO to present it as a bearer token (see
+      # minio-init.sh auth_token). Empty by default so existing deployments keep
+      # working; set it in .env to close the unauthenticated-webhook exposure.
+      MINIO_WEBHOOK_TOKEN: "${MINIO_WEBHOOK_TOKEN:-}"
       # Capability enforcement: `enforce` (default) returns HTTP 403 on policy
       # violations by scoped keys. Override to `log-only` in .env to emit
       # would-deny log lines without rejecting — useful only when iterating
@@ -550,6 +564,10 @@ services:
         condition: service_healthy
       datris:
         condition: service_started
+    environment:
+      # Must match the datris service's MINIO_WEBHOOK_TOKEN so the webhook
+      # auth_token MinIO sends matches what the server expects.
+      MINIO_WEBHOOK_TOKEN: "${MINIO_WEBHOOK_TOKEN:-}"
     configs:
       - source: minio-init-sh
         target: /minio-init.sh
@@ -1091,10 +1109,22 @@ configs:
       echo "Pipeline server is reachable."
 
       echo "Configuring MinIO webhook notification endpoint..."
-      mc admin config set myminio notify_webhook:1 \
-        endpoint=http://datris:8080/minio-events \
-        queue_limit=1000 \
-        queue_dir=/tmp/minio-events
+      # When MINIO_WEBHOOK_TOKEN is set, MinIO sends it as `Authorization: Bearer <token>`
+      # and the datris server (same env var) requires it — closing the otherwise
+      # unauthenticated /minio-events endpoint. Empty by default for back-compat.
+      if [ -n "$${MINIO_WEBHOOK_TOKEN}" ]; then
+        mc admin config set myminio notify_webhook:1 \
+          endpoint=http://datris:8080/minio-events \
+          auth_token="$${MINIO_WEBHOOK_TOKEN}" \
+          queue_limit=1000 \
+          queue_dir=/tmp/minio-events
+      else
+        echo "WARNING: MINIO_WEBHOOK_TOKEN is not set — the /minio-events webhook will be unauthenticated."
+        mc admin config set myminio notify_webhook:1 \
+          endpoint=http://datris:8080/minio-events \
+          queue_limit=1000 \
+          queue_dir=/tmp/minio-events
+      fi
 
       echo "Restarting MinIO to apply notification config..."
       mc admin service restart myminio --json 2>/dev/null || true

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -28,6 +28,7 @@ volumes:
   pip-cache:
   tei-data:
   vault-data:        # persists Vault secrets across container recreation (drops dev mode)
+  datris-vault-token: # holds the server's random Vault token (written by vault-init, read by datris)
   # Named data volumes for the three stateful stores. These MUST be named:
   # anonymous volumes survive a plain recreate but are orphaned (left behind,
   # not reattached) whenever the container is removed — `down` + `up`, or a
@@ -159,7 +160,8 @@ services:
       VAULT_ADDR: http://vault:8200
       # No static VAULT_TOKEN — a non-dev Vault generates a random root token at
       # init. vault-bootstrap.sh reads it from the init file on the shared
-      # vault-data volume and mints a fixed-id `root-token` token for the server.
+      # vault-data volume and mints a RANDOM per-install token for the server,
+      # written to the shared vault-token volume (VAULT_TOKEN_FILE on datris).
       DATRIS_UI_API_KEY: ${DATRIS_UI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -227,6 +229,7 @@ services:
         mode: 0755
     volumes:
       - vault-data:/vault/file
+      - datris-vault-token:/vault-token
     entrypoint: ["/bin/sh", "/vault-bootstrap.sh"]
     restart: "no"
     networks:
@@ -283,10 +286,11 @@ services:
         condition: service_started
     environment:
       VAULT_ADDR: http://vault:8200
-      # The server authenticates with this token id. vault-bootstrap.sh mints a
-      # token with the fixed id `root-token` (the real root token is random on a
-      # non-dev Vault), so this value is unchanged from the old dev-mode setup.
-      VAULT_TOKEN: root-token
+      # The server reads its Vault token from this file. vault-bootstrap.sh mints
+      # a RANDOM per-install token and writes it to the shared vault-token volume
+      # mounted read-only below — no well-known `root-token`. An operator can pin
+      # a fixed token instead by setting DATRIS_VAULT_TOKEN (passed to vault-init).
+      VAULT_TOKEN_FILE: /vault-token/token
       # Auth / multi-tenancy toggles. Defaults preserve OSS single-tenant behavior;
       # flip these in your .env to enable user auth, API-key gating, or multi-tenant
       # mode without rebuilding the JAR. Spring's relaxed binding maps these env
@@ -350,6 +354,7 @@ services:
         target: /config/application.yaml
     volumes:
       - pip-cache:/root/.cache/pip
+      - datris-vault-token:/vault-token:ro
     networks:
       - datris-net
       - tap-net
@@ -635,16 +640,20 @@ configs:
       #      shared vault-data volume),
       #   3. unseals it from the stored Shamir key,
       #   4. enables KV v2 at secret/ (dev mode did this implicitly),
-      #   5. mints a fixed-id token so the datris server's `VAULT_TOKEN: root-token`
-      #      keeps working unchanged,
+      #   5. mints the datris server token — a RANDOM per-install token written to the
+      #      shared vault-token volume for the server to read (VAULT_TOKEN_FILE), or a
+      #      fixed-id token when DATRIS_VAULT_TOKEN is set (operator override / legacy),
       #   6. hands off to vault-init.sh for create-if-absent seeding.
       #
       # Everything after first run is idempotent: secrets persist on the volume, so
-      # reboots only unseal + re-mint the server token (if absent) and skip seeding
-      # of any path that already exists.
+      # reboots only unseal + renew/re-mint the server token and skip seeding of any
+      # path that already exists.
 
       INIT_FILE=/vault/file/datris-init.txt
-      SERVER_TOKEN_ID="$${DATRIS_VAULT_TOKEN:-root-token}"
+      # Where the server reads its token from (VAULT_TOKEN_FILE on the datris service
+      # points here). On a dedicated volume — NOT the vault-data volume — so the
+      # server never gets read access to the root token / unseal key in the init file.
+      SERVER_TOKEN_FILE=/vault-token/token
 
       echo "vault-bootstrap: waiting for Vault to respond..."
       # `vault status` exit codes: 0 = unsealed, 2 = sealed (both mean reachable),
@@ -707,32 +716,52 @@ configs:
         vault secrets enable -path=secret -version=2 kv >/dev/null
       fi
 
-      # 5. Policy + fixed-id token for the datris server. The server authenticates
-      #    with `VAULT_TOKEN: root-token` (unchanged from dev mode) — we mint a
-      #    token with that exact id so nothing downstream has to change.
+      # 5. Policy + token for the datris server.
       vault policy write datris - >/dev/null <<'EOF'
       path "secret/*" {
         capabilities = ["create", "read", "update", "delete", "list"]
       }
       EOF
 
-      if VAULT_TOKEN="$$SERVER_TOKEN_ID" vault token lookup >/dev/null 2>&1; then
-        # Token still valid — renew so its TTL is re-extended to the full period on
-        # every boot. Tokens minted before max_lease_ttl was raised to 87600h were
-        # clamped to a 768h TTL and would otherwise die a month after install.
-        vault token renew "$$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+      # Orphan + periodic so the token survives reboots without a parent. The 10-year
+      # period, combined with max_lease_ttl=87600h in vault.hcl (the initial TTL is
+      # clamped to max_lease_ttl regardless of period) and the renew-on-boot below,
+      # makes it effectively non-expiring.
+      if [ -n "$${DATRIS_VAULT_TOKEN:-}" ]; then
+        # Operator override / legacy path: mint a fixed-id token. Kept so an operator
+        # who pins DATRIS_VAULT_TOKEN (e.g. to preserve an existing setup) still works.
+        SERVER_TOKEN_ID="$$DATRIS_VAULT_TOKEN"
+        if VAULT_TOKEN="$$SERVER_TOKEN_ID" vault token lookup >/dev/null 2>&1; then
+          vault token renew "$$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+        else
+          echo "vault-bootstrap: creating datris server token (fixed id from DATRIS_VAULT_TOKEN)..."
+          # Revoke defensively so the re-mint can't fail with "duplicate ID" on a live
+          # zombie entry left by the expiration manager after an upgrade restart.
+          vault token revoke "$$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+          vault token create -id="$$SERVER_TOKEN_ID" -policy=datris -orphan -period=87600h >/dev/null
+        fi
+        mkdir -p "$$(dirname "$$SERVER_TOKEN_FILE")"
+        printf '%s' "$$SERVER_TOKEN_ID" > "$$SERVER_TOKEN_FILE"
+        chmod 600 "$$SERVER_TOKEN_FILE" 2>/dev/null || true
       else
-        echo "vault-bootstrap: creating datris server token (id=$$SERVER_TOKEN_ID)..."
-        # An expired token's entry can linger until the expiration manager reaps it
-        # (which happens during the lease restore after the Vault restart that
-        # accompanies an upgrade). Revoke defensively so the re-mint below can't fail
-        # with "cannot create a token with a duplicate ID" on a live zombie entry.
-        vault token revoke "$$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
-        # Orphan + periodic so it survives reboots without a parent. The 10-year
-        # period, combined with max_lease_ttl=87600h in vault.hcl (the initial TTL is
-        # clamped to max_lease_ttl regardless of period) and the renew-on-boot above,
-        # makes it effectively non-expiring — matching the old dev-mode root-token.
-        vault token create -id="$$SERVER_TOKEN_ID" -policy=datris -orphan -period=87600h >/dev/null
+        # Default path: a RANDOM per-install token (no well-known id). Persist it to
+        # the shared vault-token volume and reuse it across reboots (renew) so we
+        # don't leak a fresh token every boot.
+        mkdir -p "$$(dirname "$$SERVER_TOKEN_FILE")"
+        EXISTING_TOKEN=""
+        [ -f "$$SERVER_TOKEN_FILE" ] && EXISTING_TOKEN=$$(cat "$$SERVER_TOKEN_FILE" 2>/dev/null)
+        if [ -n "$$EXISTING_TOKEN" ] && VAULT_TOKEN="$$EXISTING_TOKEN" vault token lookup >/dev/null 2>&1; then
+          vault token renew "$$EXISTING_TOKEN" >/dev/null 2>&1 || true
+        else
+          echo "vault-bootstrap: creating random datris server token..."
+          NEW_TOKEN=$$(vault token create -policy=datris -orphan -period=87600h -field=token)
+          printf '%s' "$$NEW_TOKEN" > "$$SERVER_TOKEN_FILE"
+          chmod 600 "$$SERVER_TOKEN_FILE" 2>/dev/null || true
+        fi
+        # Revoke the legacy well-known `root-token` if a prior install created it, so
+        # upgrades don't leave a guessable server token valid. Best-effort; harmless
+        # if it never existed.
+        vault token revoke root-token >/dev/null 2>&1 || true
       fi
 
       # 6. Seed (create-if-absent). vault-init.sh inherits VAULT_TOKEN from the env.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,8 +245,8 @@ services:
       - datris-net
 
   datris:
-    image: datrisai/datris-server:latest
-    #build: .  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-server:latest
+    build: .  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris
     ports:
       - "8080:8080"
@@ -344,8 +344,8 @@ services:
   # all capabilities dropped, no privilege escalation. Only used when the datris
   # server has USE_TAP_RUNNER=true.
   datris-tap-runner:
-    image: datrisai/datris-tap-runner:latest
-    #build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-tap-runner:latest
+    build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
@@ -363,8 +363,8 @@ services:
       - tap-net
 
   ui:
-    image: datrisai/datris-ui:latest
-    #build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-ui:latest
+    build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: ui
     ports:
       - "4200:8080"
@@ -374,8 +374,8 @@ services:
       - datris-net
 
   mcp-server:
-    image: datrisai/datris-mcp-server:latest
-    #build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
+    #image: datrisai/datris-mcp-server:latest
+    build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: mcp-server
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,12 @@ services:
   minio:
     image: minio/minio:latest
     container_name: minio
+    # Bound to loopback: reachable from the host (dev tools, console) but not
+    # from other machines. Ships with default creds (minioadmin), so a public
+    # bind would expose object storage to the network.
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -58,8 +61,9 @@ services:
   mongodb:
     image: mongo:7
     container_name: mongodb
+    # Loopback-only: reachable from the host but not from other machines.
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-configdb:/data/configdb
@@ -78,7 +82,8 @@ services:
     deploy:
       replicas: ${POSTGRES_ENABLED:-1}
     ports:
-      - "5432:5432"
+      # Loopback-only: reachable from the host but not from other machines.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -96,8 +101,12 @@ services:
   vault:
     image: hashicorp/vault:1.15
     container_name: vault
+    # Loopback-only. Vault holds every platform secret and the server
+    # authenticates with a well-known token id, so the host port must not be
+    # reachable from other machines. Services reach Vault over the compose
+    # network (http://vault:8200), which is unaffected by this binding.
     ports:
-      - "8200:8200"
+      - "127.0.0.1:8200:8200"
     # File storage on a named volume — secrets PERSIST across container
     # recreation (`--build`, `down && up`, host reboot). Replaces dev mode,
     # which kept everything in memory and wiped it on every restart. The
@@ -262,6 +271,11 @@ services:
       USEUSERAUTH: "${USE_USER_AUTH:-false}"
       USEAPIKEYS: "${USE_API_KEYS:-false}"
       MULTITENANT: "${MULTI_TENANT:-false}"
+      # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
+      # the server requires MinIO to present it as a bearer token (see
+      # minio-init.sh auth_token). Empty by default so existing deployments keep
+      # working; set it in .env to close the unauthenticated-webhook exposure.
+      MINIO_WEBHOOK_TOKEN: "${MINIO_WEBHOOK_TOKEN:-}"
       # Capability enforcement: `enforce` (default) returns HTTP 403 on policy
       # violations by scoped keys. Override to `log-only` in .env to emit
       # would-deny log lines without rejecting — useful only when iterating
@@ -525,6 +539,10 @@ services:
         condition: service_healthy
       datris:
         condition: service_started
+    environment:
+      # Must match the datris service's MINIO_WEBHOOK_TOKEN so the webhook
+      # auth_token MinIO sends matches what the server expects.
+      MINIO_WEBHOOK_TOKEN: "${MINIO_WEBHOOK_TOKEN:-}"
     volumes:
       - ./docker/minio-init.sh:/minio-init.sh
     entrypoint: ["/bin/sh", "/minio-init.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ volumes:
   pip-cache:
   tei-data:
   vault-data:        # persists Vault secrets across container recreation (drops dev mode)
+  datris-vault-token: # holds the server's random Vault token (written by vault-init, read by datris)
   # Named data volumes for the three stateful stores. These MUST be named:
   # anonymous volumes survive a plain recreate but are orphaned (left behind,
   # not reattached) whenever the container is removed — `down` + `up`, or a
@@ -139,7 +140,8 @@ services:
       VAULT_ADDR: http://vault:8200
       # No static VAULT_TOKEN — a non-dev Vault generates a random root token at
       # init. vault-bootstrap.sh reads it from the init file on the shared
-      # vault-data volume and mints a fixed-id `root-token` token for the server.
+      # vault-data volume and mints a RANDOM per-install token for the server,
+      # written to the shared vault-token volume (VAULT_TOKEN_FILE on datris).
       DATRIS_UI_API_KEY: ${DATRIS_UI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -202,6 +204,8 @@ services:
       # Shares vault-data so bootstrap can read/write the init file (unseal key
       # + root token) and unseal the same storage the vault service uses.
       - vault-data:/vault/file
+      # Writes the server's random token here for the datris service to read.
+      - datris-vault-token:/vault-token
       - ./docker/vault-bootstrap.sh:/vault-bootstrap.sh
       - ./docker/vault-init.sh:/vault-init.sh
     entrypoint: ["/bin/sh", "/vault-bootstrap.sh"]
@@ -260,10 +264,11 @@ services:
         condition: service_started
     environment:
       VAULT_ADDR: http://vault:8200
-      # The server authenticates with this token id. vault-bootstrap.sh mints a
-      # token with the fixed id `root-token` (the real root token is random on a
-      # non-dev Vault), so this value is unchanged from the old dev-mode setup.
-      VAULT_TOKEN: root-token
+      # The server reads its Vault token from this file. vault-bootstrap.sh mints
+      # a RANDOM per-install token and writes it to the shared vault-token volume
+      # mounted read-only below — no well-known `root-token`. An operator can pin
+      # a fixed token instead by setting DATRIS_VAULT_TOKEN (passed to vault-init).
+      VAULT_TOKEN_FILE: /vault-token/token
       # Auth / multi-tenancy toggles. Defaults preserve OSS single-tenant behavior;
       # flip these in your .env to enable user auth, API-key gating, or multi-tenant
       # mode without rebuilding the JAR. Spring's relaxed binding maps these env
@@ -325,6 +330,10 @@ services:
     volumes:
       - ./docker/config:/config
       - pip-cache:/root/.cache/pip
+      # Read-only: the server reads its Vault token (written by vault-init) but
+      # can't modify it. Dedicated volume so the server never sees the Vault
+      # root token / unseal key that live on the vault-data volume.
+      - datris-vault-token:/vault-token:ro
     networks:
       - datris-net
       - tap-net

--- a/docker/minio-init.sh
+++ b/docker/minio-init.sh
@@ -19,10 +19,22 @@ done
 echo "Pipeline server is reachable."
 
 echo "Configuring MinIO webhook notification endpoint..."
-mc admin config set myminio notify_webhook:1 \
-  endpoint=http://datris:8080/minio-events \
-  queue_limit=1000 \
-  queue_dir=/tmp/minio-events
+# When MINIO_WEBHOOK_TOKEN is set, MinIO sends it as `Authorization: Bearer <token>`
+# and the datris server (same env var) requires it — closing the otherwise
+# unauthenticated /minio-events endpoint. Empty by default for back-compat.
+if [ -n "${MINIO_WEBHOOK_TOKEN}" ]; then
+  mc admin config set myminio notify_webhook:1 \
+    endpoint=http://datris:8080/minio-events \
+    auth_token="${MINIO_WEBHOOK_TOKEN}" \
+    queue_limit=1000 \
+    queue_dir=/tmp/minio-events
+else
+  echo "WARNING: MINIO_WEBHOOK_TOKEN is not set — the /minio-events webhook will be unauthenticated."
+  mc admin config set myminio notify_webhook:1 \
+    endpoint=http://datris:8080/minio-events \
+    queue_limit=1000 \
+    queue_dir=/tmp/minio-events
+fi
 
 echo "Restarting MinIO to apply notification config..."
 mc admin service restart myminio --json 2>/dev/null || true

--- a/docker/vault-bootstrap.sh
+++ b/docker/vault-bootstrap.sh
@@ -113,7 +113,6 @@ if [ -n "${DATRIS_VAULT_TOKEN:-}" ]; then
   fi
   mkdir -p "$(dirname "$SERVER_TOKEN_FILE")"
   printf '%s' "$SERVER_TOKEN_ID" > "$SERVER_TOKEN_FILE"
-  chmod 600 "$SERVER_TOKEN_FILE" 2>/dev/null || true
 else
   # Default path: a RANDOM per-install token (no well-known id). Persist it to
   # the shared vault-token volume and reuse it across reboots (renew) so we
@@ -127,13 +126,20 @@ else
     echo "vault-bootstrap: creating random datris server token..."
     NEW_TOKEN=$(vault token create -policy=datris -orphan -period=87600h -field=token)
     printf '%s' "$NEW_TOKEN" > "$SERVER_TOKEN_FILE"
-    chmod 600 "$SERVER_TOKEN_FILE" 2>/dev/null || true
   fi
   # Revoke the legacy well-known `root-token` if a prior install created it, so
   # upgrades don't leave a guessable server token valid. Best-effort; harmless
   # if it never existed.
   vault token revoke root-token >/dev/null 2>&1 || true
 fi
+
+# The datris container runs as a non-root user (USER datris) and mounts this
+# volume read-only, so the token file must be world-readable INSIDE the shared
+# volume — a 0600 file owned by root (this init container) is unreadable by the
+# server, which then fails to start. The volume is dedicated to vault-init +
+# datris only, so 0644 exposes nothing further. Applied unconditionally (create
+# AND renew paths) so an already-written 0600 file is repaired on the next run.
+chmod 644 "$SERVER_TOKEN_FILE" 2>/dev/null || true
 
 # 6. Seed (create-if-absent). vault-init.sh inherits VAULT_TOKEN from the env.
 echo "vault-bootstrap: handing off to vault-init.sh for seeding..."

--- a/docker/vault-bootstrap.sh
+++ b/docker/vault-bootstrap.sh
@@ -11,16 +11,20 @@ set -e
 #      shared vault-data volume),
 #   3. unseals it from the stored Shamir key,
 #   4. enables KV v2 at secret/ (dev mode did this implicitly),
-#   5. mints a fixed-id token so the datris server's `VAULT_TOKEN: root-token`
-#      keeps working unchanged,
+#   5. mints the datris server token — a RANDOM per-install token written to the
+#      shared vault-token volume for the server to read (VAULT_TOKEN_FILE), or a
+#      fixed-id token when DATRIS_VAULT_TOKEN is set (operator override / legacy),
 #   6. hands off to vault-init.sh for create-if-absent seeding.
 #
 # Everything after first run is idempotent: secrets persist on the volume, so
-# reboots only unseal + re-mint the server token (if absent) and skip seeding
-# of any path that already exists.
+# reboots only unseal + renew/re-mint the server token and skip seeding of any
+# path that already exists.
 
 INIT_FILE=/vault/file/datris-init.txt
-SERVER_TOKEN_ID="${DATRIS_VAULT_TOKEN:-root-token}"
+# Where the server reads its token from (VAULT_TOKEN_FILE on the datris service
+# points here). On a dedicated volume — NOT the vault-data volume — so the
+# server never gets read access to the root token / unseal key in the init file.
+SERVER_TOKEN_FILE=/vault-token/token
 
 echo "vault-bootstrap: waiting for Vault to respond..."
 # `vault status` exit codes: 0 = unsealed, 2 = sealed (both mean reachable),
@@ -83,32 +87,52 @@ if ! vault secrets list 2>/dev/null | grep -q '^secret/'; then
   vault secrets enable -path=secret -version=2 kv >/dev/null
 fi
 
-# 5. Policy + fixed-id token for the datris server. The server authenticates
-#    with `VAULT_TOKEN: root-token` (unchanged from dev mode) — we mint a
-#    token with that exact id so nothing downstream has to change.
+# 5. Policy + token for the datris server.
 vault policy write datris - >/dev/null <<'EOF'
 path "secret/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 EOF
 
-if VAULT_TOKEN="$SERVER_TOKEN_ID" vault token lookup >/dev/null 2>&1; then
-  # Token still valid — renew so its TTL is re-extended to the full period on
-  # every boot. Tokens minted before max_lease_ttl was raised to 87600h were
-  # clamped to a 768h TTL and would otherwise die a month after install.
-  vault token renew "$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+# Orphan + periodic so the token survives reboots without a parent. The 10-year
+# period, combined with max_lease_ttl=87600h in vault.hcl (the initial TTL is
+# clamped to max_lease_ttl regardless of period) and the renew-on-boot below,
+# makes it effectively non-expiring.
+if [ -n "${DATRIS_VAULT_TOKEN:-}" ]; then
+  # Operator override / legacy path: mint a fixed-id token. Kept so an operator
+  # who pins DATRIS_VAULT_TOKEN (e.g. to preserve an existing setup) still works.
+  SERVER_TOKEN_ID="$DATRIS_VAULT_TOKEN"
+  if VAULT_TOKEN="$SERVER_TOKEN_ID" vault token lookup >/dev/null 2>&1; then
+    vault token renew "$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+  else
+    echo "vault-bootstrap: creating datris server token (fixed id from DATRIS_VAULT_TOKEN)..."
+    # Revoke defensively so the re-mint can't fail with "duplicate ID" on a live
+    # zombie entry left by the expiration manager after an upgrade restart.
+    vault token revoke "$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
+    vault token create -id="$SERVER_TOKEN_ID" -policy=datris -orphan -period=87600h >/dev/null
+  fi
+  mkdir -p "$(dirname "$SERVER_TOKEN_FILE")"
+  printf '%s' "$SERVER_TOKEN_ID" > "$SERVER_TOKEN_FILE"
+  chmod 600 "$SERVER_TOKEN_FILE" 2>/dev/null || true
 else
-  echo "vault-bootstrap: creating datris server token (id=$SERVER_TOKEN_ID)..."
-  # An expired token's entry can linger until the expiration manager reaps it
-  # (which happens during the lease restore after the Vault restart that
-  # accompanies an upgrade). Revoke defensively so the re-mint below can't fail
-  # with "cannot create a token with a duplicate ID" on a live zombie entry.
-  vault token revoke "$SERVER_TOKEN_ID" >/dev/null 2>&1 || true
-  # Orphan + periodic so it survives reboots without a parent. The 10-year
-  # period, combined with max_lease_ttl=87600h in vault.hcl (the initial TTL is
-  # clamped to max_lease_ttl regardless of period) and the renew-on-boot above,
-  # makes it effectively non-expiring — matching the old dev-mode root-token.
-  vault token create -id="$SERVER_TOKEN_ID" -policy=datris -orphan -period=87600h >/dev/null
+  # Default path: a RANDOM per-install token (no well-known id). Persist it to
+  # the shared vault-token volume and reuse it across reboots (renew) so we
+  # don't leak a fresh token every boot.
+  mkdir -p "$(dirname "$SERVER_TOKEN_FILE")"
+  EXISTING_TOKEN=""
+  [ -f "$SERVER_TOKEN_FILE" ] && EXISTING_TOKEN=$(cat "$SERVER_TOKEN_FILE" 2>/dev/null)
+  if [ -n "$EXISTING_TOKEN" ] && VAULT_TOKEN="$EXISTING_TOKEN" vault token lookup >/dev/null 2>&1; then
+    vault token renew "$EXISTING_TOKEN" >/dev/null 2>&1 || true
+  else
+    echo "vault-bootstrap: creating random datris server token..."
+    NEW_TOKEN=$(vault token create -policy=datris -orphan -period=87600h -field=token)
+    printf '%s' "$NEW_TOKEN" > "$SERVER_TOKEN_FILE"
+    chmod 600 "$SERVER_TOKEN_FILE" 2>/dev/null || true
+  fi
+  # Revoke the legacy well-known `root-token` if a prior install created it, so
+  # upgrades don't leave a guessable server token valid. Best-effort; harmless
+  # if it never existed.
+  vault token revoke root-token >/dev/null 2>&1 || true
 fi
 
 # 6. Seed (create-if-absent). vault-init.sh inherits VAULT_TOKEN from the env.

--- a/docs/ai-configuration.mdx
+++ b/docs/ai-configuration.mdx
@@ -299,7 +299,8 @@ The next boot re-initializes Vault and seeds from `.env`.
 To write a secret directly to Vault (note: manual Vault writes do **not** trigger hot reload — restart the server or re-save from the UI):
 
 ```bash
-docker compose exec -e VAULT_ADDR=http://vault:8200 -e VAULT_TOKEN=root-token vault \
+docker compose exec -e VAULT_ADDR=http://vault:8200 \
+  -e VAULT_TOKEN="$(docker compose exec -T datris cat /vault-token/token)" vault \
   vault kv put secret/oss/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \
@@ -311,7 +312,8 @@ docker compose exec -e VAULT_ADDR=http://vault:8200 -e VAULT_TOKEN=root-token va
 Same shape for `oss/codegen` and `oss/embedding`. Verify with:
 
 ```bash
-docker compose exec -e VAULT_ADDR=http://vault:8200 -e VAULT_TOKEN=root-token vault \
+docker compose exec -e VAULT_ADDR=http://vault:8200 \
+  -e VAULT_TOKEN="$(docker compose exec -T datris cat /vault-token/token)" vault \
   vault kv get secret/oss/ai-primary
 ```
 
@@ -426,7 +428,8 @@ To revert to defaults, click **Reset to Datris-managed**. This deletes all three
 For operators provisioning tenants programmatically:
 
 ```bash
-docker compose exec -e VAULT_ADDR=http://vault:8200 -e VAULT_TOKEN=root-token vault \
+docker compose exec -e VAULT_ADDR=http://vault:8200 \
+  -e VAULT_TOKEN="$(docker compose exec -T datris cat /vault-token/token)" vault \
   vault kv put secret/trial-acme/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -168,7 +168,8 @@ Region lives in the credentials secret rather than on the pipeline config so the
 
 Vault connection is configured via environment variables:
 - `VAULT_ADDR` - Vault server URL (e.g., `http://vault:8200`)
-- `VAULT_TOKEN` - Authentication token
+- `VAULT_TOKEN_FILE` - Path to a file holding the auth token (preferred; the bundled Compose writes a random per-install token here). Takes precedence over `VAULT_TOKEN`.
+- `VAULT_TOKEN` - Authentication token, used when `VAULT_TOKEN_FILE` is unset (local dev, custom setups)
 
 ### ActiveMQ (Queue & Notifications)
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -149,7 +149,7 @@ Your data is preserved across upgrades — Postgres pipelines, Vault secrets, Mi
 
 Datris occasionally deprecates secret paths between versions (for example, v1.5.6 split AI configuration into three new Vault slots and stopped reading the old single-slot path). Because Vault data persists across upgrades, deprecated entries stay in Vault and continue to appear in the Configuration → Secrets list even though the server ignores them. To clean them up:
 
-- **Targeted (preserves your data):** delete the stale entries one at a time from Configuration → Secrets in the UI, or run `docker compose exec -e VAULT_TOKEN=root-token vault vault kv delete secret/oss/<name>` for each deprecated path.
+- **Targeted (preserves your data):** delete the stale entries one at a time from Configuration → Secrets in the UI, or run `docker compose exec -e VAULT_TOKEN="$(docker compose exec -T datris cat /vault-token/token)" vault vault kv delete secret/oss/<name>` for each deprecated path.
 - **Total reset (destroys all data):** see the next section.
 
 ### Reset everything (destroys all data)
@@ -227,7 +227,7 @@ Commonly used packages (`requests`, `beautifulsoup4`, `pandas`, `lxml`, `feedpar
 | **MinIO Console** | [http://localhost:9001](http://localhost:9001) | `minioadmin` / `minioadmin` |
 | **ActiveMQ Console** | [http://localhost:8161](http://localhost:8161) | `admin` / `admin` |
 | **Kafka UI** (opt-in) | [http://localhost:8085](http://localhost:8085) | none — only with `COMPOSE_PROFILES=kafka` |
-| **Vault UI** | [http://localhost:8200](http://localhost:8200) | Token: `root-token` |
+| **Vault UI** | [http://localhost:8200](http://localhost:8200) | Token: run `docker compose exec -T datris cat /vault-token/token` (random per install) |
 
 ## API Keys and AI Providers
 

--- a/scripts/build-standalone-compose.py
+++ b/scripts/build-standalone-compose.py
@@ -53,6 +53,8 @@ REPLACEMENTS = [
         "      # Shares vault-data so bootstrap can read/write the init file (unseal key\n"
         "      # + root token) and unseal the same storage the vault service uses.\n"
         "      - vault-data:/vault/file\n"
+        "      # Writes the server's random token here for the datris service to read.\n"
+        "      - datris-vault-token:/vault-token\n"
         "      - ./docker/vault-bootstrap.sh:/vault-bootstrap.sh\n"
         "      - ./docker/vault-init.sh:/vault-init.sh\n",
         "    configs:\n"
@@ -63,7 +65,8 @@ REPLACEMENTS = [
         "        target: /vault-init.sh\n"
         "        mode: 0755\n"
         "    volumes:\n"
-        "      - vault-data:/vault/file\n",
+        "      - vault-data:/vault/file\n"
+        "      - datris-vault-token:/vault-token\n",
     ),
     (
         "    volumes:\n"
@@ -77,12 +80,17 @@ REPLACEMENTS = [
         # datris: inline the config override, keep the pip-cache named volume.
         "    volumes:\n"
         "      - ./docker/config:/config\n"
-        "      - pip-cache:/root/.cache/pip\n",
+        "      - pip-cache:/root/.cache/pip\n"
+        "      # Read-only: the server reads its Vault token (written by vault-init) but\n"
+        "      # can't modify it. Dedicated volume so the server never sees the Vault\n"
+        "      # root token / unseal key that live on the vault-data volume.\n"
+        "      - datris-vault-token:/vault-token:ro\n",
         "    configs:\n"
         "      - source: datris-app-yaml\n"
         "        target: /config/application.yaml\n"
         "    volumes:\n"
-        "      - pip-cache:/root/.cache/pip\n",
+        "      - pip-cache:/root/.cache/pip\n"
+        "      - datris-vault-token:/vault-token:ro\n",
     ),
 ]
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -4,6 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Don't advertise the nginx version in responses/error pages.
+    server_tokens off;
+
+    # Security headers. CSP frame-ancestors + X-Frame-Options block clickjacking;
+    # nosniff stops MIME-type confusion; Referrer-Policy avoids leaking full URLs
+    # (which can carry tokens) to third parties. Applied to every response.
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "frame-ancestors 'none'" always;
+
     resolver 127.0.0.11 valid=10s;
     set $upstream http://datris:8080;
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12160,9 +12160,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14135,9 +14135,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Security audit remediation plus continuous supply-chain scanning. Four commits, each self-contained.

## 1. Security audit fixes
Findings from a full-codebase audit (auth, code-exec, injection, SSRF, secrets, deployment).

**Critical**
- **Auth bypasses** — `@RequiresRole` is now enforced independently of the `AuthAPIController` class exemption and the `x-api-key`-presence shortcut, so admin user-management and the Keys API can no longer be reached anonymously or with a forged/scoped key (previously: unauth admin creation + `*:*` master-key minting).
- **First-login takeover** — seeded admin and invited users now get a random bootstrap/temporary password instead of a null hash; login always verifies. Existing null-hash accounts self-heal with a logged password on startup.
- **CodeGen sandbox** — LLM-generated DQ/transformation Python now runs with a scrubbed environment (no `VAULT_TOKEN`/provider keys/DB passwords in `os.environ`), matching the tap runner.

**High**
- PostgresLoader second-order SQLi: destination db/schema/table/warehouse identifiers validated; COPY options reject `;`.
- SSRF egress filtering for HTTP taps and REST endpoints (blocks loopback/link-local/private/metadata; `DATRIS_ALLOW_PRIVATE_EGRESS` opt-out).
- `/minio-events` webhook authenticated via bearer token (`MINIO_WEBHOOK_TOKEN`).

**Medium / hardening**
- Secret read-scope enforcement + DSN/URL credential redaction; XXE hardening; config-upload path-traversal sanitization; env-driven cookie `Secure`; CORS no longer pairs `*` with credentials; nginx security headers; Vault/Postgres/Mongo/MinIO host ports bound to `127.0.0.1`.

## 2. Vault token randomization
Server no longer authenticates with the well-known `root-token`. `vault-bootstrap.sh` mints a random per-install token to a dedicated volume; the server reads it via `VAULT_TOKEN_FILE` (falls back to `VAULT_TOKEN`). `DATRIS_VAULT_TOKEN` still pins a fixed id for operators who want it.

## 3. Dependabot + Trivy scanning
- Dependabot: github-actions, npm (ui), pip (mcp-server), docker base images.
- Trivy: filesystem scan (deps/secrets/misconfig) on PR/push; weekly image scan of published `datrisai/*` images. Report-only initially; results upload to the Security tab.

## 4. Scala dependency graph
`sbt-dependency-submission` submits the sbt dependency graph to GitHub so Dependabot covers Scala/JVM deps too (the one ecosystem it can't do natively). Chosen because the `sbt-dependency-check` plugin is unmaintained and broken against the current NVD.

## Verification
Server compiles; **189 tests pass**; both compose files validate; standalone regenerated.

## Behavior changes to note
- First-login now reads a bootstrap password from server logs (no more "any password"); invited users get a returned temp password.
- HTTP taps pointed at `localhost`/`host.docker.internal` now require `DATRIS_ALLOW_PRIVATE_EGRESS=true`.
- Manual Vault CLI/UI uses the random token (`docker compose exec -T datris cat /vault-token/token`) instead of `root-token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
