### PR TITLE
Clear all open code-scanning alerts (HIGH + MEDIUM) across the four images

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,10 @@
+# Findings accepted after review. Trivy reads this file from the repo root for
+# both the fs scan and the image scans in .github/workflows/security-scan.yml.
+
+# setuptools + msgpack VENDORED INSIDE pip (pip/_vendor/vendor.txt). Even the
+# newest pip release pins setuptools 70.3.0 (pkg_resources subset) and msgpack
+# 1.1.2 there; no pip upgrade clears these, and the vulnerable code paths
+# (PackageIndex.download, msgpack unpacking of untrusted streams) are not
+# reachable through pip's vendored usage. Re-check when pip bumps its vendor set.
+CVE-2025-47273
+GHSA-6v7p-g79w-8964

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,4 +7,5 @@
 # (PackageIndex.download, msgpack unpacking of untrusted streams) are not
 # reachable through pip's vendored usage. Re-check when pip bumps its vendor set.
 CVE-2025-47273
+CVE-2026-59890
 GHSA-6v7p-g79w-8964

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
 FROM eclipse-temurin:17-jre@sha256:13cc28a6cc72a38ce1f00c906be3580c1a3e604b8984d694f369a96742abc93b
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3 python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
+# pebble is a loose (non-dpkg) service-manager binary shipped in the Ubuntu base;
+# nothing here uses it and its bundled Go stdlib trips Trivy, so drop it.
+RUN rm -f /usr/bin/pebble
 RUN pip3 install --break-system-packages requests beautifulsoup4 pandas lxml feedparser boto3 pyyaml openpyxl python-dateutil pytz google-cloud-storage azure-storage-blob
 ARG JAR_FILE=datrisserver/target/scala-*/*.jar
 RUN mkdir -p /usr/src/datrisserver /usr/src/datrisserver/config
@@ -10,4 +13,8 @@ RUN chmod +x /usr/src/datrisserver/docker-init.sh
 RUN groupadd -r datris && useradd -r -g datris -d /usr/src/datrisserver datris \
     && chown -R datris:datris /usr/src/datrisserver
 USER datris
+# Liveness only (any HTTP response counts): /api/v1/health/services probes every
+# backend and is too slow/heavy for a container healthcheck.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
+  CMD curl -s -o /dev/null http://127.0.0.1:8080/ || exit 1
 ENTRYPOINT ["/usr/src/datrisserver/docker-init.sh"]

--- a/mcp-server/.dockerignore
+++ b/mcp-server/.dockerignore
@@ -1,4 +1,7 @@
 my-env
+.venv
+venv
+dist
 __pycache__
 .env
 *.md

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -5,6 +5,9 @@ LABEL io.modelcontextprotocol.server.name="io.github.datris/datris"
 
 WORKDIR /app
 
+# The pip bundled with the slim image lags behind its own security fixes.
+RUN pip install --no-cache-dir --upgrade pip
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,5 +1,5 @@
 # Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
-FROM python:3.12-slim@sha256:2c941e860699f878900b0edc2403613c234d4b32eda3cc9fa7036991a2a63c4a
+FROM python:3.12-slim@sha256:7a8b475003c4fe15a2cd4e55e5cfc2f3560bdc9333d624f24cdd6d4340fd7a17
 
 LABEL io.modelcontextprotocol.server.name="io.github.datris/datris"
 
@@ -14,5 +14,9 @@ RUN groupadd -r mcp && useradd -r -g mcp -d /app mcp && chown -R mcp:mcp /app
 USER mcp
 
 EXPOSE 3000
+
+# TCP-connect liveness: the SSE endpoint streams, so an HTTP GET would hang.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD python -c "import socket; socket.create_connection(('127.0.0.1', 3000), timeout=3)" || exit 1
 
 CMD ["python", "server.py", "--sse", "--port", "3000"]

--- a/tap-runner/Dockerfile
+++ b/tap-runner/Dockerfile
@@ -1,7 +1,10 @@
 # datris-tap-runner — isolated tap execution sidecar (tap-execution-isolation Phase 3).
 # Holds NO platform secrets: no JVM, no Vault, no /datris/.env, no /config, no Docker socket.
 # Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
-FROM python:3.12-slim-bookworm@sha256:a116514e19457bcb7af7efe9c3dd0b9b71e85b317694e7882a1c52aa15a78134
+FROM python:3.12-slim-bookworm@sha256:0f5b26b9518d002b6173fd61daad821fa340635ebfec5bba471013f9ca114579
+
+# The pip bundled with the bookworm image lags behind its own security fixes.
+RUN pip install --no-cache-dir --upgrade pip
 
 # Pre-bake the same common package set the server image carries, so taps that don't
 # declare extras run with no per-run install. (Tap-declared extras install into a
@@ -18,4 +21,6 @@ WORKDIR /app
 COPY app.py /app/app.py
 USER runner
 EXPOSE 8090
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/health', timeout=3)" || exit 1
 ENTRYPOINT ["python3", "/app/app.py"]

--- a/tap-runner/Dockerfile
+++ b/tap-runner/Dockerfile
@@ -3,8 +3,8 @@
 # Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
 FROM python:3.12-slim-bookworm@sha256:0f5b26b9518d002b6173fd61daad821fa340635ebfec5bba471013f9ca114579
 
-# The pip bundled with the bookworm image lags behind its own security fixes.
-RUN pip install --no-cache-dir --upgrade pip
+# The pip/setuptools bundled with the bookworm image lag behind their own security fixes.
+RUN pip install --no-cache-dir --upgrade pip setuptools
 
 # Pre-bake the same common package set the server image carries, so taps that don't
 # declare extras run with no per-run install. (Tap-declared extras install into a

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -15,3 +15,5 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # explicit USER makes that visible to image scanners (Trivy DS-0002).
 USER nginx
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q --spider http://127.0.0.1:8080/ || exit 1


### PR DESCRIPTION
## Summary
Clears all 82 open code-scanning alerts plus the follow-on findings local Trivy verification surfaced. All four images (`datris-server`, `datris-mcp-server`, `datris-tap-runner`, `datris-ui`) now scan **0 MEDIUM/HIGH/CRITICAL** locally with the same Trivy settings CI uses (`--ignore-unfixed`).

- **mcp-server**: bump `python:3.12-slim` digest (util-linux family fixed in 2.41.5-0+deb13u1 — 63 alerts); upgrade the base's bundled pip; `.dockerignore` the local `.venv`/`dist` that `COPY . .` was baking into the image (15 stale-package HIGHs)
- **server**: `apt-get upgrade` in the build (curl CVE-2026-11856) and drop the unused loose `pebble` binary from the Ubuntu base (8 HIGH Go stdlib CVEs) — upstream temurin:17-jre hasn't rebuilt yet
- **tap-runner**: bump `python:3.12-slim-bookworm` digest; upgrade bundled pip + setuptools
- **all four Dockerfiles**: add `HEALTHCHECK` (Trivy DS-0026)
- **`.trivyignore`** (new): accept the three findings against packages vendored inside pip itself (`pip/_vendor` pins setuptools 70.3.0 + msgpack 1.1.2 even at latest pip); no upgrade clears them

## Test plan
- Built all four images locally; Trivy-scanned each at MEDIUM,HIGH,CRITICAL with `--ignore-unfixed`: zero findings
- Ran tap-runner, mcp-server, and UI containers to `healthy` (new HEALTHCHECKs verified live); server healthcheck is a plain curl liveness probe
- Verified pebble removed and curl at 8.18.0-1ubuntu2.4 in the server image; pip 26.2.1/setuptools 84 in the Python images

The GitHub alerts close after the next release rebuilds `:latest` and the weekly image scan reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)