### PR TITLE
Fix broken UI build (zone.js/typescript vs Angular 18) + add UI build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,28 @@ jobs:
 
       - name: Format check and test
         run: sbt scalafmtCheckAll test
+
+  # Builds the Angular UI so a dependency bump that breaks the UI (peer-dep
+  # conflict on `npm ci`, or a build error) fails CI instead of merging green.
+  # The `test` job above only covers the Scala server — a UI-breaking dep
+  # (e.g. a zone.js/typescript bump past Angular's supported range) slipped
+  # through before this existed.
+  ui-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install and build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,7 @@
         "ngx-echarts": "^18.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "zone.js": "~0.16.2"
+        "zone.js": "~0.14.10"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.0.2",
@@ -35,7 +35,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
-        "typescript": "~5.9.3"
+        "typescript": "~5.4.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4883,9 +4883,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4900,9 +4897,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4917,9 +4911,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4934,9 +4925,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4951,9 +4939,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4968,9 +4953,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4985,9 +4967,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5002,9 +4981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5019,9 +4995,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13594,9 +13567,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14448,9 +14421,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
-      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
+      "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
       "license": "MIT"
     },
     "node_modules/zrender": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     "ngx-echarts": "^18.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.16.2"
+    "zone.js": "~0.14.10"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.0.2",
@@ -37,6 +37,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "typescript": "~5.9.3"
+    "typescript": "~5.4.2"
   }
 }


### PR DESCRIPTION
## The regression
A Dependabot `npm-minor-patch` group merge bumped **zone.js 0.14.3 → 0.16.2** and **typescript 5.4.2 → 5.9.3**, both past Angular 18's supported range:
- `@angular/core@18` peer-requires `zone.js@~0.14.10`
- `@angular-devkit/build-angular@18` peer-requires `typescript >=5.4 <5.6`

So `npm ci` failed with ERESOLVE and **main's UI could no longer build**. (These are `0.x`/minor bumps, so they landed in the minor-patch group and slipped through — because CI's `test` job only builds the Scala server.)

## Fix
- Pin `zone.js → ~0.14.10`, `typescript → ~5.4.2`; lockfile regenerated.
- **Verified locally:** `npm ci` exits 0 and `npm run build` completes.

## Prevention
- New **`ui-build`** CI job runs `npm ci && npm run build` on every PR/push, so a UI-breaking dependency fails CI instead of merging green.

## Follow-up for the maintainer
To make this actually *gate* merges, add **`ui-build`** to the required status checks in `main`'s branch protection (currently only `test` is required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)