### PR TITLE
Fix 5 critical dependency CVEs; provision default objectStore bucket at install time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,19 @@ lazy val datrisserver = project
             // mismatch between them makes the embedded server fail to start.
             "org.apache.tomcat.embed" % "tomcat-embed-core" % "10.1.55",
             "org.apache.tomcat.embed" % "tomcat-embed-el" % "10.1.55",
-            "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55"
+            "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55",
+            // CVE patch bumps over what Spark 3.5.4 pulls transitively. Avro
+            // 1.11.4 is a patch release over Spark's 1.11.2 (CVE-2024-47561,
+            // code execution reading untrusted Avro). ZooKeeper 3.7.2 replaces
+            // the 3.6.3 client jar Spark/Curator drag in (CVE-2023-44981);
+            // nothing in the stack runs a ZooKeeper server, and the 3.7 client
+            // wire protocol is compatible with the 3.5+ servers Spark supports.
+            "org.apache.avro" % "avro" % "1.11.4",
+            "org.apache.zookeeper" % "zookeeper" % "3.7.2",
+            // minio (even at 8.5.17) still ships bcprov 1.78.1, which carries
+            // CVE-2025-14813 (GOST 28147 keystream reuse — cipher unused here,
+            // but the override clears the alert). 1.80.2 is the patched line.
+            "org.bouncycastle" % "bcprov-jdk18on" % "1.80.2"
         ),
         buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
         buildInfoPackage := "ai.datris.build.sbt",
@@ -75,7 +87,7 @@ lazy val datrisserver = project
 
 lazy val allDependencies = Seq(
     // Object store
-    "io.minio" % "minio" % "8.5.14",
+    "io.minio" % "minio" % "8.5.17",
 
     // HTTP
     "org.apache.httpcomponents" % "httpclient" % "4.5.14",
@@ -141,12 +153,11 @@ lazy val allDependencies = Seq(
     // principal / managed identity) — the Azure analogue of the Bedrock
     // credential chain above. Token-fetch-only: AI requests still execute on
     // the shared Apache client in AIHttp; azure-identity only talks to the
-    // Entra token endpoints. This adds no new HTTP transport to the jar:
-    // milvus-sdk-java already ships the full azure-core + azure-core-http-netty
-    // + reactor-netty stack (via azure-storage-blob) — including azure-identity
-    // 1.10.1, which this direct dependency evicts up to a current version.
-    // Jackson stays safe: the 2.15.2 dependencyOverrides pin above applies to
-    // azure-core's transitives too.
+    // Entra token endpoints. azure-identity declares its own azure-core +
+    // azure-core-http-netty transport (milvus-sdk-java 2.5+ no longer ships
+    // the azure-storage-blob stack it used to piggyback on). Jackson stays
+    // safe: the 2.15.2 dependencyOverrides pin above applies to azure-core's
+    // transitives too.
     "com.azure" % "azure-identity" % "1.18.4",
 
     // Secrets: HashiCorp Vault
@@ -165,8 +176,14 @@ lazy val allDependencies = Seq(
     // Vector database: Weaviate
     "io.weaviate" % "client" % "4.9.0",
 
-    // Vector database: Milvus
-    "io.milvus" % "milvus-sdk-java" % "2.4.4",
+    // Vector database: Milvus. 2.5.x dropped the bulkwriter dependency tree
+    // (hadoop-client, parquet-avro, minio, azure-storage-blob) that 2.4.x
+    // shipped — we only use the io.milvus.v2 client API, never the bulkwriter,
+    // and that tree carried three critical CVEs (parquet-avro RCE, the
+    // unpatchable jackson-mapper-asl, and hadoop's old avro/zookeeper).
+    // 2.5.10 rather than 2.6.x: users bring their own Milvus server, and the
+    // 2.5 SDK has the wider server-compat window.
+    "io.milvus" % "milvus-sdk-java" % "2.5.10",
 
     // Document text extraction
     "org.apache.pdfbox" % "pdfbox" % "3.0.4",

--- a/deploy/migrate-trial.sh
+++ b/deploy/migrate-trial.sh
@@ -84,7 +84,7 @@ echo "MongoDB migration complete."
 # ---- Step 3: Migrate MinIO buckets ----
 echo "[3/4] Migrating MinIO buckets..."
 
-BUCKETS="${TRIAL_ENV}-config ${TRIAL_ENV}-raw ${TRIAL_ENV}-raw-plus ${TRIAL_ENV}-temp"
+BUCKETS="${TRIAL_ENV}-config ${TRIAL_ENV}-raw ${TRIAL_ENV}-data ${TRIAL_ENV}-temp"
 
 for BUCKET in $BUCKETS; do
     NEW_BUCKET=$(echo "$BUCKET" | sed "s/${TRIAL_ENV}/${NEW_ENV}/")

--- a/deploy/minio-init-prod.sh
+++ b/deploy/minio-init-prod.sh
@@ -9,7 +9,7 @@ done
 echo "Creating buckets for environment: $ENVIRONMENT"
 mc mb --ignore-existing myminio/${ENVIRONMENT}-config
 mc mb --ignore-existing myminio/${ENVIRONMENT}-raw
-mc mb --ignore-existing myminio/${ENVIRONMENT}-raw-plus
+mc mb --ignore-existing myminio/${ENVIRONMENT}-data
 mc mb --ignore-existing myminio/${ENVIRONMENT}-temp
 
 echo "Waiting for Datris server to be reachable..."

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1134,7 +1134,7 @@ configs:
       echo "Creating buckets..."
       mc mb --ignore-existing myminio/oss-config
       mc mb --ignore-existing myminio/oss-raw
-      mc mb --ignore-existing myminio/oss-raw-plus
+      mc mb --ignore-existing myminio/oss-data
       mc mb --ignore-existing myminio/oss-temp
 
       echo "Waiting for Pipeline server to be reachable..."

--- a/docker/minio-init.sh
+++ b/docker/minio-init.sh
@@ -9,7 +9,7 @@ done
 echo "Creating buckets..."
 mc mb --ignore-existing myminio/oss-config
 mc mb --ignore-existing myminio/oss-raw
-mc mb --ignore-existing myminio/oss-raw-plus
+mc mb --ignore-existing myminio/oss-data
 mc mb --ignore-existing myminio/oss-temp
 
 echo "Waiting for Pipeline server to be reachable..."

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -329,7 +329,6 @@ The following buckets are created automatically by the `minio-init` container:
 | Bucket | Purpose |
 |--------|---------|
 | `{environment}-raw` | File upload staging |
-| `{environment}-raw-plus` | Processed file staging |
 | `{environment}-temp` | Temporary processing files |
 | `{environment}-data` | Object store destination output |
 | `{environment}-config` | Configuration files (validation schemas) |

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -251,7 +251,6 @@ At least one AI provider key is required for AI features. The embedding provider
 The `minio-init` container automatically creates the required buckets:
 
 - `{env}-raw` - File upload staging
-- `{env}-raw-plus` - Processed file staging
 - `{env}-temp` - Temporary processing files
 - `{env}-data` - Pipeline output (object store destination)
 - `{env}-config` - Configuration files (validation schemas)


### PR DESCRIPTION
## Critical CVE fixes (all 5 open critical Dependabot alerts)

All five were transitive — none is a direct dependency.

- **milvus-sdk-java 2.4.4 → 2.5.10** — the 2.5 line dropped the unused bulkwriter dependency tree (hadoop-client, parquet-avro, minio, azure-storage-blob). This removes CVE-2025-30065 (parquet-avro RCE, alert #144) and CVE-2019-10202 (jackson-mapper-asl deserialization, alert #118 — no patched version exists; removal is the only fix) from the graph entirely. Only the `io.milvus.v2` client API is used, which is unchanged.
- **dependencyOverrides** for what Spark 3.5.4 still pulls:
  - avro 1.11.4 (CVE-2024-47561, alert #132) — patch release over Spark's 1.11.2
  - zookeeper 3.7.2 (CVE-2023-44981, alert #125) — client jar only; nothing in the stack runs a ZooKeeper server
  - bcprov-jdk18on 1.80.2 (CVE-2025-14813, alert #210) — minio still ships 1.78.1 even at 8.5.17
- **minio 8.5.14 → 8.5.17**

### Verification
- dependencyTree contains zero occurrences of any flagged artifact; avro/zookeeper/bcprov resolve to patched versions everywhere
- 189/189 tests pass; assembly builds and contains no parquet-avro or unshaded codehaus-jackson classes (only hadoop-client-runtime's relocated `org.apache.hadoop.shaded.*` copies, which ship with Spark and are not the flagged artifacts)
- Live smoke: objectStore (MinIO) destination write verified on the rebuilt image — S3A now runs off Spark's hadoop-client-api/runtime with hadoop-common gone from the classpath
- azure-identity keeps its own azure-core-http-netty transport now that milvus no longer supplies one
- Live Milvus E2E pending (bring-your-own-server feature) — verify on first use against a real Milvus instance

## Default objectStore bucket provisioned at install time

The server defaults objectStore destinations to `{environment}-data` and the docs always listed that bucket as auto-created, but no init script created it — the first pipeline using the default destination on a fresh install failed with NoSuchBucket. Now created in minio-init.sh, minio-init-prod.sh, and migrate-trial.sh.

Also drops `{environment}-raw-plus` from provisioning and docs: nothing in the server, MCP server, tap-runner, or UI reads or writes it. Existing installs keep the empty bucket harmlessly.

`docker-compose.standalone.yml` regenerated via `scripts/build-standalone-compose.py`.

**Upgrade note for existing installs:** minio-init only runs against fresh volumes — pre-existing deployments should create the `{environment}-data` bucket once (`mc mb` or the MinIO console). Include in the next release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)