### PR TITLE
MCP profiles: capability-filtered tool catalogs for scoped API keys

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
@@ -476,9 +476,15 @@ object KeysAPIController {
                 "pipeline:read",
                 "pipeline:run:owner=self",
                 "tap:create",
+                "tap:read",
                 "tap:run:owner=self",
                 "document:upload",
                 "search:vector",
+                // Read stays scoped to tap-typed secrets: the canonical
+                // workflow (list secrets → create tap secret → create tap)
+                // does GET pre-reads, and SecretsAPIController filters reads
+                // per-secret by scope, so platform/AI keys stay invisible.
+                "secret:read:_type=tap",
                 "secret:write:_type=tap",
                 "job:read"
             )

--- a/datrisserver/src/main/scala/ai/datris/api/MCPToolsAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/MCPToolsAPIController.scala
@@ -1,0 +1,59 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import ai.datris.auth.MCPToolRoutes
+import ai.datris.config.TenantInterceptor
+import ai.datris.model.ResolvedKey
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+import scala.collection.JavaConverters._
+
+/** Answers "which MCP tools may this key see" for the MCP server's
+  * `list_tools`, from the same capability tables the CapabilityInterceptor
+  * enforces at call time. The route sits in CapabilityRoutes' skip list —
+  * any valid key may ask about itself — but a request that resolves to no
+  * key at all (keys on, header missing or invalid) is rejected here. */
+@RestController
+@RequestMapping(Array("/api/v1"))
+class MCPToolsAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[MCPToolsAPIController])
+    private val gson = new Gson
+
+    @GetMapping(path = Array("/mcp/tools"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def listMcpTools(request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            logger.info("API endpoint GET /api/v1/mcp/tools called")
+            request.getAttribute(TenantInterceptor.ResolvedKeyAttr) match {
+                case rk: ResolvedKey =>
+                    // Legacy `*:*` — includes the anonymous identity when
+                    // useApiKeys=false — sees the unfiltered catalog.
+                    val filtered = !rk.isLegacyFullAccess
+                    val tools = if (filtered) MCPToolRoutes.allowedTools(rk) else MCPToolRoutes.allToolNames
+                    val body = Map(
+                        "filtered" -> java.lang.Boolean.valueOf(filtered),
+                        "tools" -> tools.asJava
+                    ).asJava
+                    new ResponseEntity[String](gson.toJson(body), HttpStatus.OK)
+                case _ =>
+                    // TenantInterceptor attaches a ResolvedKey whenever the key
+                    // resolves (including anonymous mode); absence means keys
+                    // are required and this one is missing or invalid.
+                    ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body[String]("""{"error":"x-api-key does not exist or is invalid"}""")
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("Error: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/api/SecretsAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/SecretsAPIController.scala
@@ -7,7 +7,7 @@ Copyright (C) 2026 Datris (https://datris.ai)
 
 import com.google.common.base.Throwables
 import com.google.gson.{Gson, JsonParser}
-import ai.datris.auth.{CapabilityCheck, ResolvedKeyAccess}
+import ai.datris.auth.{CapabilityCheck, CapabilityDeniedException, ResolvedKeyAccess}
 import ai.datris.config.RequiresRole
 import ai.datris.model.DatrisEnvironment
 import ai.datris.util.{APIKeyValidator, SecretsRetrieverUtil, SecretsUtil}
@@ -112,6 +112,14 @@ class SecretsAPIController {
             val gson = new Gson
             new ResponseEntity[String](gson.toJson(visible.asJava), HttpStatus.OK)
         } catch {
+            case e: CapabilityDeniedException =>
+                // Same clean-JSON shape as a CapabilityInterceptor enforce-mode
+                // deny — a stack-trace 500 reads to agents as a server fault,
+                // not a permission boundary.
+                logger.info("capability scope denial: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body[String]("{\"error\":\"capability denied\",\"errorKind\":\"capability_denied\",\"message\":\"" +
+                        e.getMessage.replace("\"", "\\\"") + "\"}")
             case e: Exception =>
                 logger.error("Error: " + Throwables.getStackTraceAsString(e))
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
@@ -167,6 +175,14 @@ class SecretsAPIController {
                     ResponseEntity.status(HttpStatus.NOT_FOUND).body[String]("{\"error\": \"Secret not found: " + name + "\"}")
             }
         } catch {
+            case e: CapabilityDeniedException =>
+                // Same clean-JSON shape as a CapabilityInterceptor enforce-mode
+                // deny — a stack-trace 500 reads to agents as a server fault,
+                // not a permission boundary.
+                logger.info("capability scope denial: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body[String]("{\"error\":\"capability denied\",\"errorKind\":\"capability_denied\",\"message\":\"" +
+                        e.getMessage.replace("\"", "\\\"") + "\"}")
             case e: Exception =>
                 logger.error("Error: " + Throwables.getStackTraceAsString(e))
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
@@ -191,19 +207,27 @@ class SecretsAPIController {
                 // when the request sends them as the masked placeholder.
                 val existing = SecretsUtil.getSecretMap(secretPath).map(_.asScala).getOrElse(scala.collection.mutable.Map.empty[String, String])
 
+                val json = JsonParser.parseString(body).getAsJsonObject
+
                 // In-action capability scope check for `secret:write:_type=tap`
                 // keys. The interceptor's scope-agnostic gate already confirmed
                 // the key holds `secret:write` for some scope; we now verify
-                // the actual target (existing secret's _type, or "tap" for a
-                // brand-new tap secret) satisfies the key's scope predicates.
+                // the actual target satisfies the key's scope predicates.
+                // For an EXISTING secret its stored _type is authoritative — a
+                // scoped key cannot re-tag a platform secret by claiming
+                // `_type: tap` in the payload. A BRAND-NEW secret is scoped by
+                // the _type it declares (a tap-scoped key creating a secret
+                // tagged tap is exactly the intended workflow; declaring no
+                // _type leaves the context empty and the scoped key denied).
                 // Server-side parallel to the Python `_type=tap` filter on the
                 // MCP path — both retained for defense in depth.
                 val existingType = existing.get("_type").getOrElse("")
-                val scopeContext = if (existingType.nonEmpty) Map("_type" -> existingType)
+                val incomingType =
+                    if (json.has("_type") && json.get("_type").isJsonPrimitive) json.get("_type").getAsString else ""
+                val effectiveType = if (existing.nonEmpty) existingType else incomingType
+                val scopeContext = if (effectiveType.nonEmpty) Map("_type" -> effectiveType)
                 else Map.empty[String, String]
                 CapabilityCheck.assertScope(request, "secret", "write", scopeContext)
-
-                val json = JsonParser.parseString(body).getAsJsonObject
                 val incoming = new java.util.LinkedHashMap[String, Object]()
                 json.entrySet().asScala.foreach { entry =>
                     val value = entry.getValue
@@ -321,6 +345,14 @@ class SecretsAPIController {
                 new ResponseEntity[String]("{\"status\": \"ok\"}", HttpStatus.OK)
             }
         } catch {
+            case e: CapabilityDeniedException =>
+                // Same clean-JSON shape as a CapabilityInterceptor enforce-mode
+                // deny — a stack-trace 500 reads to agents as a server fault,
+                // not a permission boundary.
+                logger.info("capability scope denial: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body[String]("{\"error\":\"capability denied\",\"errorKind\":\"capability_denied\",\"message\":\"" +
+                        e.getMessage.replace("\"", "\\\"") + "\"}")
             case e: Exception =>
                 logger.error("Error: " + Throwables.getStackTraceAsString(e))
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
@@ -353,6 +385,14 @@ class SecretsAPIController {
                 new ResponseEntity[String]("{\"status\": \"ok\"}", HttpStatus.OK)
             }
         } catch {
+            case e: CapabilityDeniedException =>
+                // Same clean-JSON shape as a CapabilityInterceptor enforce-mode
+                // deny — a stack-trace 500 reads to agents as a server fault,
+                // not a permission boundary.
+                logger.info("capability scope denial: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body[String]("{\"error\":\"capability denied\",\"errorKind\":\"capability_denied\",\"message\":\"" +
+                        e.getMessage.replace("\"", "\\\"") + "\"}")
             case e: Exception =>
                 logger.error("Error: " + Throwables.getStackTraceAsString(e))
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityCheck.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityCheck.scala
@@ -9,6 +9,12 @@ import ai.datris.config.TenantInterceptor
 import ai.datris.model.{DatrisException, ResolvedKey}
 import jakarta.servlet.http.HttpServletRequest
 
+/** Thrown by [[CapabilityCheck.assertScope]] on a scope denial. A distinct
+  * type so controller catch blocks can map it to a clean 403 (matching the
+  * CapabilityInterceptor's enforce-mode denials) instead of the generic
+  * 500-with-stacktrace path. */
+class CapabilityDeniedException(msg: String) extends DatrisException(msg)
+
 /** In-action scope check helper, called by controllers AFTER loading the
   * target resource. The CapabilityInterceptor's pre-action gate is scope-
   * agnostic: it confirms the request's key holds SOME capability for the
@@ -44,7 +50,7 @@ object CapabilityCheck {
         val resolved = readResolvedKey(request)
         resolved.foreach { rk =>
             if (!rk.grants(resource, action, context)) {
-                throw new DatrisException(
+                throw new CapabilityDeniedException(
                     "capability denied: key '" + rk.label + "' does not hold capability '" +
                         resource + ":" + action + "' for the targeted resource " +
                         "(scope: " + scopeStr(context) + ")"

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -50,6 +50,9 @@ object CapabilityRoutes {
         "/api/v1/health/**",
         "/api/v1/version",
         "/api/v1/mcp/activity",
+        // Any valid key may ask which MCP tools it can see; the controller
+        // itself rejects requests that resolve to no key at all.
+        "/api/v1/mcp/tools",
         "/api/v1/assistant/**",
         "/api/v1/ops-chat/**",
         "/api/v1/catalog-chat/**"
@@ -88,6 +91,11 @@ object CapabilityRoutes {
         Route("POST", "/api/v1/tap/brainstorm", "tap", "read"),
         Route("GET", "/api/v1/tap/ledger", "tap", "read"),
         Route("DELETE", "/api/v1/tap/ledger", "tap", "update"),
+        // Tap incremental sync state (read = read; set/reset mutate the
+        // cursor a scheduled run resumes from, so they gate like an update)
+        Route("GET", "/api/v1/tap/state", "tap", "read"),
+        Route("POST", "/api/v1/tap/state", "tap", "update"),
+        Route("DELETE", "/api/v1/tap/state", "tap", "update"),
         Route("GET", "/api/v1/tap/logs", "job", "read"),
         // Tap definition versions (read/diff = read; restore = update)
         Route("GET", "/api/v1/tap/versions", "tap", "read"),

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -1,0 +1,163 @@
+package ai.datris.auth
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.ResolvedKey
+import org.slf4j.LoggerFactory
+
+/** Maps every MCP tool the Python MCP server advertises to the primary REST
+  * route that tool calls, so the server can answer "which tools may this key
+  * see" from the same route→capability table [[CapabilityRoutes]] already
+  * enforces. The MCP server's `list_tools` fetches the allowed names from
+  * `GET /api/v1/mcp/tools` and returns that subset of its catalog — it never
+  * owns a copy of this mapping, so the two cannot drift.
+  *
+  * Rules:
+  *   - Visibility is decided on `resource:action` only. Scope predicates
+  *     (`owner=self`, `_type=tap`) need the loaded resource and stay
+  *     call-time enforced by the controllers — same split as the
+  *     pre-action gate in CapabilityInterceptor.
+  *   - Multi-call tools are classified by their PRIMARY route. Secondary
+  *     calls with other capabilities may still 403 at call time; that
+  *     backstop is unchanged.
+  *   - A tool added to server.py WITHOUT a row here is hidden from every
+  *     scoped key (fail-closed) until someone classifies it. Legacy `*:*`
+  *     keys and keys-off installs always get the full catalog, so a
+  *     missing row can never break an unscoped install.
+  */
+object MCPToolRoutes {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    /** How a tool relates to the REST capability surface. */
+    sealed trait ToolRoute
+
+    /** No capability-checked REST call: a pure local helper (wait_seconds)
+      * or public Skip-class infrastructure (/version, /health). Always
+      * visible to every session. */
+    case object Local extends ToolRoute
+
+    /** The tool's primary REST call. Visible iff the key would pass the
+      * interceptor's grant test for this method+path. */
+    case class Mapped(method: String, path: String) extends ToolRoute
+
+    /** One row per tool in mcp-server/server.py's catalog, same order.
+      * Paths are concrete representatives — CapabilityRoutes matches them
+      * with AntPathMatcher patterns (e.g. `/api/v1/secrets/example` hits
+      * the double-wildcard secrets row). */
+    val tools: Seq[(String, ToolRoute)] = Seq(
+        // Pipeline management
+        "list_pipelines" -> Mapped("GET", "/api/v1/pipelines"),
+        "get_pipeline" -> Mapped("GET", "/api/v1/pipeline"),
+        "create_pipeline" -> Mapped("POST", "/api/v1/pipeline"),
+        "set_catalog" -> Mapped("POST", "/api/v1/pipeline"),
+        "delete_pipeline" -> Mapped("DELETE", "/api/v1/pipeline"),
+        "upload_data" -> Mapped("POST", "/api/v1/pipeline/upload"),
+        "get_job_status" -> Mapped("GET", "/api/v1/pipeline/status"),
+        "kill_job" -> Mapped("POST", "/api/v1/job/kill"),
+        "profile_data" -> Mapped("POST", "/api/v1/pipeline/profile"),
+
+        // Infrastructure
+        "get_version" -> Local,
+        "check_service_health" -> Local,
+
+        // Vector search
+        "search_qdrant" -> Mapped("POST", "/api/v1/search/qdrant"),
+        "search_weaviate" -> Mapped("POST", "/api/v1/search/weaviate"),
+        "search_milvus" -> Mapped("POST", "/api/v1/search/milvus"),
+        "search_pgvector" -> Mapped("POST", "/api/v1/search/pgvector"),
+        "search_chroma" -> Mapped("POST", "/api/v1/search/chroma"),
+
+        // Query
+        "query_postgres" -> Mapped("POST", "/api/v1/query/postgres"),
+        "query_objectstore" -> Mapped("POST", "/api/v1/query/objectstore"),
+        "query_snowflake" -> Mapped("POST", "/api/v1/query/snowflake"),
+        "query_databricks" -> Mapped("POST", "/api/v1/query/databricks"),
+        "query_mongodb" -> Mapped("POST", "/api/v1/query/mongodb"),
+        "query_natural" -> Mapped("POST", "/api/v1/query/natural"),
+
+        // Metadata
+        "list_postgres_databases" -> Mapped("GET", "/api/v1/metadata/postgres/databases"),
+        "list_postgres_schemas" -> Mapped("GET", "/api/v1/metadata/postgres/schemas"),
+        "list_postgres_tables" -> Mapped("GET", "/api/v1/metadata/postgres/tables"),
+        "list_postgres_columns" -> Mapped("GET", "/api/v1/metadata/postgres/columns"),
+        "list_mongodb_databases" -> Mapped("GET", "/api/v1/metadata/mongodb/databases"),
+        "list_mongodb_collections" -> Mapped("GET", "/api/v1/metadata/mongodb/collections"),
+        "list_qdrant_collections" -> Mapped("GET", "/api/v1/metadata/qdrant/collections"),
+        "list_weaviate_classes" -> Mapped("GET", "/api/v1/metadata/weaviate/classes"),
+        "list_milvus_collections" -> Mapped("GET", "/api/v1/metadata/milvus/collections"),
+        "list_chroma_collections" -> Mapped("GET", "/api/v1/metadata/chroma/collections"),
+        "list_pgvector_collections" -> Mapped("GET", "/api/v1/metadata/postgres/tables"),
+
+        // AI answer + config
+        "ai_answer" -> Mapped("POST", "/api/v1/ai/answer"),
+        "upload_config" -> Mapped("POST", "/api/v1/config/upload"),
+
+        // Secrets (single-secret paths hit the /api/v1/secrets/** rows)
+        "update_secret" -> Mapped("PUT", "/api/v1/secrets/example"),
+        "list_tap_secrets" -> Mapped("GET", "/api/v1/secrets"),
+        "get_tap_secret_fields" -> Mapped("GET", "/api/v1/secrets/example"),
+        "list_platform_secrets" -> Mapped("GET", "/api/v1/secrets"),
+        "get_platform_secret_fields" -> Mapped("GET", "/api/v1/secrets/example"),
+        "create_tap_secret" -> Mapped("PUT", "/api/v1/secrets/example"),
+        "delete_tap_secret" -> Mapped("DELETE", "/api/v1/secrets/example"),
+
+        // Taps
+        "create_tap" -> Mapped("POST", "/api/v1/tap"),
+        "list_taps" -> Mapped("GET", "/api/v1/taps"),
+        "run_tap" -> Mapped("POST", "/api/v1/tap/run"),
+        "get_pipeline_status" -> Mapped("GET", "/api/v1/pipeline/status"),
+        "delete_tap" -> Mapped("DELETE", "/api/v1/tap"),
+        "get_tap" -> Mapped("GET", "/api/v1/tap"),
+        "get_tap_logs" -> Mapped("GET", "/api/v1/tap/logs"),
+        "get_tap_ledger" -> Mapped("GET", "/api/v1/tap/ledger"),
+        "get_tap_state" -> Mapped("GET", "/api/v1/tap/state"),
+        "set_tap_state" -> Mapped("POST", "/api/v1/tap/state"),
+        "test_tap" -> Mapped("POST", "/api/v1/tap/run"),
+        "update_tap" -> Mapped("POST", "/api/v1/tap"),
+
+        // Definition versions
+        "list_tap_versions" -> Mapped("GET", "/api/v1/tap/versions"),
+        "get_tap_version" -> Mapped("GET", "/api/v1/tap/version"),
+        "diff_tap_versions" -> Mapped("GET", "/api/v1/tap/version/diff"),
+        "restore_tap_version" -> Mapped("POST", "/api/v1/tap/version/restore"),
+        "list_pipeline_versions" -> Mapped("GET", "/api/v1/pipeline/versions"),
+        "get_pipeline_version" -> Mapped("GET", "/api/v1/pipeline/version"),
+        "diff_pipeline_versions" -> Mapped("GET", "/api/v1/pipeline/version/diff"),
+        "restore_pipeline_version" -> Mapped("POST", "/api/v1/pipeline/version/restore"),
+
+        // Agent workflow helper — no REST call at all
+        "wait_seconds" -> Local
+    )
+
+    val allToolNames: Seq[String] = tools.map(_._1)
+
+    /** Tool names this key may see. Legacy `*:*` keys (which includes the
+      * anonymous identity in keys-off mode) get the full catalog. */
+    def allowedTools(key: ResolvedKey): Seq[String] = {
+        if (key.isLegacyFullAccess) return allToolNames
+        tools.collect {
+            case (name, Local) => name
+            case (name, Mapped(method, path)) if mappedAllowed(name, method, path, key) => name
+        }
+    }
+
+    private def mappedAllowed(name: String, method: String, path: String, key: ResolvedKey): Boolean =
+        CapabilityRoutes.lookup(method, path) match {
+            case RouteCheck.Require(resource, action) => key.matchesResourceAction(resource, action)
+            case RouteCheck.Skip => true
+            case RouteCheck.Unmapped =>
+                // A Mapped row pointing at a route CapabilityRoutes doesn't
+                // know means the two tables drifted. Fail closed for scoped
+                // keys and say so in the log; MCPToolRoutesSpec also fails
+                // on this so drift is caught before it ships.
+                logger.warn(
+                    "MCP tool '{}' maps to unmapped route {} {} — hidden from scoped keys",
+                    Array[AnyRef](name, method, path): _*
+                )
+                false
+        }
+}

--- a/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
@@ -99,7 +99,9 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
                         DatrisEnvironment.values.useApiKeys &&
                         resolvedKey(request).exists(rk =>
                             RoleEnforcementInterceptor.programmaticKeySatisfiesRoleGate(
-                                rk, request.getMethod, request.getRequestURI
+                                rk,
+                                request.getMethod,
+                                request.getRequestURI
                             )
                         )
                     )

--- a/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/RoleEnforcementInterceptor.scala
@@ -85,9 +85,23 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
                     // full-access identity present in useApiKeys=false mode is
                     // deliberately excluded so an admin gate is never satisfied
                     // by an unauthenticated caller.
+                    //
+                    // A scoped key on a CAPABILITY-MAPPED route is the other
+                    // legitimate programmatic identity: the capability check
+                    // (which already ran — WebMvcConfig ordering) granted the
+                    // route, and controllers still enforce scope predicates.
+                    // Role gates govern UI sessions; for server-to-server
+                    // callers the capability bundle is the permission model.
+                    // Routes OUTSIDE the capability table (key minting, user
+                    // management — skip-listed there) still require `*:*`, so
+                    // an admin gate is never satisfied by a scoped key.
                     if (
                         DatrisEnvironment.values.useApiKeys &&
-                        resolvedKey(request).exists(_.matchesResourceAction("*", "*"))
+                        resolvedKey(request).exists(rk =>
+                            RoleEnforcementInterceptor.programmaticKeySatisfiesRoleGate(
+                                rk, request.getMethod, request.getRequestURI
+                            )
+                        )
                     )
                         return true
                     return reject(response, HttpStatus.FORBIDDEN, """{"error":"Insufficient role"}""")
@@ -151,5 +165,27 @@ class RoleEnforcementInterceptor extends HandlerInterceptor {
         response.setContentType("application/json")
         response.getWriter.write(body)
         false
+    }
+}
+
+object RoleEnforcementInterceptor {
+
+    /** Does this validated key satisfy a role-gated endpoint reached without
+      * a user session? Full access (`*:*`) always does. A scoped key does
+      * only when the route is capability-mapped and the key holds the
+      * required capability — the same grant the CapabilityInterceptor
+      * already enforced earlier in the chain. Skip-listed and unmapped
+      * routes (key minting, user management) never accept a scoped key. */
+    private[config] def programmaticKeySatisfiesRoleGate(
+        rk: ResolvedKey,
+        method: String,
+        path: String
+    ): Boolean = {
+        if (rk.matchesResourceAction("*", "*")) return true
+        ai.datris.auth.CapabilityRoutes.lookup(method, path) match {
+            case ai.datris.auth.RouteCheck.Require(resource, action) =>
+                rk.matchesResourceAction(resource, action)
+            case _ => false
+        }
     }
 }

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -66,24 +66,50 @@ class MCPToolRoutesSpec extends AnyFunSuite {
         // The canonical workflow: list secrets → create tap secret →
         // create tap → test → run → poll.
         val expected = Seq(
-            "list_pipelines", "get_pipeline", "create_pipeline", "upload_data",
-            "list_taps", "get_tap", "create_tap", "update_tap", "run_tap", "test_tap",
-            "get_tap_ledger", "get_tap_state", "get_tap_logs",
-            "list_tap_secrets", "get_tap_secret_fields", "create_tap_secret",
-            "delete_tap_secret", "update_secret",
-            "search_qdrant", "search_pgvector",
-            "get_pipeline_status", "get_job_status",
-            "wait_seconds", "get_version", "check_service_health"
+            "list_pipelines",
+            "get_pipeline",
+            "create_pipeline",
+            "upload_data",
+            "list_taps",
+            "get_tap",
+            "create_tap",
+            "update_tap",
+            "run_tap",
+            "test_tap",
+            "get_tap_ledger",
+            "get_tap_state",
+            "get_tap_logs",
+            "list_tap_secrets",
+            "get_tap_secret_fields",
+            "create_tap_secret",
+            "delete_tap_secret",
+            "update_secret",
+            "search_qdrant",
+            "search_pgvector",
+            "get_pipeline_status",
+            "get_job_status",
+            "wait_seconds",
+            "get_version",
+            "check_service_health"
         )
         val missing = expected.filterNot(allowed.contains)
         assert(missing.isEmpty, s"rag-builder should see: $missing")
 
         // Invisible: no delete/update/kill grants, no query/metadata/config.
         val forbidden = Seq(
-            "delete_pipeline", "delete_tap", "kill_job",
-            "set_tap_state", "restore_tap_version", "restore_pipeline_version",
-            "query_postgres", "query_mongodb", "query_natural", "ai_answer",
-            "list_postgres_databases", "list_mongodb_databases", "profile_data",
+            "delete_pipeline",
+            "delete_tap",
+            "kill_job",
+            "set_tap_state",
+            "restore_tap_version",
+            "restore_pipeline_version",
+            "query_postgres",
+            "query_mongodb",
+            "query_natural",
+            "ai_answer",
+            "list_postgres_databases",
+            "list_mongodb_databases",
+            "profile_data",
             "upload_config"
         )
         val leaked = forbidden.filter(allowed.contains)
@@ -98,8 +124,14 @@ class MCPToolRoutesSpec extends AnyFunSuite {
 
     test("read-only-shaped key gets reads plus local tools, nothing mutating") {
         val readOnly = key(
-            "pipeline:read", "tap:read", "job:read", "metadata:read",
-            "config:read", "query:postgres", "query:mongodb", "search:vector"
+            "pipeline:read",
+            "tap:read",
+            "job:read",
+            "metadata:read",
+            "config:read",
+            "query:postgres",
+            "query:mongodb",
+            "search:vector"
         )
         val allowed = MCPToolRoutes.allowedTools(readOnly).toSet
         assert(allowed.contains("list_pipelines"))

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -1,0 +1,119 @@
+package ai.datris.auth
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{Capability, ResolvedKey}
+import org.scalatest.funsuite.AnyFunSuite
+
+class MCPToolRoutesSpec extends AnyFunSuite {
+
+    private def key(caps: String*): ResolvedKey =
+        ResolvedKey(None, "test-key", Capability.parseList(caps), isLegacyFullAccess = false)
+
+    private val legacyKey =
+        ResolvedKey(None, "legacy", Seq(Capability.FullAccess), isLegacyFullAccess = true)
+
+    // Mirrors the rag-builder template in KeysAPIController — if the template
+    // changes, this test states what the MCP catalog consequences are.
+    private val ragBuilder = key(
+        "pipeline:create",
+        "pipeline:read",
+        "pipeline:run:owner=self",
+        "tap:create",
+        "tap:read",
+        "tap:run:owner=self",
+        "document:upload",
+        "search:vector",
+        "secret:read:_type=tap",
+        "secret:write:_type=tap",
+        "job:read"
+    )
+
+    test("catalog has one row per MCP tool, no duplicates") {
+        assert(MCPToolRoutes.allToolNames.size == 63)
+        assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
+    }
+
+    test("drift guard: every Mapped row resolves in CapabilityRoutes") {
+        val unmapped = MCPToolRoutes.tools.collect {
+            case (name, MCPToolRoutes.Mapped(method, path))
+                if CapabilityRoutes.lookup(method, path) == RouteCheck.Unmapped =>
+                s"$name -> $method $path"
+        }
+        assert(unmapped.isEmpty, s"tools mapped to routes CapabilityRoutes does not know: $unmapped")
+    }
+
+    test("tap sync state routes are capability-mapped (was a live unmapped hole)") {
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/tap/state") == RouteCheck.Require("tap", "read"))
+        assert(CapabilityRoutes.lookup("POST", "/api/v1/tap/state") == RouteCheck.Require("tap", "update"))
+        assert(CapabilityRoutes.lookup("DELETE", "/api/v1/tap/state") == RouteCheck.Require("tap", "update"))
+    }
+
+    test("the mcp/tools endpoint itself is skip-class") {
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/mcp/tools") == RouteCheck.Skip)
+    }
+
+    test("legacy full-access key sees the entire catalog") {
+        assert(MCPToolRoutes.allowedTools(legacyKey) == MCPToolRoutes.allToolNames)
+    }
+
+    test("rag-builder sees its workflow and never the destructive tools") {
+        val allowed = MCPToolRoutes.allowedTools(ragBuilder).toSet
+
+        // The canonical workflow: list secrets → create tap secret →
+        // create tap → test → run → poll.
+        val expected = Seq(
+            "list_pipelines", "get_pipeline", "create_pipeline", "upload_data",
+            "list_taps", "get_tap", "create_tap", "update_tap", "run_tap", "test_tap",
+            "get_tap_ledger", "get_tap_state", "get_tap_logs",
+            "list_tap_secrets", "get_tap_secret_fields", "create_tap_secret",
+            "delete_tap_secret", "update_secret",
+            "search_qdrant", "search_pgvector",
+            "get_pipeline_status", "get_job_status",
+            "wait_seconds", "get_version", "check_service_health"
+        )
+        val missing = expected.filterNot(allowed.contains)
+        assert(missing.isEmpty, s"rag-builder should see: $missing")
+
+        // Invisible: no delete/update/kill grants, no query/metadata/config.
+        val forbidden = Seq(
+            "delete_pipeline", "delete_tap", "kill_job",
+            "set_tap_state", "restore_tap_version", "restore_pipeline_version",
+            "query_postgres", "query_mongodb", "query_natural", "ai_answer",
+            "list_postgres_databases", "list_mongodb_databases", "profile_data",
+            "upload_config"
+        )
+        val leaked = forbidden.filter(allowed.contains)
+        assert(leaked.isEmpty, s"rag-builder must not see: $leaked")
+    }
+
+    test("scope suffixes do not hide tools — scoped grants match on resource:action") {
+        // tap:run:owner=self must still surface run_tap; owner is call-time.
+        assert(MCPToolRoutes.allowedTools(key("tap:run:owner=self")).contains("run_tap"))
+        assert(MCPToolRoutes.allowedTools(key("secret:write:_type=tap")).contains("update_secret"))
+    }
+
+    test("read-only-shaped key gets reads plus local tools, nothing mutating") {
+        val readOnly = key(
+            "pipeline:read", "tap:read", "job:read", "metadata:read",
+            "config:read", "query:postgres", "query:mongodb", "search:vector"
+        )
+        val allowed = MCPToolRoutes.allowedTools(readOnly).toSet
+        assert(allowed.contains("list_pipelines"))
+        assert(allowed.contains("query_postgres"))
+        assert(allowed.contains("list_postgres_databases"))
+        assert(allowed.contains("wait_seconds"))
+        // No secret capabilities at all → every secret tool hidden.
+        assert(!allowed.exists(_.contains("secret")))
+        Seq("create_pipeline", "delete_pipeline", "run_tap", "kill_job", "set_tap_state", "upload_config")
+            .foreach(t => assert(!allowed.contains(t), s"read-only must not see $t"))
+    }
+
+    test("a key with no capabilities still sees the local tools") {
+        val none = key("nonexistent:nothing")
+        assert(MCPToolRoutes.allowedTools(none) == Seq("get_version", "check_service_health", "wait_seconds"))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/config/RoleGateSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/config/RoleGateSpec.scala
@@ -1,0 +1,52 @@
+package ai.datris.config
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{Capability, ResolvedKey}
+import org.scalatest.funsuite.AnyFunSuite
+
+class RoleGateSpec extends AnyFunSuite {
+
+    private def key(caps: String*): ResolvedKey =
+        ResolvedKey(None, "test-key", Capability.parseList(caps), isLegacyFullAccess = false)
+
+    private val full = ResolvedKey(None, "full", Seq(Capability.FullAccess), isLegacyFullAccess = true)
+
+    private def gate(rk: ResolvedKey, method: String, path: String): Boolean =
+        RoleEnforcementInterceptor.programmaticKeySatisfiesRoleGate(rk, method, path)
+
+    test("full-access key satisfies every role gate, mapped or not") {
+        assert(gate(full, "POST", "/api/v1/keys"))
+        assert(gate(full, "GET", "/api/v1/secrets"))
+        assert(gate(full, "POST", "/api/v1/users"))
+    }
+
+    test("scoped key satisfies a role gate on a capability-mapped route it holds") {
+        val rag = key("secret:read:_type=tap", "secret:write:_type=tap")
+        assert(gate(rag, "GET", "/api/v1/secrets"))
+        assert(gate(rag, "GET", "/api/v1/secrets/some-tap-secret"))
+        assert(gate(rag, "PUT", "/api/v1/secrets/some-tap-secret"))
+    }
+
+    test("scoped key never satisfies skip-listed admin surfaces (key minting, users)") {
+        val rag = key("secret:read:_type=tap", "secret:write:_type=tap", "tap:create", "pipeline:create")
+        assert(!gate(rag, "POST", "/api/v1/keys"))
+        assert(!gate(rag, "GET", "/api/v1/keys"))
+        assert(!gate(rag, "POST", "/api/v1/users"))
+        assert(!gate(rag, "POST", "/api/v1/auth/anything"))
+    }
+
+    test("scoped key without the route's capability is refused") {
+        val readOnly = key("secret:read")
+        assert(gate(readOnly, "GET", "/api/v1/secrets"))
+        assert(!gate(readOnly, "PUT", "/api/v1/secrets/x"))
+        assert(!gate(readOnly, "DELETE", "/api/v1/secrets/x"))
+    }
+
+    test("unmapped routes are refused for scoped keys") {
+        assert(!gate(key("tap:read"), "GET", "/api/v1/does-not-exist"))
+    }
+}

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -412,6 +412,9 @@ services:
       - "3000:3000"
     environment:
       DATRIS_API_URL: http://datris:8080
+      # Mirrors the server's USEAPIKEYS: when keys are on, MCP sessions
+      # without an x-api-key are rejected instead of silently connecting.
+      REQUIRE_API_KEY: ${USE_API_KEYS:-false}
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}
       EMBEDDING_ENDPOINT: ${EMBEDDING_ENDPOINT:-http://host.docker.internal:11434}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,6 +392,9 @@ services:
       - "3000:3000"
     environment:
       DATRIS_API_URL: http://datris:8080
+      # Mirrors the server's USEAPIKEYS: when keys are on, MCP sessions
+      # without an x-api-key are rejected instead of silently connecting.
+      REQUIRE_API_KEY: ${USE_API_KEYS:-false}
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}
       EMBEDDING_ENDPOINT: ${EMBEDDING_ENDPOINT:-http://host.docker.internal:11434}

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -27,6 +27,7 @@ import asyncio
 import contextvars
 import json
 import os
+import sys
 import threading
 import time
 import uuid
@@ -1357,8 +1358,52 @@ async def read_resource(uri):
 # MCP Tools
 # ---------------------------------------------------------------------------
 
+# Profile filter: ask the Scala server which tools this session's key may
+# see, so list_tools matches what the REST capability layer would actually
+# allow. The tool→route mapping lives ONLY on the server (MCPToolRoutes) —
+# never copy it here, it would drift. Cached per key with a short TTL so a
+# template edit applies on reconnect without hammering the endpoint.
+_allowed_tools_cache: dict[str, tuple[float, set | None]] = {}
+_allowed_tools_lock = threading.Lock()
+_ALLOWED_TOOLS_TTL = 60.0
+
+
+def _allowed_tool_names() -> set | None:
+    """Return the set of tool names this session's key may see, or None for
+    'no filtering' (keys off, legacy full-access key, or the server could
+    not answer — visibility is UX, the REST 403 stays the boundary)."""
+    key = _effective_api_key()
+    now = time.time()
+    with _allowed_tools_lock:
+        cached = _allowed_tools_cache.get(key)
+        if cached and now - cached[0] < _ALLOWED_TOOLS_TTL:
+            return cached[1]
+    allowed: set | None = None
+    try:
+        data = json.loads(_call("get", "/api/v1/mcp/tools", timeout=15))
+        if isinstance(data, dict) and data.get("filtered") and isinstance(data.get("tools"), list):
+            allowed = set(data["tools"])
+        elif isinstance(data, dict) and "error" in data:
+            # Unauthorized key or older server without the endpoint — fall
+            # back to the full catalog; every call still 403s at REST.
+            print(f"mcp/tools filter unavailable ({str(data['error'])[:120]}); serving full catalog", file=sys.stderr)
+    except (json.JSONDecodeError, TypeError) as e:
+        print(f"mcp/tools filter unavailable ({e}); serving full catalog", file=sys.stderr)
+    with _allowed_tools_lock:
+        _allowed_tools_cache[key] = (now, allowed)
+    return allowed
+
+
 @server.list_tools()
 async def list_tools():
+    allowed = await asyncio.to_thread(_allowed_tool_names)
+    tools = _all_tools()
+    if allowed is None:
+        return tools
+    return [t for t in tools if t.name in allowed]
+
+
+def _all_tools():
     return [
         # --- Pipeline Management ---
         Tool(
@@ -3594,6 +3639,15 @@ def _dispatch(name: str, args: dict) -> str:
 
 async def run_stdio():
     from mcp.server.stdio import stdio_server
+    # stdio has no headers — the key comes from the environment. Same
+    # REQUIRE_API_KEY contract as the SSE/HTTP transports: keys-on installs
+    # must not fall back to an unkeyed (full-catalog) session.
+    stdio_key = os.getenv("DATRIS_API_KEY", "")
+    if REQUIRE_API_KEY and not stdio_key:
+        print("REQUIRE_API_KEY is set but DATRIS_API_KEY is empty — set DATRIS_API_KEY "
+              "to this agent's API key in the MCP client config.", file=sys.stderr)
+        sys.exit(1)
+    _session_api_key.set(stdio_key)
     async with stdio_server() as (read_stream, write_stream):
         # Refresh the instructions' baked-in destination list for this session
         # (create_initialization_options reads server.instructions). to_thread


### PR DESCRIPTION
## What

MCP `list_tools` advertised all 63 tools to every session regardless of the API key's capabilities, so scoped keys planned around tools that could only ever 403 at REST. The catalog now matches what the capability layer actually enforces.

- **Server-owned filter**: `MCPToolRoutes` maps each MCP tool to its primary REST route; `GET /api/v1/mcp/tools` answers "which tools may this key see" from the same table `CapabilityInterceptor` enforces. The Python MCP server fetches the allowed set per session (60s TTL cache) and filters `list_tools` — it never owns a copy of the mapping, so the layers cannot drift. A tool with no mapping row stays hidden from scoped keys until classified (fail-closed); legacy `*:*` keys and keys-off installs always get the full catalog.
- **Closed a live enforcement hole**: `/api/v1/tap/state` (GET/POST/DELETE) was absent from `CapabilityRoutes`, and unmapped routes pass even in enforce mode — any scoped key could mutate tap sync state. Now mapped (read=`tap:read`, mutate=`tap:update`).
- **rag-builder template fixed**: added `tap:read` and `secret:read:_type=tap` so the canonical workflow (list secrets → create tap secret → create tap → test → run → poll) works end to end. Reads stay scoped to tap-typed secrets; no deletes, no `tap:update`.
- **Keyless sessions rejected when keys are on**: compose now mirrors `USE_API_KEYS` into the MCP server's `REQUIRE_API_KEY`; stdio reads `DATRIS_API_KEY` and refuses to start keyless under it. (`docker-compose.standalone.yml` regenerated.)
- **Role gate vs capability model**: with user auth + keys both on, `@RequiresRole("admin")` on the secrets endpoints rejected every scoped key even when its capabilities granted the route. Sessionless programmatic callers on a capability-mapped route now satisfy the role gate via the capability grant; skip-listed admin surfaces (key minting, user management) still require a full-access key.
- **Scoped secret creation fixed**: `putSecret` built its `_type` scope context only from the existing secret, so `_type=tap`-scoped keys could never create one. New secrets are scoped by the `_type` they declare; an existing secret's stored `_type` stays authoritative (no re-tagging platform secrets).
- Scope denials in secrets endpoints return clean 403 JSON (`CapabilityDeniedException`) instead of a stack-trace 500.

## Testing

- 231 unit tests green, including `MCPToolRoutesSpec` (9 tests, with a drift guard that every mapped tool resolves in `CapabilityRoutes`) and `RoleGateSpec` (5 tests on the role-gate boundary).
- Live E2E against the full docker stack, keys on + user auth on: **16/16 checks** — rag-builder key sees exactly 37 tools with `delete_pipeline` hidden, full-access key sees 63, keyless MCP sessions get 401, REST 403 backstops hold, full rag secrets workflow passes, platform secrets invisible and un-writable to scoped keys, key minting still full-access-only, and keys-off installs are byte-for-byte unchanged (full catalog, no key required).

## Compatibility

- Keys-off installs (OSS default): zero behavior change.
- Legacy `*:*` keys: unaffected everywhere.
- Keys-on operators: keyless MCP sessions are now rejected (previously slipped through unkeyed) — upgrade note needed. Existing issued keys keep their stored capabilities; re-issue rag-builder keys to pick up the template additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)