### PR TITLE
Fix compose default: pull published images instead of building from source

### DIFF
--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -267,8 +267,8 @@ services:
       - datris-net
 
   datris:
-    #image: datrisai/datris-server:latest
-    build: .  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-server:latest
+    #build: .  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris
     ports:
       - "8080:8080"
@@ -365,8 +365,8 @@ services:
   # all capabilities dropped, no privilege escalation. Only used when the datris
   # server has USE_TAP_RUNNER=true.
   datris-tap-runner:
-    #image: datrisai/datris-tap-runner:latest
-    build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-tap-runner:latest
+    #build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
@@ -384,8 +384,8 @@ services:
       - tap-net
 
   ui:
-    #image: datrisai/datris-ui:latest
-    build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-ui:latest
+    #build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: ui
     ports:
       - "4200:8080"
@@ -395,8 +395,8 @@ services:
       - datris-net
 
   mcp-server:
-    #image: datrisai/datris-mcp-server:latest
-    build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-mcp-server:latest
+    #build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: mcp-server
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,8 +245,8 @@ services:
       - datris-net
 
   datris:
-    #image: datrisai/datris-server:latest
-    build: .  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-server:latest
+    #build: .  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris
     ports:
       - "8080:8080"
@@ -344,8 +344,8 @@ services:
   # all capabilities dropped, no privilege escalation. Only used when the datris
   # server has USE_TAP_RUNNER=true.
   datris-tap-runner:
-    #image: datrisai/datris-tap-runner:latest
-    build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-tap-runner:latest
+    #build: ./tap-runner  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
@@ -363,8 +363,8 @@ services:
       - tap-net
 
   ui:
-    #image: datrisai/datris-ui:latest
-    build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-ui:latest
+    #build: ./ui  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: ui
     ports:
       - "4200:8080"
@@ -374,8 +374,8 @@ services:
       - datris-net
 
   mcp-server:
-    #image: datrisai/datris-mcp-server:latest
-    build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
+    image: datrisai/datris-mcp-server:latest
+    #build: ./mcp-server  # Uncomment to build from source instead of pulling from Docker Hub
     container_name: mcp-server
     ports:
       - "3000:3000"


### PR DESCRIPTION
`docker-compose.yml` (and the generated standalone) shipped with **`build:` active and `image:` commented** on all four services — an accidental commit of a local build-from-source toggle. Effects:
- A fresh `docker compose up` builds everything from source instead of pulling the `datrisai/*` images.
- The **standalone** (a single downloaded file with no source tree) couldn't build at all — it's meant to pull images.

Restores the intended default: `image: datrisai/*:latest` active, `build:` commented as the opt-in. Standalone regenerated to match (passes the standalone-compose-check guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)