### PR TITLE
Security plan Phase 4: Prometheus metrics endpoint + JSON logs in production

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,6 +227,12 @@ lazy val allDependencies = Seq(
     // (spring-core auth flaw, webmvc XSS/DoS, SpEL DoS).
     "org.springframework.boot" % "spring-boot-starter" % "3.5.16",
     "org.springframework.boot" % "spring-boot-starter-web" % "3.5.16",
+    // Actuator + Prometheus metrics (/actuator/prometheus). The registry version
+    // must match what Boot 3.5.16 manages (micrometer 1.15.12) — sbt has no BOM.
+    "org.springframework.boot" % "spring-boot-starter-actuator" % "3.5.16",
+    "io.micrometer" % "micrometer-registry-prometheus" % "1.15.12",
+    // JSON console logs when the production profile is active (see logback-spring.xml).
+    "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
 
     // Password hashing for UI user auth (BCrypt). The crypto module is
     // standalone (no spring-framework deps), so it can run ahead of the Boot

--- a/datrisserver/src/main/resources/application.yaml
+++ b/datrisserver/src/main/resources/application.yaml
@@ -9,14 +9,20 @@ spring:
   data:
     mongodb:
       uri: mongodb://localhost:27017/datris
-  management:
+
+# Actuator: health probes plus the Prometheus scrape endpoint
+# (/actuator/prometheus). Actuator endpoints carry no secrets but describe the
+# runtime — nginx blocks /actuator from the outside; scrape it from inside the
+# compose network (http://datris:8080/actuator/prometheus).
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
     health:
       probes:
-        enabled: "true"
-      livenessState:
-        enabled: "true"
-      readinessState:
-        enabled: "true"
+        enabled: true
 logging:
   level:
     root: INFO

--- a/datrisserver/src/main/resources/logback-spring.xml
+++ b/datrisserver/src/main/resources/logback-spring.xml
@@ -2,13 +2,29 @@
 <!--
   Datris logging config.
 
-  Includes Spring Boot's default console (and optional file) setup unchanged,
-  so log format and the per-logger levels in application.yaml still apply. The
-  only addition is a turbo filter that drops benign client-disconnect stack
+  Two modes, switched by Spring profile:
+  - default (dev / sbt / IDE): Spring Boot's stock human-readable console setup,
+    unchanged, so log format and the per-logger levels in application.yaml apply.
+  - production profile: one JSON line per event (logstash-logback-encoder), for
+    SIEM / log-aggregator ingestion. Same levels from application.yaml.
+
+  Both modes keep the turbo filter that drops benign client-disconnect stack
   traces (broken pipe / connection reset) the servlet container raises when an
   SSE stream's browser closes mid-response. See ClientAbortLogFilter.
 -->
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <turboFilter class="ai.datris.util.ClientAbortLogFilter"/>
+
+    <springProfile name="production">
+        <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!production">
+        <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    </springProfile>
 </configuration>

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -233,6 +233,9 @@ services:
       # ignore them so platform keys never leak across tenants.
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      # production profile switches server logs to JSON (one line per event) for
+      # SIEM ingestion; unset/override to get human-readable console logs.
+      SPRING_PROFILES_ACTIVE: "${SPRING_PROFILES_ACTIVE:-production}"
       USE_TAP_RUNNER: "${USE_TAP_RUNNER:-true}"
       TAP_RUNNER_URL: "http://datris-tap-runner:8090"
       TAP_RUNNER_TOKEN: "${TAP_RUNNER_TOKEN:-changeme-tap-runner-token}"

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -82,6 +82,12 @@ http {
 
         limit_req zone=api burst=50 nodelay;
 
+        # Actuator (health/info/prometheus) is internal-only: scrape it from
+        # inside the compose network, never through the public edge.
+        location /actuator {
+            return 404;
+        }
+
         location / {
             proxy_pass http://datris:8080;
             proxy_set_header Host $host;

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,6 +4,11 @@ description: "Release history for Datris"
 ---
 
 <Update label="Unreleased" description="August 24, 2026">
+  **Observability: Prometheus metrics and structured logs.**
+
+  - New `/actuator/prometheus` endpoint for Prometheus scraping, reachable only from inside the deployment's network (the bundled edge proxy blocks it publicly).
+  - Production deployments emit one JSON log line per event for SIEM / log-aggregator ingestion; development logs stay human-readable.
+
   **Tap isolation on by default for docker compose.**
 
   - `docker-compose.yml` / `docker-compose.standalone.yml` / `deploy/docker-compose.prod.yml` now default `USE_TAP_RUNNER=true`. `scripts/install.sh` and `docker/vault-init.sh` mint `TAP_RUNNER_TOKEN` on first boot (including upgrades whose token was missing or `changeme`). The server fails fast if isolation is on and the token is still empty/`changeme` — a minted token is accepted.

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,11 @@
 
 ## Unreleased — August 24, 2026
 
+**Observability: Prometheus metrics and structured logs.**
+
+- New `/actuator/prometheus` endpoint exposes server metrics for Prometheus scraping. It is reachable only from inside the deployment's network — the bundled edge proxy does not expose it publicly.
+- Production deployments now emit one JSON log line per event, ready for SIEM / log-aggregator ingestion. Development logs stay human-readable.
+
 **Tap isolation on by default for docker compose.**
 
 - Compose (and prod compose) now default `USE_TAP_RUNNER=true`. Isolated taps cannot open direct DB / MinIO / Vault connections — they return records; this is existing behavior, called out because isolation is now the compose default.


### PR DESCRIPTION
Completes Phase 4 of the security-fixes implementation plan (observability). **Stacked on #59** — GitHub retargets this to main automatically when #59 merges. Low risk, ships in any patch release.

## 4.1 — Micrometer + Prometheus endpoint
- `spring-boot-starter-actuator` 3.5.16 + `micrometer-registry-prometheus` 1.15.12 (pinned to the exact version Boot 3.5.16 manages, since sbt has no BOM).
- Root-level `management` block in `application.yaml` exposes `health,info,prometheus` — this also fixes the pre-existing health-probes config, which was nested under `spring:` and silently inert (actuator wasn't even a dependency before; `/actuator/health` 404'd).
- **Internal-only**: the prod nginx `api.` vhost returns 404 for `/actuator`; the UI nginx only ever proxied `/api/`, so the endpoint is unreachable from the edge in both topologies. Scrape from inside the network: `http://datris:8080/actuator/prometheus`.

## 4.2 — Structured JSON logs in production
- `logstash-logback-encoder` 8.1; `logback-spring.xml` emits one JSON line per event when the `production` Spring profile is active, and keeps Boot's stock human-readable console format otherwise. `ClientAbortLogFilter` stays installed in both modes.
- `deploy/docker-compose.prod.yml` now defaults `SPRING_PROFILES_ACTIVE=production` (overridable), so prod deployments actually get JSON without extra steps. Dev compose and sbt/IDE stay human-readable.

## Verified live
- `/actuator/health` → `{"status":"UP","groups":["liveness","readiness"]}`; `/actuator/prometheus` serves metrics; boot logs "Exposing 3 endpoints beneath base path '/actuator'".
- Through the UI nginx edge, `/actuator/*` serves the SPA, not metrics.
- A production-profile boot emits clean LogstashEncoder JSON from the first line.
- 204/204 sbt tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)