### PR TITLE
Security plan Phase 3: digest-pinned base images + tap isolation on by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,13 +209,12 @@ OPENAI_API_KEY=
 # forwards whatever the connecting agent provides.
 
 # Tap execution isolation (see https://docs.datris.ai/tap-execution-isolation).
-# By default a tap's fetch() runs in-process. Set USE_TAP_RUNNER=true to run it in
-# the isolated datris-tap-runner sidecar instead — separated from platform
-# credentials and internal services. When you enable it, set TAP_RUNNER_TOKEN to a
-# strong random value; it authenticates the server→runner call. The URL and
-# callback host rarely need changing (defaults match the docker-compose service).
-# USE_TAP_RUNNER=false
-# TAP_RUNNER_TOKEN=change-me-to-a-long-random-string
+# docker compose defaults USE_TAP_RUNNER=true (sidecar). sbt/IDE without the
+# sidecar stays in-process. scripts/install.sh and docker/vault-init.sh mint TAP_RUNNER_TOKEN; the
+# server refuses to start isolated with an empty or changeme token.
+# Set USE_TAP_RUNNER=false to force in-process (loud server warning).
+# USE_TAP_RUNNER=true
+# TAP_RUNNER_TOKEN=
 # TAP_RUNNER_URL=http://datris-tap-runner:8090
 # TAP_RUNNER_CALLBACK_HOST=datris
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre
+# Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
+FROM eclipse-temurin:17-jre@sha256:13cc28a6cc72a38ce1f00c906be3580c1a3e604b8984d694f369a96742abc93b
 RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --break-system-packages requests beautifulsoup4 pandas lxml feedparser boto3 pyyaml openpyxl python-dateutil pytz google-cloud-storage azure-storage-blob
 ARG JAR_FILE=datrisserver/target/scala-*/*.jar

--- a/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
@@ -157,6 +157,9 @@ class StartupRunner extends ApplicationRunner {
 
     @Override
     def run(args: ApplicationArguments): Unit = {
+        ai.datris.util.TapScriptRunner.assertIsolationConfig()
+        if (!ai.datris.util.TapScriptRunner.useTapRunner)
+            ai.datris.util.TapScriptRunner.warnInProcess("startup")
         initDatrisEnvironment()
         initUserAuth()
         // Seed v1 definition snapshots for any pre-versioning taps/pipelines so

--- a/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
@@ -44,7 +44,8 @@ class VersionAPIController {
                 "useUserAuth" -> DatrisEnvironment.values.useUserAuth.toString,
                 "useApiKeys" -> DatrisEnvironment.values.useApiKeys.toString,
                 "postgresDatabase" -> DatrisEnvironment.current.postgresDatabase,
-                "mongodbDatabase" -> mongodbDatabase
+                "mongodbDatabase" -> mongodbDatabase,
+                "useTapRunner" -> ai.datris.util.TapScriptRunner.useTapRunner.toString
             ).asJava
             val gson = new Gson
             new ResponseEntity[String](gson.toJson(map), HttpStatus.OK)

--- a/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
@@ -808,6 +808,7 @@ object TapScriptRunner {
             }
         } catch { case _: Exception => None }
     }
+
     /** Env token if it is a real minted value; otherwise the vault-init file. */
     private[datris] def resolvedTapRunnerToken: String = {
         val envTok = envTapRunnerToken
@@ -825,10 +826,10 @@ object TapScriptRunner {
     private[datris] def warnInProcess(where: String): Unit = {
         logger.warn(
             "************************************************************************\n" +
-            "TAP EXECUTION IS IN-PROCESS (" + where + "; USE_TAP_RUNNER is not true).\n" +
-            "fetch() shares this JVM network and can reach DB / MinIO / Vault directly.\n" +
-            "Compose/prod should isolate (USE_TAP_RUNNER=true). sbt/IDE without a sidecar is expected.\n" +
-            "************************************************************************"
+                "TAP EXECUTION IS IN-PROCESS (" + where + "; USE_TAP_RUNNER is not true).\n" +
+                "fetch() shares this JVM network and can reach DB / MinIO / Vault directly.\n" +
+                "Compose/prod should isolate (USE_TAP_RUNNER=true). sbt/IDE without a sidecar is expected.\n" +
+                "************************************************************************"
         )
     }
     // Host a tap should use to call back into the platform when running in the sidecar

--- a/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapScriptRunner.scala
@@ -257,16 +257,15 @@ object TapScriptRunner {
                 else Seq.empty
             val allEnvVars = platformEnvVars ++ testLimitEnvVars ++ paramEnvVars ++ stateEnvVars ++ secretEnvVars
 
-            // Step 5: Execute the wrapper — either in the isolated datris-tap-runner sidecar
-            // (Phase 3, when USE_TAP_RUNNER is set) or in-process (default). Both receive the
-            // same allEnvVars and return (stdout, stderr); the wrapper/envelope protocol is
-            // identical, so everything downstream is unchanged.
+            // Step 5: Execute the wrapper — isolated sidecar (compose/prod default) or
+            // in-process (sbt/IDE, or USE_TAP_RUNNER=false). Same allEnvVars and envelope.
             val secretValues = secretEnvVars.map(_._2)
             secretValuesForMasking = secretValues
             val (rawOutput, rawLogs) =
                 if (useTapRunner) {
                     executeViaRunner(scriptContent, allEnvVars, tapConfig.packages, scriptTimeoutSeconds, secretValues)
                 } else {
+                    warnInProcess("tap " + tapConfig.name)
                     // In-process path: materialize the script/wrapper, install any extra
                     // packages into a throwaway venv, and run with the chosen interpreter.
                     Files.write(scriptFile, scriptContent.getBytes("UTF-8"))
@@ -787,13 +786,51 @@ object TapScriptRunner {
 
     // ---- Phase 3: isolated sidecar execution -------------------------------------------------
     // When USE_TAP_RUNNER is set, tap code runs in the datris-tap-runner container, which holds
-    // no platform secrets and has no route to Vault. Default off so the OSS quick-start keeps
-    // in-process execution with zero extra dependencies.
-    private def useTapRunner: Boolean =
+    // no platform secrets and has no route to Vault. Compose/prod defaults the flag on;
+    // sbt/IDE without the sidecar leaves it unset (in-process).
+    private val WeakTapRunnerTokens = Set("", "changeme-tap-runner-token", "change-me-to-a-long-random-string")
+    private val TapRunnerTokenFile = sys.env.getOrElse("TAP_RUNNER_TOKEN_FILE", "/tap-runner-token/token")
+
+    private[datris] def useTapRunner: Boolean =
         sys.env.getOrElse("USE_TAP_RUNNER", "false").equalsIgnoreCase("true")
     private def tapRunnerUrl: String =
         sys.env.getOrElse("TAP_RUNNER_URL", "http://datris-tap-runner:8090")
-    private def tapRunnerToken: String = sys.env.getOrElse("TAP_RUNNER_TOKEN", "")
+    private def envTapRunnerToken: String = sys.env.getOrElse("TAP_RUNNER_TOKEN", "")
+    private def isWeakTapRunnerToken(t: String): Boolean =
+        t == null || WeakTapRunnerTokens.contains(t.trim)
+    private def readMintedTapRunnerToken(): Option[String] = {
+        try {
+            val p = java.nio.file.Paths.get(TapRunnerTokenFile)
+            if (!java.nio.file.Files.isRegularFile(p)) None
+            else {
+                val s = new String(java.nio.file.Files.readAllBytes(p), java.nio.charset.StandardCharsets.UTF_8).trim
+                if (s.isEmpty) None else Some(s)
+            }
+        } catch { case _: Exception => None }
+    }
+    /** Env token if it is a real minted value; otherwise the vault-init file. */
+    private[datris] def resolvedTapRunnerToken: String = {
+        val envTok = envTapRunnerToken
+        if (!isWeakTapRunnerToken(envTok)) envTok
+        else readMintedTapRunnerToken().filterNot(isWeakTapRunnerToken).getOrElse(envTok)
+    }
+    private def tapRunnerToken: String = resolvedTapRunnerToken
+    private[datris] def assertIsolationConfig(): Unit = {
+        if (useTapRunner && isWeakTapRunnerToken(resolvedTapRunnerToken))
+            throw new DatrisException(
+                "USE_TAP_RUNNER=true but TAP_RUNNER_TOKEN is empty or the changeme default. " +
+                    "scripts/install.sh and docker/vault-init.sh mint a token on first boot."
+            )
+    }
+    private[datris] def warnInProcess(where: String): Unit = {
+        logger.warn(
+            "************************************************************************\n" +
+            "TAP EXECUTION IS IN-PROCESS (" + where + "; USE_TAP_RUNNER is not true).\n" +
+            "fetch() shares this JVM network and can reach DB / MinIO / Vault directly.\n" +
+            "Compose/prod should isolate (USE_TAP_RUNNER=true). sbt/IDE without a sidecar is expected.\n" +
+            "************************************************************************"
+        )
+    }
     // Host a tap should use to call back into the platform when running in the sidecar
     // (the datris server's name on tap-net). Replaces "localhost", which in the runner
     // would point at the runner itself.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,6 +1,11 @@
 networks:
   datris-net:
     driver: bridge
+  tap-net:
+    driver: bridge
+
+volumes:
+  tap-runner-token:
 
 services:
   nginx:
@@ -151,9 +156,11 @@ services:
         condition: service_healthy
     environment:
       VAULT_ADDR: http://vault:8200
+      TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
     volumes:
       - ./vault/vault-init-prod.sh:/vault-init-prod.sh:ro
       - /data/secrets:/secrets
+      - tap-runner-token:/tap-runner-token
     entrypoint: ["/bin/sh", "/vault-init-prod.sh"]
     restart: "no"
     networks:
@@ -226,9 +233,14 @@ services:
       # ignore them so platform keys never leak across tenants.
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      USE_TAP_RUNNER: "${USE_TAP_RUNNER:-true}"
+      TAP_RUNNER_URL: "http://datris-tap-runner:8090"
+      TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
     volumes:
       - ./config:/config:ro
       - /data/secrets:/secrets:ro
+      - tap-runner-token:/tap-runner-token:ro
     restart: unless-stopped
     logging:
       driver: json-file
@@ -237,6 +249,29 @@ services:
         max-file: "5"
     networks:
       - datris-net
+      - tap-net
+
+  datris-tap-runner:
+    image: datrisai/datris-tap-runner:latest
+    container_name: datris-tap-runner
+    environment:
+      TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
+    volumes:
+      - tap-runner-token:/tap-runner-token:ro
+    depends_on:
+      vault-init:
+        condition: service_completed_successfully
+    read_only: true
+    tmpfs:
+      - /tmp:size=512m,mode=1777,exec
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    networks:
+      - tap-net
 
   ui:
     image: datrisai/datris-ui:latest

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -29,6 +29,7 @@ volumes:
   tei-data:
   vault-data:        # persists Vault secrets across container recreation (drops dev mode)
   datris-vault-token: # holds the server's random Vault token (written by vault-init, read by datris)
+  tap-runner-token:  # TAP_RUNNER_TOKEN minted by vault-init on first boot
   # Named data volumes for the three stateful stores. These MUST be named:
   # anonymous volumes survive a plain recreate but are orphaned (left behind,
   # not reattached) whenever the container is removed — `down` + `up`, or a
@@ -220,6 +221,7 @@ services:
       DATABRICKS_CLIENT_ID: ${DATABRICKS_CLIENT_ID:-}
       DATABRICKS_CLIENT_SECRET: ${DATABRICKS_CLIENT_SECRET:-}
       DATABRICKS_TOKEN: ${DATABRICKS_TOKEN:-}
+      TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
     configs:
       - source: vault-bootstrap-sh
         target: /vault-bootstrap.sh
@@ -230,6 +232,7 @@ services:
     volumes:
       - vault-data:/vault/file
       - datris-vault-token:/vault-token
+      - tap-runner-token:/tap-runner-token
     entrypoint: ["/bin/sh", "/vault-bootstrap.sh"]
     restart: "no"
     networks:
@@ -342,19 +345,20 @@ services:
       # trial droplet alongside TEI, postgres, mongo, etc. Override in .env
       # (e.g. JAVA_OPTS=-Xms1g -Xmx8g) on larger hosts.
       JAVA_OPTS: "${JAVA_OPTS:--Xms512m -Xmx2g}"
-      # Tap execution isolation (Phase 3). When USE_TAP_RUNNER=true, tap fetch()
-      # code runs in the datris-tap-runner sidecar (no secrets, no Vault route)
-      # instead of in-process. Default false preserves the zero-dependency OSS
-      # quick-start. The shared token authenticates the server→runner call.
-      USE_TAP_RUNNER: "${USE_TAP_RUNNER:-false}"
+      # Tap execution isolation (Phase 3). Compose/prod default ON: tap fetch()
+      # runs in the datris-tap-runner sidecar. Set USE_TAP_RUNNER=false for
+      # in-process (sbt/IDE without the sidecar). Token minted by install.sh/vault-init.
+      USE_TAP_RUNNER: "${USE_TAP_RUNNER:-true}"
       TAP_RUNNER_URL: "http://datris-tap-runner:8090"
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
     configs:
       - source: datris-app-yaml
         target: /config/application.yaml
     volumes:
       - pip-cache:/root/.cache/pip
       - datris-vault-token:/vault-token:ro
+      - tap-runner-token:/tap-runner-token:ro
     networks:
       - datris-net
       - tap-net
@@ -370,6 +374,12 @@ services:
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
+    volumes:
+      - tap-runner-token:/tap-runner-token:ro
+    depends_on:
+      vault-init:
+        condition: service_completed_successfully
     read_only: true
     # Scratch must allow exec: runtime-installed packages (venv interpreter, pip, and
     # any C-extension .so) live here and must be loadable. Safe — the tap is already
@@ -1120,6 +1130,36 @@ configs:
           host="$${CHROMA_HOST}" port="$${CHROMA_PORT:-8000}"
       fi
 
+
+      # Mint TAP_RUNNER_TOKEN so compose isolation default-on works without a .env token.
+      # Prefer a persisted file, then a non-changeme env value, else generate.
+      TAP_RUNNER_TOKEN_FILE="$${TAP_RUNNER_TOKEN_FILE:-/tap-runner-token/token}"
+      tap_token_weak() {
+        case "$$1" in
+          ""|changeme-tap-runner-token|change-me-to-a-long-random-string) return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+      if mkdir -p "$$(dirname "$$TAP_RUNNER_TOKEN_FILE")" 2>/dev/null; then
+        _existing=""
+        [ -f "$$TAP_RUNNER_TOKEN_FILE" ] && _existing=$$(cat "$$TAP_RUNNER_TOKEN_FILE" 2>/dev/null || true)
+        _from_env="$${TAP_RUNNER_TOKEN:-}"
+        if ! tap_token_weak "$$_existing"; then
+          echo "  TAP_RUNNER_TOKEN already minted — keeping persisted value"
+        elif ! tap_token_weak "$$_from_env"; then
+          printf '%s' "$$_from_env" > "$$TAP_RUNNER_TOKEN_FILE"
+          echo "  persisted TAP_RUNNER_TOKEN from environment"
+        else
+          _tok=$$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')
+          if [ $${#_tok} -lt 32 ]; then
+            echo "ERROR: failed to mint TAP_RUNNER_TOKEN" >&2
+            exit 1
+          fi
+          printf '%s' "$$_tok" > "$$TAP_RUNNER_TOKEN_FILE"
+          echo "  minted TAP_RUNNER_TOKEN"
+        fi
+        chmod 644 "$$TAP_RUNNER_TOKEN_FILE" 2>/dev/null || true
+      fi
       echo "Vault secrets seeded successfully."
   minio-init-sh:
     content: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ volumes:
   tei-data:
   vault-data:        # persists Vault secrets across container recreation (drops dev mode)
   datris-vault-token: # holds the server's random Vault token (written by vault-init, read by datris)
+  tap-runner-token:  # TAP_RUNNER_TOKEN minted by vault-init on first boot
   # Named data volumes for the three stateful stores. These MUST be named:
   # anonymous volumes survive a plain recreate but are orphaned (left behind,
   # not reattached) whenever the container is removed — `down` + `up`, or a
@@ -200,12 +201,15 @@ services:
       DATABRICKS_CLIENT_ID: ${DATABRICKS_CLIENT_ID:-}
       DATABRICKS_CLIENT_SECRET: ${DATABRICKS_CLIENT_SECRET:-}
       DATABRICKS_TOKEN: ${DATABRICKS_TOKEN:-}
+      TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
     volumes:
       # Shares vault-data so bootstrap can read/write the init file (unseal key
       # + root token) and unseal the same storage the vault service uses.
       - vault-data:/vault/file
       # Writes the server's random token here for the datris service to read.
       - datris-vault-token:/vault-token
+      # TAP_RUNNER_TOKEN file minted on first boot so compose up works without a .env token.
+      - tap-runner-token:/tap-runner-token
       - ./docker/vault-bootstrap.sh:/vault-bootstrap.sh
       - ./docker/vault-init.sh:/vault-init.sh
     entrypoint: ["/bin/sh", "/vault-bootstrap.sh"]
@@ -320,13 +324,13 @@ services:
       # trial droplet alongside TEI, postgres, mongo, etc. Override in .env
       # (e.g. JAVA_OPTS=-Xms1g -Xmx8g) on larger hosts.
       JAVA_OPTS: "${JAVA_OPTS:--Xms512m -Xmx2g}"
-      # Tap execution isolation (Phase 3). When USE_TAP_RUNNER=true, tap fetch()
-      # code runs in the datris-tap-runner sidecar (no secrets, no Vault route)
-      # instead of in-process. Default false preserves the zero-dependency OSS
-      # quick-start. The shared token authenticates the server→runner call.
-      USE_TAP_RUNNER: "${USE_TAP_RUNNER:-false}"
+      # Tap execution isolation (Phase 3). Compose/prod default ON: tap fetch()
+      # runs in the datris-tap-runner sidecar. Set USE_TAP_RUNNER=false for
+      # in-process (sbt/IDE without the sidecar). Token minted by install.sh/vault-init.
+      USE_TAP_RUNNER: "${USE_TAP_RUNNER:-true}"
       TAP_RUNNER_URL: "http://datris-tap-runner:8090"
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
     volumes:
       - ./docker/config:/config
       - pip-cache:/root/.cache/pip
@@ -334,6 +338,7 @@ services:
       # can't modify it. Dedicated volume so the server never sees the Vault
       # root token / unseal key that live on the vault-data volume.
       - datris-vault-token:/vault-token:ro
+      - tap-runner-token:/tap-runner-token:ro
     networks:
       - datris-net
       - tap-net
@@ -349,6 +354,12 @@ services:
     container_name: datris-tap-runner
     environment:
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"
+      TAP_RUNNER_TOKEN_FILE: /tap-runner-token/token
+    volumes:
+      - tap-runner-token:/tap-runner-token:ro
+    depends_on:
+      vault-init:
+        condition: service_completed_successfully
     read_only: true
     # Scratch must allow exec: runtime-installed packages (venv interpreter, pip, and
     # any C-extension .so) live here and must be loadable. Safe — the tap is already

--- a/docker/vault-init.sh
+++ b/docker/vault-init.sh
@@ -343,4 +343,34 @@ if [ -n "${CHROMA_HOST:-}" ]; then
     host="${CHROMA_HOST}" port="${CHROMA_PORT:-8000}"
 fi
 
+
+# Mint TAP_RUNNER_TOKEN so compose isolation default-on works without a .env token.
+# Prefer a persisted file, then a non-changeme env value, else generate.
+TAP_RUNNER_TOKEN_FILE="${TAP_RUNNER_TOKEN_FILE:-/tap-runner-token/token}"
+tap_token_weak() {
+  case "$1" in
+    ""|changeme-tap-runner-token|change-me-to-a-long-random-string) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if mkdir -p "$(dirname "$TAP_RUNNER_TOKEN_FILE")" 2>/dev/null; then
+  _existing=""
+  [ -f "$TAP_RUNNER_TOKEN_FILE" ] && _existing=$(cat "$TAP_RUNNER_TOKEN_FILE" 2>/dev/null || true)
+  _from_env="${TAP_RUNNER_TOKEN:-}"
+  if ! tap_token_weak "$_existing"; then
+    echo "  TAP_RUNNER_TOKEN already minted — keeping persisted value"
+  elif ! tap_token_weak "$_from_env"; then
+    printf '%s' "$_from_env" > "$TAP_RUNNER_TOKEN_FILE"
+    echo "  persisted TAP_RUNNER_TOKEN from environment"
+  else
+    _tok=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')
+    if [ ${#_tok} -lt 32 ]; then
+      echo "ERROR: failed to mint TAP_RUNNER_TOKEN" >&2
+      exit 1
+    fi
+    printf '%s' "$_tok" > "$TAP_RUNNER_TOKEN_FILE"
+    echo "  minted TAP_RUNNER_TOKEN"
+  fi
+  chmod 644 "$TAP_RUNNER_TOKEN_FILE" 2>/dev/null || true
+fi
 echo "Vault secrets seeded successfully."

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Release history for Datris"
 ---
 
+<Update label="Unreleased" description="August 24, 2026">
+  **Tap isolation on by default for docker compose.**
+
+  - `docker-compose.yml` / `docker-compose.standalone.yml` / `deploy/docker-compose.prod.yml` now default `USE_TAP_RUNNER=true`. `scripts/install.sh` and `docker/vault-init.sh` mint `TAP_RUNNER_TOKEN` on first boot (including upgrades whose token was missing or `changeme`). The server fails fast if isolation is on and the token is still empty/`changeme` — a minted token is accepted.
+  - `sbt` / IDE (no sidecar) stays in-process and logs a warning. Isolated taps still cannot open direct connections to internal DB / object store / Vault — they return records; this is existing behavior, called out because compose now isolates by default.
+  - Set `USE_TAP_RUNNER=false` to keep in-process on compose. No host allowlist in this change.
+</Update>
+
 <Update label="v1.19.4" description="August 21, 2026">
   **Dependency security cleanup across the server and UI.**
 

--- a/docs/tap-execution-isolation.mdx
+++ b/docs/tap-execution-isolation.mdx
@@ -9,14 +9,16 @@ dedicated, isolated **runner** container, cut off from the platform's credential
 services.
 
 <Note>
-The isolated runner is **opt-in** (off by default). Enable it by setting `USE_TAP_RUNNER=true`.
-Tap behavior is identical either way — the same `fetch()` contract, the same environment
-variables, the same packages. The only difference is *where* the code runs and what it can reach.
+On **docker compose / prod**, the isolated runner is **on by default** (`USE_TAP_RUNNER=true`).
+`sbt` / IDE runs (no sidecar) stay in-process. Tap behavior is identical either way — the same
+`fetch()` contract, the same environment variables, the same packages. The only difference is
+*where* the code runs and what it can reach. `scripts/install.sh` and `docker/vault-init.sh` mint `TAP_RUNNER_TOKEN`;
+the server refuses to start with isolation on and a missing or `changeme` token.
 </Note>
 
 ## Execution modes
 
-| | In-process (default) | Isolated runner (opt-in) |
+| | In-process (`sbt` / IDE, or `USE_TAP_RUNNER=false`) | Isolated runner (compose/prod default) |
 |---|---|---|
 | Where tap code runs | Inside the datris server container | A separate `datris-tap-runner` container |
 | Platform secrets reachable | Limited (see [always-on protections](#always-on-protections)) | **No** |
@@ -24,9 +26,9 @@ variables, the same packages. The only difference is *where* the code runs and w
 | Internet + platform API reachable | Yes | Yes |
 | Extra packages | Installed in an isolated, throwaway environment | Installed in an isolated, throwaway environment |
 
-**In-process** mode (the default) runs tap code inside the server. Tap code in this mode
+**In-process** mode runs tap code inside the server. Tap code in this mode
 shares the server's filesystem and network, so it can reach internal services. This is
-appropriate for a trusted, single-operator install where you author all taps yourself.
+the `sbt` / IDE path (no sidecar). Compose/prod should keep the isolated runner on.
 
 In **isolated runner** mode (`USE_TAP_RUNNER=true`), tap code runs in a container that holds
 no platform credentials and sits on a network with no route to the platform's internal
@@ -83,18 +85,17 @@ Set these on the `datris` service (for example in your `.env`). Defaults work ou
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `USE_TAP_RUNNER` | `false` | Run taps in the isolated runner. Leave unset/`false` to run in-process. |
+| `USE_TAP_RUNNER` | `true` (compose) / unset=`false` (sbt) | Isolated runner. Set `false` to run in-process. |
 | `TAP_RUNNER_URL` | `http://datris-tap-runner:8090` | Address of the runner service. |
-| `TAP_RUNNER_TOKEN` | _(compose default)_ | Shared token authenticating the server → runner call. **Set a strong value.** |
+| `TAP_RUNNER_TOKEN` | minted on first boot | Shared token authenticating the server to runner call. install.sh / vault-init mint it; changeme or empty fails fast when isolation is on. |
 | `TAP_RUNNER_CALLBACK_HOST` | `datris` | Host a tap uses to call back into the platform API from the runner. The datris service name on the shared network. |
 
 The runner is defined as the `datris-tap-runner` service in `docker-compose.yml`; a normal
-`docker compose up` starts it alongside the server, but taps only route to it when
-`USE_TAP_RUNNER=true`. To enable isolation, set the flag and recreate the `datris` container:
+`docker compose up` starts it alongside the server and routes taps there unless you set
+`USE_TAP_RUNNER=false`. To force in-process (for example a no-sidecar `sbt` run):
 
 ```bash
-# enable the isolated runner, then recreate
-USE_TAP_RUNNER=true docker compose up -d datris
+USE_TAP_RUNNER=false sbt -Dconfig.file=... run
 ```
 
 ## What changes for tap authors
@@ -141,9 +142,5 @@ through the API is the supported path and works regardless of mode.
 
 ## When to use which
 
-- **In-process (default)** — fine for a trusted single-operator install where you author all
-  taps yourself, or for a tap that needs direct access to an internal service. The
-  [always-on protections](#always-on-protections) still apply; internal services are reachable.
-- **Isolated runner (`USE_TAP_RUNNER=true`)** — enable for defense-in-depth: tap code stays
-  separated from platform credentials and internal services. Recommended if you run taps you
-  don't fully control, or simply want the extra boundary.
+- **Isolated runner (compose/prod default)** — tap code stays separated from platform credentials and internal services. Isolated taps cannot open a *direct* connection to internal DB / MinIO / Vault; they return records and the pipeline writes destinations.
+- **In-process (`sbt` / IDE, or `USE_TAP_RUNNER=false`)** — tap `fetch()` runs inside the server JVM. Fine for local development without the sidecar, or a legacy tap that still opens a direct internal connection. The server logs a loud warning. Do not treat a laptop compose install as in-process — compose isolates by default.

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+# Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
+FROM python:3.12-slim@sha256:2c941e860699f878900b0edc2403613c234d4b32eda3cc9fa7036991a2a63c4a
 
 LABEL io.modelcontextprotocol.server.name="io.github.datris/datris"
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Unreleased — August 24, 2026
+
+**Tap isolation on by default for docker compose.**
+
+- Compose (and prod compose) now default `USE_TAP_RUNNER=true`. Isolated taps cannot open direct DB / MinIO / Vault connections — they return records; this is existing behavior, called out because isolation is now the compose default.
+- `install.sh` / `vault-init` mint `TAP_RUNNER_TOKEN` on first boot. The server refuses to start isolated with an empty or `changeme` token. `sbt`/IDE without the sidecar stays in-process (loud warning). Set `USE_TAP_RUNNER=false` to force in-process.
+
+---
+
 ## v1.19.4 — August 21, 2026
 
 **Dependency security cleanup across the server and UI.**

--- a/scripts/build-standalone-compose.py
+++ b/scripts/build-standalone-compose.py
@@ -55,6 +55,8 @@ REPLACEMENTS = [
         "      - vault-data:/vault/file\n"
         "      # Writes the server's random token here for the datris service to read.\n"
         "      - datris-vault-token:/vault-token\n"
+        "      # TAP_RUNNER_TOKEN file minted on first boot so compose up works without a .env token.\n"
+        "      - tap-runner-token:/tap-runner-token\n"
         "      - ./docker/vault-bootstrap.sh:/vault-bootstrap.sh\n"
         "      - ./docker/vault-init.sh:/vault-init.sh\n",
         "    configs:\n"
@@ -66,7 +68,8 @@ REPLACEMENTS = [
         "        mode: 0755\n"
         "    volumes:\n"
         "      - vault-data:/vault/file\n"
-        "      - datris-vault-token:/vault-token\n",
+        "      - datris-vault-token:/vault-token\n"
+        "      - tap-runner-token:/tap-runner-token\n",
     ),
     (
         "    volumes:\n"
@@ -84,13 +87,15 @@ REPLACEMENTS = [
         "      # Read-only: the server reads its Vault token (written by vault-init) but\n"
         "      # can't modify it. Dedicated volume so the server never sees the Vault\n"
         "      # root token / unseal key that live on the vault-data volume.\n"
-        "      - datris-vault-token:/vault-token:ro\n",
+        "      - datris-vault-token:/vault-token:ro\n"
+        "      - tap-runner-token:/tap-runner-token:ro\n",
         "    configs:\n"
         "      - source: datris-app-yaml\n"
         "        target: /config/application.yaml\n"
         "    volumes:\n"
         "      - pip-cache:/root/.cache/pip\n"
-        "      - datris-vault-token:/vault-token:ro\n",
+        "      - datris-vault-token:/vault-token:ro\n"
+        "      - tap-runner-token:/tap-runner-token:ro\n",
     ),
 ]
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -629,6 +629,22 @@ else
   ok "Wrote store configuration to .env (permissions set to 600)."
 fi
 
+# Isolation default-on: mint TAP_RUNNER_TOKEN so compose up is not changeme.
+if [ -f "$ENV_FILE" ]; then
+  _tok=$(grep '^TAP_RUNNER_TOKEN=' "$ENV_FILE" 2>/dev/null | sed 's/^TAP_RUNNER_TOKEN=//' | tr -d '"' | tr -d "'")
+  case "$_tok" in
+    ""|changeme-tap-runner-token|change-me-to-a-long-random-string)
+      _tok=$(openssl rand -hex 32 2>/dev/null || dd if=/dev/urandom bs=32 count=1 2>/dev/null | xxd -p | tr -d '\n')
+      if [ ${#_tok} -lt 32 ]; then
+        die "failed to mint TAP_RUNNER_TOKEN (need openssl or /dev/urandom)"
+      fi
+      set_env TAP_RUNNER_TOKEN "$_tok"
+      ok "Minted TAP_RUNNER_TOKEN (tap isolation on for compose)."
+      chmod 600 "$ENV_FILE" 2>/dev/null || true
+      ;;
+  esac
+fi
+
 # --- launch ---------------------------------------------------------------
 if [ "${DATRIS_NO_START:-}" = "1" ]; then
   ok "Files written to $DIR. Skipping start (DATRIS_NO_START=1)."

--- a/tap-runner/Dockerfile
+++ b/tap-runner/Dockerfile
@@ -1,6 +1,7 @@
 # datris-tap-runner — isolated tap execution sidecar (tap-execution-isolation Phase 3).
 # Holds NO platform secrets: no JVM, no Vault, no /datris/.env, no /config, no Docker socket.
-FROM python:3.12-slim-bookworm
+# Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
+FROM python:3.12-slim-bookworm@sha256:a116514e19457bcb7af7efe9c3dd0b9b71e85b317694e7882a1c52aa15a78134
 
 # Pre-bake the same common package set the server image carries, so taps that don't
 # declare extras run with no per-run install. (Tap-declared extras install into a

--- a/tap-runner/app.py
+++ b/tap-runner/app.py
@@ -18,7 +18,22 @@ import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 PORT = int(os.environ.get("TAP_RUNNER_PORT", "8090"))
-TOKEN = os.environ.get("TAP_RUNNER_TOKEN", "")
+def _token():
+    env = os.environ.get("TAP_RUNNER_TOKEN", "")
+    weak = {"", "changeme-tap-runner-token", "change-me-to-a-long-random-string"}
+    if env not in weak:
+        return env
+    path = os.environ.get("TAP_RUNNER_TOKEN_FILE", "/tap-runner-token/token")
+    try:
+        with open(path) as f:
+            minted = f.read().strip()
+        if minted:
+            return minted
+    except OSError:
+        pass
+    return env
+
+TOKEN = _token()
 
 # Benign system env vars the Python runtime / TLS may need. Mirror of the server's
 # NonSecretEnvVars. The tap subprocess gets exactly these (from the runner's own env)

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Build
-FROM node:20-alpine AS build
+# Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -7,7 +8,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Serve (non-root nginx, listens on 8080)
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:alpine@sha256:901e944d1f4fc2bd077e8f5568b98c1f6f8cdacf6b97a87747c43134a339b9a7
 COPY --from=build /app/dist/pipeline-ui/browser /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 # The base image already runs as the unprivileged nginx user (UID 101); the

--- a/ui/src/app/configuration/configuration.component.html
+++ b/ui/src/app/configuration/configuration.component.html
@@ -39,6 +39,11 @@
       </div>
     </div>
 
+    <div class="note-banner" *ngIf="!useTapRunner">
+      <p class="note-title">Taps are running in-process.</p>
+      <p>This server has <code>USE_TAP_RUNNER</code> off, so tap <code>fetch()</code> shares the server network and can reach internal DB, object storage, and Vault. Docker Compose defaults to isolated taps. Keep <code>USE_TAP_RUNNER=false</code> only for sbt/IDE without the sidecar.</p>
+    </div>
+
     <div class="status-block" *ngIf="multiTenant">
       <div class="status-block-row">
         <span class="status-label">AI Provider</span>

--- a/ui/src/app/configuration/configuration.component.ts
+++ b/ui/src/app/configuration/configuration.component.ts
@@ -120,6 +120,7 @@ export class ConfigurationComponent implements OnInit {
   isHosted = false;
   multiTenant = false;
   useApiKeys = false;
+  useTapRunner = true;
   saving = false;
   success = '';
   error = '';
@@ -176,6 +177,7 @@ export class ConfigurationComponent implements OnInit {
         this.isHosted = String(data.hosted) === 'true';
         this.multiTenant = String(data.multiTenant) === 'true';
         this.useUserAuth = String(data.useUserAuth) === 'true';
+        this.useTapRunner = String(data.useTapRunner) === 'true';
         this.useApiKeys = String(data.useApiKeys) === 'true';
         // The Users sub-tab only exists when user-auth is on. If a deep-link
         // (or stale URL) put us on activeTab='users' before we knew that,


### PR DESCRIPTION
Completes Phase 3 of the security-fixes implementation plan (container hardening). **Breaking-adjacent for self-hosters — ship in a minor release with the release notes included here.**

## 3.1 — Base images pinned by digest
All five `FROM` lines (server, UI build+runtime, MCP server, tap-runner) now pin `tag@sha256:` using multi-arch manifest-list digests. Dependabot's docker ecosystem takes over digest-bump maintenance — merge its weekly bumps promptly, since pins freeze base-OS CVE pickup otherwise. All four images verified building `--no-cache` from the pins.

## 3.2 — Tap execution isolation is now the compose/prod default
`USE_TAP_RUNNER` defaults to `true` in `docker-compose.yml`, `docker-compose.standalone.yml` (regenerated via the script — CI guard passes), and `deploy/docker-compose.prod.yml`. Tap `fetch()` runs in the `datris-tap-runner` sidecar: no platform secrets, no route to vault/postgres/mongo/minio.

**No boot breakage on upgrades:** `docker/vault-init.sh` runs every boot and mints `TAP_RUNNER_TOKEN` into a named `tap-runner-token` volume whenever the env value is empty/changeme; `install.sh` mints into `.env` on fresh installs. Server and runner both fall back to the minted file. The server fails fast only when isolation is on and no real token resolves (a mis-wired deployment). `sbt`/IDE without the sidecar stays in-process with a loud warning. The version API and Configuration tab surface the mode.

**Behavior change to release-note:** taps that opened *direct* connections to internal DB/MinIO/Vault stop working under isolation (pre-existing sidecar behavior, now the default). The sanctioned `DATRIS_PLATFORM_*` callback keeps working. Opt-out: `USE_TAP_RUNNER=false`. Operators should pull all images together — a new server with an old runner image will fail tap runs until the runner is updated.

## Verification (run live against a real stack)
- 204/204 sbt tests pass; standalone compose regenerates byte-identical.
- vault-init minted a 64-char token with no `.env` entry; server booted isolated, `useTapRunner: true` via the version API.
- External tap (weather) and secret+callback tap (portfolio-8k) both returned records through the sidecar.
- From inside the runner: postgres/vault/mongodb/minio do not even DNS-resolve; the datris callback host is reachable.
- Routing proof: tap runs fail with "Tap runner request failed" while the runner is stopped, recover when it returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)