### PR TITLE
Delete objectStore destination data on pipeline delete

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/PipelineAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/PipelineAPIController.scala
@@ -490,6 +490,44 @@ class PipelineAPIController {
             }
         }
 
-        // Object Store — skipped (no bulk delete API available)
+        // Object Store — recursively delete s3a://<bucket>/<prefixKey> through
+        // the Hadoop FileSystem with per-bucket config applied (same route as
+        // deleteBeforeWrite in SparkObjectStoreLoader), so it works for both
+        // the built-in MinIO and provider=s3 buckets. prefixKey is not forced
+        // to be unique across pipelines, so refuse to delete when another
+        // pipeline's objectStore destination shares or nests with this prefix —
+        // a blind prefix delete would take out data a live pipeline still reads.
+        if (dest.objectStore != null) {
+            try {
+                val sharedWith = pipelinesSharingObjectStorePrefix(config)
+                if (sharedWith.nonEmpty) {
+                    logger.warn(
+                        "Skipped object store data delete for pipeline '" + config.name + "': prefixKey '" +
+                            dest.objectStore.prefixKey + "' overlaps with pipeline(s): " + sharedWith.mkString(", ")
+                    )
+                } else {
+                    ObjectStoreSpark.deleteDestinationData(dest.objectStore)
+                }
+            } catch {
+                case e: Exception => logger.warn("Failed to delete object store data: " + e.getMessage)
+            }
+        }
+    }
+
+    /** Names of other pipelines whose objectStore destination would be hit by a
+     * recursive delete of this pipeline's prefix (same effective bucket, equal
+     * or nested prefix). Called before the config row is removed, so this
+     * pipeline itself is still in the table and is excluded by name.
+     */
+    private def pipelinesSharingObjectStorePrefix(config: PipelineConfig): List[String] = {
+        val table = DatrisEnvironment.current.pipelineTableName
+        NoSQLDbUtil.getItemsKeysByKeyName(table, "name")
+            .filter(_ != config.name)
+            .map(name => PipelineConfigIO.read(table, name))
+            .filter(other =>
+                other != null && other.destination != null && other.destination.objectStore != null &&
+                    ObjectStoreSpark.destinationsOverlap(config.destination.objectStore, other.destination.objectStore)
+            )
+            .map(_.name)
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/util/ObjectStoreSpark.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/ObjectStoreSpark.scala
@@ -26,6 +26,49 @@ object ObjectStoreSpark {
             DatrisEnvironment.current.environment + "-data"
     }
 
+    /** Normalize a prefix key for path comparison and deletion: null-safe,
+      *  trimmed, leading/trailing slashes stripped. */
+    def normalizePrefix(prefixKey: String): String =
+        Option(prefixKey).getOrElse("").trim.stripPrefix("/").stripSuffix("/")
+
+    /** True when recursively deleting one destination's prefix would also hit
+      *  the other's data — same effective bucket, and one normalized prefix
+      *  equals or contains the other on a path-segment boundary. "city" vs
+      *  "city-forecasts" do NOT overlap; "city" vs "city/2026" do. An empty
+      *  prefix spans the whole bucket, so it overlaps everything in it. */
+    def destinationsOverlap(a: ObjectStore, b: ObjectStore): Boolean = {
+        if (resolveBucket(a) != resolveBucket(b)) return false
+        val pa = normalizePrefix(a.prefixKey)
+        val pb = normalizePrefix(b.prefixKey)
+        if (pa.isEmpty || pb.isEmpty) return true
+        pa == pb || pa.startsWith(pb + "/") || pb.startsWith(pa + "/")
+    }
+
+    /** Recursively delete an objectStore destination's data at
+      *  s3a://<bucket>/<prefixKey>. Routed through the Hadoop FileSystem with
+      *  the per-bucket config applied — same rationale as deleteBeforeWrite in
+      *  SparkObjectStoreLoader: the global MinIO SDK client only reaches the
+      *  built-in MinIO, which is wrong for provider=s3 or
+      *  destinationBucketOverride buckets. */
+    def deleteDestinationData(objectStore: ObjectStore): Unit = {
+        val bucket = resolveBucket(objectStore)
+        val prefix = normalizePrefix(objectStore.prefixKey)
+        if (prefix.isEmpty)
+            throw new IllegalStateException(
+                "objectStore prefixKey is empty — refusing to delete the entire bucket s3a://" + bucket + "/"
+            )
+        val spark = SparkSessionManager.getOrCreate()
+        applyPerBucketConfig(spark, bucket, objectStore)
+        val path = new org.apache.hadoop.fs.Path("s3a://" + bucket + "/" + prefix)
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+        if (fs.exists(path)) {
+            fs.delete(path, true)
+            logger.info("Deleted object store destination data at: s3a://" + bucket + "/" + prefix)
+        } else {
+            logger.info("No object store destination data to delete at: s3a://" + bucket + "/" + prefix)
+        }
+    }
+
     /** Apply per-bucket S3A settings on top of the global SparkSession config.
       *  Per-bucket keys (`fs.s3a.bucket.<bucket>.*`) override globals only for
       *  that bucket, so MinIO writes elsewhere keep using the global config set

--- a/datrisserver/src/test/scala/ai/datris/util/ObjectStoreSparkSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/ObjectStoreSparkSpec.scala
@@ -1,0 +1,49 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.ObjectStore
+import org.scalatest.funsuite.AnyFunSuite
+
+class ObjectStoreSparkSpec extends AnyFunSuite {
+
+    // All fixtures pin destinationBucketOverride so resolveBucket never falls
+    // back to DatrisEnvironment.current (not initialized in unit tests).
+    private def dest(prefix: String, bucket: String = "bucket-a"): ObjectStore =
+        ObjectStore(prefixKey = prefix, destinationBucketOverride = bucket)
+
+    test("normalizePrefix strips leading/trailing slashes and whitespace, null-safe") {
+        assert(ObjectStoreSpark.normalizePrefix(null) == "")
+        assert(ObjectStoreSpark.normalizePrefix("") == "")
+        assert(ObjectStoreSpark.normalizePrefix(" /city-forecasts/ ") == "city-forecasts")
+        assert(ObjectStoreSpark.normalizePrefix("a/b/c") == "a/b/c")
+    }
+
+    test("equal prefixes in the same bucket overlap") {
+        assert(ObjectStoreSpark.destinationsOverlap(dest("city-forecasts"), dest("city-forecasts")))
+        assert(ObjectStoreSpark.destinationsOverlap(dest("city-forecasts/"), dest("/city-forecasts")))
+    }
+
+    test("nested prefixes overlap in both directions") {
+        assert(ObjectStoreSpark.destinationsOverlap(dest("city"), dest("city/2026")))
+        assert(ObjectStoreSpark.destinationsOverlap(dest("city/2026"), dest("city")))
+    }
+
+    test("sibling prefixes sharing a string prefix do not overlap") {
+        assert(!ObjectStoreSpark.destinationsOverlap(dest("city"), dest("city-forecasts")))
+        assert(!ObjectStoreSpark.destinationsOverlap(dest("city-forecasts"), dest("city-forecasts-v2")))
+    }
+
+    test("same prefix in different buckets does not overlap") {
+        assert(!ObjectStoreSpark.destinationsOverlap(dest("city-forecasts", "bucket-a"), dest("city-forecasts", "bucket-b")))
+    }
+
+    test("an empty prefix spans the bucket and overlaps everything in it") {
+        assert(ObjectStoreSpark.destinationsOverlap(dest(""), dest("city-forecasts")))
+        assert(ObjectStoreSpark.destinationsOverlap(dest("city-forecasts"), dest(null)))
+        assert(!ObjectStoreSpark.destinationsOverlap(dest("", "bucket-a"), dest("city", "bucket-b")))
+    }
+}


### PR DESCRIPTION
## Summary

Pipeline delete cleaned up every destination type (Postgres/Mongo/Snowflake/Databricks tables, all four vector-store collections) **except objectStore** — parquet files were left orphaned under `s3a://{env}-data/<prefixKey>/`, and recreating a pipeline with the same prefix silently read/appended onto the stale data. The old comment claimed "no bulk delete API available", but the Hadoop-FS route used by `deleteBeforeWrite` has always been capable of it.

## Changes

- **`ObjectStoreSpark.deleteDestinationData`**: recursive delete of `s3a://<bucket>/<prefixKey>` via the Hadoop FileSystem with per-bucket config applied — same route as `deleteBeforeWrite`, so it works for both the built-in MinIO and `provider=s3` buckets with their own credentials (the global MinIO SDK client can't reach the latter). Refuses an empty prefix, which would wipe the whole bucket.
- **Overlap guard**: `prefixKey` is not forced unique across pipelines, so the delete is skipped with a warning when another pipeline's objectStore destination shares or nests with the prefix (path-segment aware: `city` vs `city/2026` overlaps; `city` vs `city-forecasts` does not).
- **`ObjectStoreSparkSpec`**: 6 unit tests covering prefix normalization and overlap semantics.

## Backward compatibility

`DELETE /pipeline` already documents `deleteData=true` as the default and enforces it whenever `deleteConfig=true` — this makes the objectStore destination honor the contract every other destination already followed. Callers passing `deleteData=false&deleteConfig=false` are untouched. Data orphaned by deletes made before this fix is not retroactively cleaned.

## Testing

- Full server test suite passes with the new spec
- Cleanup failures are logged and swallowed, matching the behavior of every other destination cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)