### PR TITLE
Clear all 5 high Dependabot alerts (Spring Boot 3.5.16) + pgvector as installer default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,11 @@ lazy val datrisserver = project
             "org.apache.hadoop" % "hadoop-client-api" % "3.3.4",
             "org.apache.hadoop" % "hadoop-client-runtime" % "3.3.4",
             // Embedded Tomcat (Spring Boot's servlet container — the process
-            // serving the API). Bump from the 10.1.33 that Boot 3.2.12 ships to
-            // 10.1.55 to clear 4 critical CVEs: partial-PUT RCE, HTTP/2 header
-            // validation, digest-auth bypass, and security-constraint bypass.
+            // serving the API). Boot 3.5.16 manages this same version; the
+            // override stays as an explicit floor so a Boot downgrade can't
+            // silently reintroduce the 4 critical CVEs fixed here: partial-PUT
+            // RCE, HTTP/2 header validation, digest-auth bypass, and
+            // security-constraint bypass.
             // All three tomcat-embed-* artifacts MUST move together — a version
             // mismatch between them makes the embedded server fail to start.
             "org.apache.tomcat.embed" % "tomcat-embed-core" % "10.1.55",
@@ -185,9 +187,12 @@ lazy val allDependencies = Seq(
     // Logging
     "org.slf4j" % "slf4j-api" % "2.0.16",
 
-    // Spring Boot
-    "org.springframework.boot" % "spring-boot-starter" % "3.2.12",
-    "org.springframework.boot" % "spring-boot-starter-web" % "3.2.12",
+    // Spring Boot. 3.5.x because the 3.2.x/6.1.x lines are past OSS EOL —
+    // their CVE fixes are commercial-only. 3.5.16 manages Spring Framework
+    // 6.2.19, which carries the OSS fixes for the 2025/2026 Framework CVEs
+    // (spring-core auth flaw, webmvc XSS/DoS, SpEL DoS).
+    "org.springframework.boot" % "spring-boot-starter" % "3.5.16",
+    "org.springframework.boot" % "spring-boot-starter-web" % "3.5.16",
 
     // Password hashing for UI user auth (BCrypt). The crypto module is
     // standalone (no spring-framework deps), so it can run ahead of the Boot

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -34,7 +34,8 @@ for a standard install:
    - **Semantic search embeddings** — OpenAI `text-embedding-3-small`
      (recommended: no 2.2 GB model download, no resident container) or the
      bundled local TEI server for data that can't leave the machine
-   - **Vector stores** — qdrant, weaviate, chroma (default: none)
+   - **Vector stores** — pgvector by default (included with Postgres, no
+     extra container); optionally add qdrant, weaviate, or chroma
    - **Kafka** — local test broker or external (default: none)
    - **Snowflake / Databricks** — optionally store destination credentials
      now so pipelines can use them on day one

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -426,15 +426,38 @@ else
       ;;
   esac
 
-  # Vector stores — opt-in, bundled (profile) or external per store.
+  # Vector stores — pgvector is the default: it rides on Postgres (the bundled
+  # image is pgvector/pgvector) and vault-init always seeds its secret, so it
+  # needs no extra container and no prompt. The rest are opt-in additions,
+  # bundled (profile) or external per store.
+  if [ "$PG_MODE" != "none" ]; then
+    if [ "$PG_MODE" = "external" ]; then
+      add_summary pgvector external "via Postgres (needs the pgvector extension)"
+    else
+      add_summary pgvector bundled "via Postgres (no extra container)"
+    fi
+  fi
   VEC_CHOICE=""
   if [ -n "$TTY" ] && [ -z "${DATRIS_PROFILES:-}${QDRANT_HOST:-}${WEAVIATE_HOST:-}${CHROMA_HOST:-}${MILVUS_HOST:-}" ]; then
     say ""
-    ask "  Vector stores (qdrant, weaviate, chroma; milvus external-only) — comma-separated, or Enter for none: "
+    if [ "$PG_MODE" != "none" ]; then
+      say "  Vector search runs on pgvector inside your Postgres by default —"
+      say "  nothing extra to install."
+      ask "  Additional vector stores (qdrant, weaviate, chroma; milvus external-only) — comma-separated, or Enter for pgvector only: "
+    else
+      ask "  Vector stores (qdrant, weaviate, chroma; milvus external-only) — comma-separated, or Enter for none: "
+    fi
     VEC_CHOICE="$ANS"
   fi
   for store in $(printf '%s' "$VEC_CHOICE" | tr ',' ' '); do
     case "$store" in
+      pgvector)
+        if [ "$PG_MODE" = "none" ]; then
+          warn "  pgvector rides on Postgres, which is set to 'none' — skipping."
+        else
+          say "    pgvector is already included via Postgres — nothing to add."
+        fi
+        continue ;;
       qdrant|weaviate|chroma|milvus) ;;
       *) warn "  Unknown vector store '$store' — skipping."; continue ;;
     esac


### PR DESCRIPTION
## Summary

**1. Spring Boot 3.2.12 → 3.5.16** — clears all 5 open high Dependabot alerts. The 3.2.x / Framework 6.1.x lines are past OSS EOL (patches are commercial-only), so the fix is moving lines. Boot 3.5.16 manages Spring Framework 6.2.19, the OSS fix line for CVE-2025-22235, CVE-2025-41249, CVE-2026-41842, CVE-2026-41845, and CVE-2026-41850. Also picks up logback 1.5.34, which clears the four open logback alerts, plus the Spring Framework medium/low alerts on the same fix line. The tomcat-embed 10.1.55 override is kept as an explicit floor (Boot 3.5.16 manages the identical version).

**2. Installer: pgvector is the default vector store, not "none"** — pgvector was already functionally the default (bundled Postgres image is pgvector/pgvector:pg16, vault-init seeds oss/pgvector unconditionally), but the prompt said "Enter for none". The prompt now presents pgvector as the default with the other stores as opt-in additions, the install summary always shows a pgvector row when Postgres is installed, and typing "pgvector" is acknowledged instead of warned as unknown. Docs updated to match. Presentation-only — no env vars, profiles, or seeded secrets changed.

## Verification

- `sbt clean assembly` green
- All `org.springframework:*` artifacts resolve to 6.2.19, Boot artifacts to 3.5.16, logback to 1.5.34 (verified via `dependencyTree`)
- 197/197 tests pass
- `sh -n` / `bash -n` clean on install.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)