### PR TITLE
Bump embedded Tomcat to 10.1.55 (clears 4 critical CVEs)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,16 @@ lazy val datrisserver = project
             // applies to every transitive consumer too.
             "org.apache.hadoop" % "hadoop-common" % "3.3.4",
             "org.apache.hadoop" % "hadoop-client-api" % "3.3.4",
-            "org.apache.hadoop" % "hadoop-client-runtime" % "3.3.4"
+            "org.apache.hadoop" % "hadoop-client-runtime" % "3.3.4",
+            // Embedded Tomcat (Spring Boot's servlet container — the process
+            // serving the API). Bump from the 10.1.33 that Boot 3.2.12 ships to
+            // 10.1.55 to clear 4 critical CVEs: partial-PUT RCE, HTTP/2 header
+            // validation, digest-auth bypass, and security-constraint bypass.
+            // All three tomcat-embed-* artifacts MUST move together — a version
+            // mismatch between them makes the embedded server fail to start.
+            "org.apache.tomcat.embed" % "tomcat-embed-core" % "10.1.55",
+            "org.apache.tomcat.embed" % "tomcat-embed-el" % "10.1.55",
+            "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55"
         ),
         buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
         buildInfoPackage := "ai.datris.build.sbt",


### PR DESCRIPTION
Overrides the embedded Tomcat (Spring Boot's servlet container — the process serving the API) from 10.1.33 to **10.1.55**, clearing 4 critical Dependabot alerts (#142 partial-PUT RCE, #199 HTTP/2 header validation, #202 digest-auth bypass, #204 security-constraint bypass).

Same 10.1.x line Boot 3.2.12 ships, so low risk. Resolves to 10.1.55, compiles, 189 tests pass.

Note: unit tests don't boot the web server — worth a build-from-source smoke to confirm the server starts on the new Tomcat before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)