### PR TITLE
Bump zookeeper override 3.8.4 → 3.8.6 (clears the 2 high alerts the 3.8 move exposed)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,14 +58,15 @@ lazy val datrisserver = project
             "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55",
             // CVE patch bumps over what Spark 3.5.x pulls transitively. Avro
             // 1.11.4 is a patch release over Spark's 1.11.2 (CVE-2024-47561,
-            // code execution reading untrusted Avro). ZooKeeper 3.8.4 replaces
+            // code execution reading untrusted Avro). ZooKeeper 3.8.6 replaces
             // the 3.6.3 client jar Spark/Curator drag in (CVE-2023-44981 +
             // CVE-2024-23944 persistent-watcher info disclosure — no fix on
-            // the 3.7 line); nothing in the stack runs a ZooKeeper server, and
-            // the 3.8 client wire protocol is compatible with the 3.5+ servers
-            // Spark supports.
+            // the 3.7 line — plus the 3.8.0–3.8.5 ZKTrustManager reverse-DNS
+            // hostname-verification bypass and config-handling advisories);
+            // nothing in the stack runs a ZooKeeper server, and the 3.8 client
+            // wire protocol is compatible with the 3.5+ servers Spark supports.
             "org.apache.avro" % "avro" % "1.11.4",
-            "org.apache.zookeeper" % "zookeeper" % "3.8.4",
+            "org.apache.zookeeper" % "zookeeper" % "3.8.6",
             // minio still ships a stale bcprov. 1.84 patches the LDAP
             // injection (CertPath/X509LDAP) on top of the earlier GOST
             // keystream fix — neither code path is used here, but the


### PR DESCRIPTION
Follow-up to #56: the ZooKeeper 3.7.2 → 3.8.4 bump cleared the persistent-watcher medium alert but landed inside the 3.8.0–3.8.5 range flagged by two high advisories (ZKTrustManager reverse-DNS hostname-verification bypass, improper config-value handling), both patched in **3.8.6**. The 3.7 line never tripped these because the vulnerable range starts at 3.8.0.

Same client-only usage as before — nothing in the stack runs a ZooKeeper server, and the 3.8 client wire protocol remains compatible with the 3.5+ servers Spark supports.

Verified: `sbt clean test assembly` green (204 tests).

After this merges, open alerts should be down to the single unfixable snowflake-jdbc low (#174, no patched release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)