### PR TITLE
Clear all 20 medium Dependabot alerts: dependency bumps + transitive overrides

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,14 +27,15 @@ lazy val datrisserver = project
         // ExceptionInInitializerError the first time RDDOperationScope loads
         // (which is any time a destination uses SparkSession — objectStore
         // writes, in particular). Spark 3.5.x ships 2.15.2; overriding all four
-        // artifacts together to 2.18.8 keeps the pair consistent and clears the
-        // jackson-core/databind high CVEs (2.18.8 is the patched release).
-        // Bump all four together or none.
+        // artifacts together to 2.18.9 keeps the pair consistent and clears the
+        // jackson-core/databind CVEs (2.18.9 patches the @JsonView bypasses and
+        // case-insensitive @JsonIgnoreProperties bypass on top of the 2.18.8
+        // high fixes). Bump all four together or none.
         dependencyOverrides ++= Seq(
-            "com.fasterxml.jackson.core" % "jackson-core" % "2.18.8",
-            "com.fasterxml.jackson.core" % "jackson-annotations" % "2.18.8",
-            "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.8",
-            "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.8",
+            "com.fasterxml.jackson.core" % "jackson-core" % "2.18.9",
+            "com.fasterxml.jackson.core" % "jackson-annotations" % "2.18.9",
+            "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
+            "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.9",
             // Lock the entire Hadoop family to 3.3.4 — what Spark 3.5.x ships.
             // S3A and the rest of the Hadoop FileSystem layer share private
             // interfaces (IOStatistics, DurationTracker, CallableRaisingIOE);
@@ -57,41 +58,45 @@ lazy val datrisserver = project
             "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55",
             // CVE patch bumps over what Spark 3.5.x pulls transitively. Avro
             // 1.11.4 is a patch release over Spark's 1.11.2 (CVE-2024-47561,
-            // code execution reading untrusted Avro). ZooKeeper 3.7.2 replaces
-            // the 3.6.3 client jar Spark/Curator drag in (CVE-2023-44981);
-            // nothing in the stack runs a ZooKeeper server, and the 3.7 client
-            // wire protocol is compatible with the 3.5+ servers Spark supports.
+            // code execution reading untrusted Avro). ZooKeeper 3.8.4 replaces
+            // the 3.6.3 client jar Spark/Curator drag in (CVE-2023-44981 +
+            // CVE-2024-23944 persistent-watcher info disclosure — no fix on
+            // the 3.7 line); nothing in the stack runs a ZooKeeper server, and
+            // the 3.8 client wire protocol is compatible with the 3.5+ servers
+            // Spark supports.
             "org.apache.avro" % "avro" % "1.11.4",
-            "org.apache.zookeeper" % "zookeeper" % "3.7.2",
-            // minio still ships a stale bcprov, which carries CVE-2025-14813
-            // (GOST 28147 keystream reuse — cipher unused here, but the
-            // override clears the alert). 1.80.2 is the patched line. Keep
-            // this override when bumping minio.
-            "org.bouncycastle" % "bcprov-jdk18on" % "1.80.2",
+            "org.apache.zookeeper" % "zookeeper" % "3.8.4",
+            // minio still ships a stale bcprov. 1.84 patches the LDAP
+            // injection (CertPath/X509LDAP) on top of the earlier GOST
+            // keystream fix — neither code path is used here, but the
+            // override clears the alerts. Keep this override when bumping
+            // minio.
+            "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
             // Netty: Spark/azure-core-http-netty/qdrant drag in assorted 4.1.x
-            // jars with HTTP/2 + SPDY decoder DoS CVEs, patched in
-            // 4.1.136.Final. All io.netty artifacts MUST stay on one version —
-            // mixed netty jars fail at runtime with NoSuchMethodError. The
-            // full family is listed; overrides are inert for absent artifacts.
-            "io.netty" % "netty-all" % "4.1.136.Final",
-            "io.netty" % "netty-buffer" % "4.1.136.Final",
-            "io.netty" % "netty-codec" % "4.1.136.Final",
-            "io.netty" % "netty-codec-http" % "4.1.136.Final",
-            "io.netty" % "netty-codec-http2" % "4.1.136.Final",
-            "io.netty" % "netty-codec-socks" % "4.1.136.Final",
-            "io.netty" % "netty-common" % "4.1.136.Final",
-            "io.netty" % "netty-handler" % "4.1.136.Final",
-            "io.netty" % "netty-handler-proxy" % "4.1.136.Final",
-            "io.netty" % "netty-resolver" % "4.1.136.Final",
-            "io.netty" % "netty-resolver-dns" % "4.1.136.Final",
-            "io.netty" % "netty-resolver-dns-classes-macos" % "4.1.136.Final",
-            "io.netty" % "netty-resolver-dns-native-macos" % "4.1.136.Final",
-            "io.netty" % "netty-transport" % "4.1.136.Final",
-            "io.netty" % "netty-transport-classes-epoll" % "4.1.136.Final",
-            "io.netty" % "netty-transport-classes-kqueue" % "4.1.136.Final",
-            "io.netty" % "netty-transport-native-epoll" % "4.1.136.Final",
-            "io.netty" % "netty-transport-native-kqueue" % "4.1.136.Final",
-            "io.netty" % "netty-transport-native-unix-common" % "4.1.136.Final",
+            // jars with HTTP/2 + SPDY decoder DoS CVEs; 4.1.137.Final also
+            // patches the CORS Vary-header cache-poisoning advisory. All
+            // io.netty artifacts MUST stay on one version — mixed netty jars
+            // fail at runtime with NoSuchMethodError. The full family is
+            // listed; overrides are inert for absent artifacts.
+            "io.netty" % "netty-all" % "4.1.137.Final",
+            "io.netty" % "netty-buffer" % "4.1.137.Final",
+            "io.netty" % "netty-codec" % "4.1.137.Final",
+            "io.netty" % "netty-codec-http" % "4.1.137.Final",
+            "io.netty" % "netty-codec-http2" % "4.1.137.Final",
+            "io.netty" % "netty-codec-socks" % "4.1.137.Final",
+            "io.netty" % "netty-common" % "4.1.137.Final",
+            "io.netty" % "netty-handler" % "4.1.137.Final",
+            "io.netty" % "netty-handler-proxy" % "4.1.137.Final",
+            "io.netty" % "netty-resolver" % "4.1.137.Final",
+            "io.netty" % "netty-resolver-dns" % "4.1.137.Final",
+            "io.netty" % "netty-resolver-dns-classes-macos" % "4.1.137.Final",
+            "io.netty" % "netty-resolver-dns-native-macos" % "4.1.137.Final",
+            "io.netty" % "netty-transport" % "4.1.137.Final",
+            "io.netty" % "netty-transport-classes-epoll" % "4.1.137.Final",
+            "io.netty" % "netty-transport-classes-kqueue" % "4.1.137.Final",
+            "io.netty" % "netty-transport-native-epoll" % "4.1.137.Final",
+            "io.netty" % "netty-transport-native-kqueue" % "4.1.137.Final",
+            "io.netty" % "netty-transport-native-unix-common" % "4.1.137.Final",
             // gRPC (qdrant + milvus clients): MadeYouReset HTTP/2 DDoS
             // (CVE in grpc-netty-shaded < 1.75.0). All io.grpc artifacts move
             // together — mixed grpc versions misbehave at runtime.
@@ -107,11 +112,29 @@ lazy val datrisserver = project
             "io.grpc" % "grpc-inprocess" % "1.75.0",
             // Apache HttpComponents 5.x (transitive via weaviate/snowflake):
             // HTTP/1 header-parsing memory exhaustion + HPACK decoder DoS +
-            // disabled domain checks, all patched in 5.4.3. Client and core
-            // move together.
-            "org.apache.httpcomponents.client5" % "httpclient5" % "5.4.3",
+            // disabled domain checks (5.4.3), plus the connection-pool
+            // exhaustion leak on Content-Encoding decode errors (client5
+            // 5.6.3). httpclient5 5.6.3 builds against httpcore5 5.4.3, so
+            // core stays put — check the httpclient5-parent pom before moving
+            // either one.
+            "org.apache.httpcomponents.client5" % "httpclient5" % "5.6.3",
             "org.apache.httpcomponents.core5" % "httpcore5" % "5.4.3",
             "org.apache.httpcomponents.core5" % "httpcore5-h2" % "5.4.3",
+            // Log4j 2.x (transitive via Spark, which ships 2.20.0): TLS
+            // hostname-verification gaps in the Socket Appender config and
+            // XML/JSON layout encoding flaws, patched across 2.25.3–2.25.5.
+            // None of these appenders/layouts are used here, but the bump
+            // clears the alerts. All four artifacts move together — a
+            // core/api skew breaks logging init at startup.
+            "org.apache.logging.log4j" % "log4j-api" % "2.25.5",
+            "org.apache.logging.log4j" % "log4j-core" % "2.25.5",
+            "org.apache.logging.log4j" % "log4j-1.2-api" % "2.25.5",
+            "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.25.5",
+            // nimbus-jose-jwt (transitive via weaviate's oauth2-oidc-sdk, same
+            // tree as the json-smart override below): DoS on deeply nested
+            // JSON, patched in 10.0.2. Only exercised when a Weaviate
+            // destination authenticates via OIDC.
+            "com.nimbusds" % "nimbus-jose-jwt" % "10.0.2",
             // Single-artifact CVE patch bumps over stale transitives:
             // beanutils RCE/deserialization (everit), json-smart recursion DoS
             // (azure msal), org.json DoS (everit), aircompressor buffer leak +
@@ -121,6 +144,12 @@ lazy val datrisserver = project
             "org.json" % "json" % "20231013",
             "io.airlift" % "aircompressor" % "2.0.3",
             "org.lz4" % "lz4-java" % "1.8.1",
+            // kafka-clients 3.9.x switched lz4 to the at.yawk.lz4 fork (the
+            // org.lz4 pin above still covers Spark). 1.11.1 patches the native
+            // XXHash JVM crash on invalid byte ranges. Both lz4 jars ship the
+            // same net.jpountz classes; the assembly MergeStrategy.first
+            // dedupe handles the overlap, as it already did before this bump.
+            "at.yawk.lz4" % "lz4-java" % "1.11.1",
             "org.apache.ivy" % "ivy" % "2.5.2"
         ),
         buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
@@ -257,10 +286,13 @@ lazy val allDependencies = Seq(
 
     // Document text extraction
     "org.apache.pdfbox" % "pdfbox" % "3.0.4",
-    "org.apache.poi" % "poi" % "5.3.0",
-    "org.apache.poi" % "poi-ooxml" % "5.3.0",
-    "org.apache.poi" % "poi-scratchpad" % "5.3.0",
-    "org.jsoup" % "jsoup" % "1.17.2",
+    // POI 5.4.x patches the OOXML input-validation advisory; jsoup 1.23.1
+    // patches the Cleaner raw-text-element exposure. All three POI artifacts
+    // move together.
+    "org.apache.poi" % "poi" % "5.4.1",
+    "org.apache.poi" % "poi-ooxml" % "5.4.1",
+    "org.apache.poi" % "poi-scratchpad" % "5.4.1",
+    "org.jsoup" % "jsoup" % "1.23.1",
 
     // Email parsing
     "org.eclipse.angus" % "angus-mail" % "2.0.3",

--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,11 @@ lazy val allDependencies = Seq(
     // Connection pooling for Postgres (slf4j-only transitives; no Spark conflicts)
     "com.zaxxer" % "HikariCP" % "5.1.0",
     "com.mysql" % "mysql-connector-j" % "8.4.0",
-    "net.snowflake" % "snowflake-jdbc" % "3.22.0",
+    // 3.23.1 patches the client-side encryption key leak into DEBUG logs.
+    // The SdkProxyRoutePlanner resource-consumption advisory has no patched
+    // release (every version through 4.0.1 is flagged) — revisit on the next
+    // driver release.
+    "net.snowflake" % "snowflake-jdbc" % "3.23.1",
     // Databricks OSS JDBC driver (Apache 2.0) — an uber jar with its own deps
     // shaded under com.databricks.jdbc.internal.*, so it can't collide with
     // Spark's arrow/netty. Used by DatabricksLoader / DatabricksQueryUtil.

--- a/datrisserver/src/test/scala/ai/datris/util/Log4jFamilyConsistencySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/Log4jFamilyConsistencySpec.scala
@@ -1,0 +1,43 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Properties
+
+/** Guards the log4j dependencyOverrides family in build.sbt (pinned over the
+  *  version Spark ships). A core/api skew breaks logging initialization at
+  *  server startup, not at compile time — same failure shape as the Jackson
+  *  pin guarded by SparkJacksonCompatSpec. Versions are read from each jar's
+  *  Maven pom.properties, which every log4j artifact ships.
+  */
+class Log4jFamilyConsistencySpec extends AnyFunSuite {
+
+    private val artifacts = Seq("log4j-api", "log4j-core", "log4j-1.2-api", "log4j-slf4j2-impl")
+
+    private def versionOf(artifact: String): String = {
+        val path = s"/META-INF/maven/org.apache.logging.log4j/$artifact/pom.properties"
+        val stream = getClass.getResourceAsStream(path)
+        assert(stream != null, s"$artifact not on the test classpath (or no pom.properties) — family list is stale")
+        try {
+            val props = new Properties()
+            props.load(stream)
+            props.getProperty("version")
+        } finally {
+            stream.close()
+        }
+    }
+
+    test("all log4j artifacts on the classpath resolve to one version") {
+        val versions = artifacts.map(a => a -> versionOf(a))
+        assert(
+            versions.map(_._2).toSet.size == 1,
+            s"log4j family is skewed: ${versions.map { case (a, v) => s"$a=$v" }.mkString(", ")} — " +
+                "bump the build.sbt log4j overrides together"
+        )
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/NettyFamilyConsistencySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/NettyFamilyConsistencySpec.scala
@@ -1,0 +1,32 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+/** Guards the netty dependencyOverrides family in build.sbt. Mixed netty jars
+  *  fail at runtime with NoSuchMethodError, and the override list only
+  *  protects artifacts it names — a NEW transitive netty artifact (dragged in
+  *  by a future Spark/azure/qdrant bump) resolves to whatever version its
+  *  parent declares and silently skews the family. Version.identify() reads
+  *  each netty jar's version properties off the classpath, so any straggler
+  *  shows up here before it can fail on a live connection.
+  */
+class NettyFamilyConsistencySpec extends AnyFunSuite {
+
+    test("every io.netty artifact on the classpath resolves to one version") {
+        val versions = io.netty.util.Version.identify().asScala
+        assert(versions.nonEmpty, "no netty artifacts found — Version.identify() returned nothing")
+        val byVersion = versions.values.map(_.artifactVersion()).toSet
+        assert(
+            byVersion.size == 1,
+            s"netty family is skewed: ${versions.map { case (a, v) => s"$a=${v.artifactVersion()}" }.mkString(", ")} — " +
+                "add the missing artifact to the build.sbt netty overrides"
+        )
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/TextExtractorUtilSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/TextExtractorUtilSpec.scala
@@ -1,0 +1,81 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.apache.poi.xwpf.usermodel.XWPFDocument
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.ByteArrayOutputStream
+
+/** Smoke tests for the POI and jsoup extraction paths. These are the only
+  *  direct consumers of both libraries, and dependency bumps compile green
+  *  even when an extractor API breaks — the failure otherwise surfaces on the
+  *  first document a user ingests. Fixture documents are generated in memory
+  *  with POI itself, so the round-trip exercises both write and read against
+  *  the resolved version.
+  */
+class TextExtractorUtilSpec extends AnyFunSuite {
+
+    test("docx round-trips through the XWPF extractor") {
+        val doc = new XWPFDocument()
+        try {
+            doc.createParagraph().createRun().setText("quarterly ingest summary")
+            val baos = new ByteArrayOutputStream()
+            doc.write(baos)
+            val text = TextExtractorUtil.extractText(baos.toByteArray, "report.docx")
+            assert(text.contains("quarterly ingest summary"))
+        } finally {
+            doc.close()
+        }
+    }
+
+    test("xlsx round-trips through the XSSF extractor with formatted cells") {
+        val wb = new XSSFWorkbook()
+        try {
+            val sheet = wb.createSheet("Metrics")
+            val row = sheet.createRow(0)
+            row.createCell(0).setCellValue("rows_loaded")
+            row.createCell(1).setCellValue(42.0)
+            val baos = new ByteArrayOutputStream()
+            wb.write(baos)
+            val text = TextExtractorUtil.extractText(baos.toByteArray, "metrics.xlsx")
+            assert(text.contains("Sheet: Metrics"))
+            assert(text.contains("rows_loaded"))
+            assert(text.contains("42"))
+        } finally {
+            wb.close()
+        }
+    }
+
+    test("legacy xls round-trips through the HSSF extractor") {
+        val wb = new HSSFWorkbook()
+        try {
+            wb.createSheet("Old").createRow(0).createCell(0).setCellValue("legacy cell")
+            val baos = new ByteArrayOutputStream()
+            wb.write(baos)
+            val text = TextExtractorUtil.extractText(baos.toByteArray, "legacy.xls")
+            assert(text.contains("legacy cell"))
+        } finally {
+            wb.close()
+        }
+    }
+
+    test("html strips tags and decodes entities via jsoup") {
+        val html = "<html><body><h1>Title</h1><p>rows &amp; columns</p><script>ignored()</script></body></html>"
+        val text = TextExtractorUtil.extractText(html.getBytes("UTF-8"), "page.html")
+        assert(text.contains("Title"))
+        assert(text.contains("rows & columns"))
+        assert(!text.contains("<p>"))
+        assert(!text.contains("ignored()"))
+    }
+
+    test("unknown extensions fall back to UTF-8 passthrough") {
+        val text = TextExtractorUtil.extractText("plain payload".getBytes("UTF-8"), "notes.custom")
+        assert(text == "plain payload")
+    }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "^21.2.21",
         "@angular/platform-browser-dynamic": "^21.2.21",
         "@angular/router": "^21.2.21",
-        "echarts": "^5.6.0",
+        "echarts": "^6.1.0",
         "ngx-echarts": "^21.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -8738,13 +8738,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
-      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.1"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -14909,14 +14909,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {
@@ -15163,9 +15166,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15187,7 +15190,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
@@ -15810,9 +15813,9 @@
       "license": "MIT"
     },
     "node_modules/zrender": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
-      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,9 @@
   },
   "private": true,
   "overrides": {
-    "tar": "^7.5.21"
+    "tar": "^7.5.21",
+    "webpack-dev-server": "^5.2.6",
+    "uuid": "^11.1.1"
   },
   "dependencies": {
     "@angular/animations": "^21.2.21",
@@ -23,7 +25,7 @@
     "@angular/platform-browser": "^21.2.21",
     "@angular/platform-browser-dynamic": "^21.2.21",
     "@angular/router": "^21.2.21",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "ngx-echarts": "^21.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
Clears every open medium-severity Dependabot alert (20 total: 16 Maven, 4 npm). Follows the same pattern as #53/#55 — patch-level bumps where possible, sbt `dependencyOverrides` / npm `overrides` for transitives.

## Server (build.sbt)

| Dependency | From → To | Alert |
|---|---|---|
| Jackson family (×4, bump-together) | 2.18.8 → 2.18.9 | `@JsonView` bypasses, case-insensitive `@JsonIgnoreProperties` bypass |
| ZooKeeper (override) | 3.7.2 → 3.8.4 | persistent-watcher info disclosure — **no fix on 3.7 line** |
| bcprov-jdk18on (override) | 1.80.2 → 1.84 | LDAP injection |
| Netty family (×19, bump-together) | 4.1.136 → 4.1.137.Final | CORS Vary-header cache poisoning |
| httpclient5 (override) | 5.4.3 → 5.6.3 | connection-pool exhaustion DoS |
| log4j family (×4, **new** override) | Spark's 2.20.0 → 2.25.5 | Socket Appender TLS hostname check, layout encoding flaws |
| nimbus-jose-jwt (**new** override) | 9.x → 10.0.2 | deeply-nested-JSON DoS |
| at.yawk.lz4:lz4-java (**new** override) | 1.10.1 → 1.11.1 | native XXHash JVM crash |
| Apache POI (×3) | 5.3.0 → 5.4.1 | OOXML input validation |
| jsoup | 1.17.2 → 1.23.1 | Cleaner raw-text exposure |

## UI (ui/package.json)

- **echarts 5.6.0 → 6.1.0** (XSS fix) — the one major bump here. `ngx-echarts@21` peer range allows `>=5`; the only consumer is the Activity component's bar/line/spark charts, all plain `EChartsOption` usage that is API-stable across 5→6. v6 refreshes the default theme palette, so chart colors may look slightly different — worth an eyeball on the Activity tab.
- overrides: `webpack-dev-server ^5.2.6` (CSRF + Host/Origin DoS), `uuid ^11.1.1` (buffer bounds) — both dev-server-only, never shipped.

## Backward-compat notes

- **httpcore5 deliberately stays 5.4.3** — that's the version httpclient5 5.6.3 builds against (per its parent pom); comment updated so the pair doesn't drift.
- **ZooKeeper 3.8.4 client** is wire-compatible with the 3.5+ servers Spark supports; nothing in the stack runs a ZK server.
- **nimbus-jose-jwt 10.0.2** sits under weaviate's `oauth2-oidc-sdk` (which declares 10.0.1) — only exercised when a Weaviate destination authenticates via OIDC.
- **at.yawk.lz4** is the lz4 fork `kafka-clients` 3.9.x ships; the existing `org.lz4` pin still covers Spark. Both jars carry the same `net.jpountz` classes — the assembly `MergeStrategy.first` dedupe already handled that overlap before this bump.
- **log4j 2.25.5 over Spark's 2.20.0**: same 2.x API line, all four artifacts (api/core/1.2-api/slf4j2-impl) move together.

## Verification

- `sbt clean test` — 197 tests green
- `sbt assembly` — fat jar builds clean
- `ng build` — green (only the pre-existing CSS budget warnings)

Also bumps snowflake-jdbc 3.22.0 → 3.23.1, clearing one of the two low alerts (encryption key in DEBUG logs). The other low (SdkProxyRoutePlanner resource consumption) has **no patched release** — every version through 4.0.1 is flagged — so it stays open until Snowflake ships a fix (or gets dismissed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
