### PR TITLE
Generation & thinking feedback: live progress everywhere the platform used to go silent

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
@@ -330,6 +330,12 @@ class AssistantAPIController {
         )
         sb.append("- Always check existing taps/pipelines first via `list_taps` and `list_pipelines` before creating new ones.\n")
         sb.append(
+            "- **Set expectations before slow tools.** Calling `create_tap` with an `instruction` triggers server-side AI script generation that typically takes 1–3 minutes with no intermediate output. In the same message that announces the call, tell the user what to expect: \"Generating the tap script with AI — this usually takes a minute or two.\" Same for `create_pipeline` on a large file. Never let a multi-minute tool run start without having told the user roughly how long it takes.\n"
+        )
+        sb.append(
+            "- **If script generation fails, write the script yourself — that IS the standard recovery, not a workaround.** A `create_tap` error like \"doesn't define a fetch() function\" or \"returned narrative text\" means the server-side generator misfired. Do not retry the same instruction (another 1–3 silent minutes for the same likely outcome) and do not just report failure. For any API you know well, compose the Python `fetch()` script directly and call `create_tap` again passing it via `script`. Tell the user in one sentence: generation failed, you wrote the script directly.\n"
+        )
+        sb.append(
             "- Tap secrets must be tagged `_type=tap`. When you call `create_tap_secret`, the platform sets that automatically — don't try to set `_type` yourself.\n"
         )
         sb.append(

--- a/datrisserver/src/main/scala/ai/datris/api/TapAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/TapAPIController.scala
@@ -677,6 +677,39 @@ class TapAPIController {
         }
     }
 
+    /** Live progress of an in-flight `/tap/generate` for this tap, so a client
+      * can show what the 1–3 minute blocking call is doing. `active: false`
+      * means no generation is running — either it finished (the blocking call
+      * carries the outcome) or none was started. Deliberately not logged per
+      * call: clients poll this every couple of seconds. */
+    @GetMapping(path = Array("/tap/generate/status"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def generateStatus(
+        @RequestHeader(name = "x-api-key", required = false) apiKey: String,
+        @RequestParam tap: String
+    ): ResponseEntity[String] = {
+        try {
+            APIKeyValidator.validate(apiKey)
+            val gson = new Gson
+            val response = new java.util.LinkedHashMap[String, Any]()
+            TapGenerationProgress.get(tap) match {
+                case Some(p) =>
+                    val now = System.currentTimeMillis()
+                    response.put("active", java.lang.Boolean.TRUE)
+                    response.put("phase", p.phase)
+                    response.put("attempt", Integer.valueOf(p.attempt))
+                    response.put("elapsedSeconds", java.lang.Long.valueOf((now - p.startedAtMs) / 1000))
+                    response.put("phaseElapsedSeconds", java.lang.Long.valueOf((now - p.phaseStartedAtMs) / 1000))
+                case None =>
+                    response.put("active", java.lang.Boolean.FALSE)
+            }
+            new ResponseEntity[String](gson.toJson(response), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
+        }
+    }
+
     @PostMapping(path = Array("/tap/fix"), consumes = Array(MediaType.APPLICATION_JSON_VALUE), produces = Array(MediaType.APPLICATION_JSON_VALUE))
     def fixScript(
         @RequestHeader(name = "x-api-key", required = false) apiKey: String,

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -85,6 +85,7 @@ object CapabilityRoutes {
         Route("POST", "/api/v1/tap/script", "tap", "update"),
         Route("POST", "/api/v1/tap/test", "tap", "run"),
         Route("POST", "/api/v1/tap/generate", "tap", "create"),
+        Route("GET", "/api/v1/tap/generate/status", "tap", "read"),
         Route("POST", "/api/v1/tap/fix", "tap", "update"),
         Route("POST", "/api/v1/tap/review", "tap", "read"),
         Route("POST", "/api/v1/tap/optimize", "tap", "update"),

--- a/datrisserver/src/main/scala/ai/datris/util/TapGenerationProgress.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapGenerationProgress.scala
@@ -1,0 +1,50 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisEnvironment
+
+import java.util.concurrent.ConcurrentHashMap
+
+/** Live progress of in-flight tap script generations, so the UI can show what
+  * a 1–3 minute blocking `/tap/generate` call is actually doing instead of a
+  * silent spinner. In-memory only: generation is a single-server, short-lived
+  * operation and its progress is worthless after the request returns.
+  *
+  * Phases: `calling-model` → (`retrying-format` on a parse failure) → `storing`.
+  * Entries are removed in the generator's finally block; a poll after removal
+  * (or after a restart) reports inactive, which the UI treats as "the request
+  * itself will tell me the outcome". */
+object TapGenerationProgress {
+
+    case class Progress(phase: String, attempt: Int, startedAtMs: Long, phaseStartedAtMs: Long)
+
+    private val active = new ConcurrentHashMap[String, Progress]()
+
+    /** Tenant-scoped key: two tenants may generate same-named taps concurrently. */
+    private def key(tapName: String): String = DatrisEnvironment.current.environment + "|" + tapName
+
+    def start(tapName: String): Unit = {
+        val now = System.currentTimeMillis()
+        active.put(key(tapName), Progress("calling-model", 1, now, now))
+    }
+
+    def phase(tapName: String, phase: String, attempt: Int = 0): Unit = {
+        val k = key(tapName)
+        val existing = active.get(k)
+        if (existing != null) {
+            val a = if (attempt > 0) attempt else existing.attempt
+            active.put(k, existing.copy(phase = phase, attempt = a, phaseStartedAtMs = System.currentTimeMillis()))
+        }
+    }
+
+    def finish(tapName: String): Unit = {
+        active.remove(key(tapName))
+    }
+
+    /** None when no generation is in flight for this tap. */
+    def get(tapName: String): Option[Progress] = Option(active.get(key(tapName)))
+}

--- a/datrisserver/src/main/scala/ai/datris/util/TapScriptGenerator.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapScriptGenerator.scala
@@ -242,6 +242,22 @@ object TapScriptGenerator {
         if (!DatrisEnvironment.current.aiEnabled)
             throw new DatrisException("AI is not enabled. Set 'ai.enabled: true' in application.yaml")
 
+        TapGenerationProgress.start(tapName)
+        try {
+            generateInternal(description, tapName, oldScriptPath, secretName, tapType)
+        } finally {
+            TapGenerationProgress.finish(tapName)
+        }
+    }
+
+    private def generateInternal(
+        description: String,
+        tapName: String,
+        oldScriptPath: String,
+        secretName: String,
+        tapType: String
+    ): TapGenerateResult = {
+
         // Build user prompt with available secret keys if configured
         val secretKeysHint = if (secretName != null && secretName.nonEmpty) {
             val secretPath = DatrisEnvironment.current.environment + "/" + secretName
@@ -322,7 +338,12 @@ object TapScriptGenerator {
         // packages manually in Edit & Test.
         val (script, packages): (String, java.util.List[String]) =
             tryParseAsJsonObject(cleaned).orElse {
-                logger.warn("TapScriptGenerator: first response did not parse as JSON — retrying with format reminder")
+                // Log the head of the unparseable response: without it a systematic
+                // envelope break (a model preamble, a new fence style) is invisible
+                // in the logs and costs a full extra generation on every tap.
+                logger.warn("TapScriptGenerator: first response did not parse as JSON — retrying with format reminder. " +
+                    "Response head: " + cleaned.take(400).replace("\n", "\\n"))
+                TapGenerationProgress.phase(tapName, "retrying-format", attempt = 2)
                 val preview = if (cleaned.length > 2000) cleaned.take(2000) + "\n... (truncated)" else cleaned
                 val retrySystemPrompt =
                     """Return ONLY a JSON object with exactly two fields:
@@ -380,6 +401,7 @@ object TapScriptGenerator {
             )
 
         // Store script in MinIO (cleanup old)
+        TapGenerationProgress.phase(tapName, "storing")
         val scriptPath = storeScript(tapName, script, oldScriptPath)
 
         logger.info("TapScriptGenerator: script stored at: " + scriptPath + ", packages: " + packages)

--- a/datrisserver/src/main/scala/ai/datris/util/aiutil/AIHttp.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/aiutil/AIHttp.scala
@@ -125,7 +125,12 @@ object AIHttp {
                     result =
                         if (contentType.startsWith("text/event-stream")) assembleEventStream(response.getEntity)
                         else EntityUtils.toString(response.getEntity, StandardCharsets.UTF_8)
-                    logger.info("AI API responded in " + elapsedMs + "ms, response length: " + result.length + " chars")
+                    // Measure through body/stream assembly: execute() returns at the
+                    // response HEADERS, and for SSE the generation happens while the
+                    // stream is consumed — headers-only timing once logged a 104s
+                    // codegen call as "1137ms" and sent a live debug down a dead end.
+                    val totalMs = System.currentTimeMillis() - startTime
+                    logger.info("AI API responded in " + totalMs + "ms (first byte " + elapsedMs + "ms), response length: " + result.length + " chars")
                 }
             } catch {
                 // Dropped/stale connections (e.g. an intermediary closing a

--- a/datrisserver/src/main/scala/ai/datris/util/aiutil/AIStreaming.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/aiutil/AIStreaming.scala
@@ -199,6 +199,10 @@ object AIStreaming {
         if (msg == null) return false
         val m = msg.toLowerCase
         m.contains("thinking.type") ||
+        // display: "summarized" is sent with the adaptive form; a model that
+        // takes adaptive but rejects the display field should fall down the
+        // ladder like any other thinking-shape rejection.
+        m.contains("thinking.display") ||
         (m.contains("thinking") && m.contains("not supported")) ||
         m.contains("output_config") ||
         // Bedrock validates the invoke body against a per-model schema and
@@ -236,6 +240,11 @@ object AIStreaming {
             case ThinkingForm.Adaptive =>
                 val thinkingObj = new JsonObject()
                 thinkingObj.addProperty("type", "adaptive")
+                // Claude 5-family default is display "omitted": thinking blocks
+                // stream with EMPTY text, so the UI's reasoning block/ticker
+                // never appears and a long think reads as a hang. "summarized"
+                // streams a readable summary; billing is identical either way.
+                thinkingObj.addProperty("display", "summarized")
                 req.add("thinking", thinkingObj)
                 val outputCfg = new JsonObject()
                 outputCfg.addProperty("effort", "medium")
@@ -543,6 +552,11 @@ object AIStreaming {
             case ThinkingForm.Adaptive =>
                 val thinkingObj = new JsonObject()
                 thinkingObj.addProperty("type", "adaptive")
+                // Claude 5-family default is display "omitted": thinking blocks
+                // stream with EMPTY text, so the UI's reasoning block/ticker
+                // never appears and a long think reads as a hang. "summarized"
+                // streams a readable summary; billing is identical either way.
+                thinkingObj.addProperty("display", "summarized")
                 req.add("thinking", thinkingObj)
                 val outputCfg = new JsonObject()
                 outputCfg.addProperty("effort", "medium")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1868,6 +1868,43 @@ paths:
                   scriptPath:
                     type: string
 
+  /api/v1/tap/generate/status:
+    get:
+      tags: [Taps]
+      summary: Live progress of an in-flight script generation
+      description: >-
+        Reports what a blocking `/tap/generate` call is currently doing so
+        clients can show real progress during the 1–3 minute wait. Poll every
+        few seconds while a generate request is in flight. `active: false`
+        means no generation is running for this tap.
+      parameters:
+        - name: tap
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Progress snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: boolean
+                  phase:
+                    type: string
+                    enum: [calling-model, retrying-format, storing]
+                  attempt:
+                    type: integer
+                  elapsedSeconds:
+                    type: integer
+                  phaseElapsedSeconds:
+                    type: integer
+        '500':
+          description: Error
+
   /api/v1/tap/fix:
     post:
       tags: [Taps]

--- a/ui/src/app/assistant/assistant-state.service.ts
+++ b/ui/src/app/assistant/assistant-state.service.ts
@@ -23,6 +23,10 @@ export interface ToolCard {
    *  reads as visible progress instead of a frozen spinner. */
   startedAt?: number;
   executingSince?: number;
+  /** Live server-side phase for a running `create_tap` script generation,
+   *  polled from /tap/generate/status — replaces the generic "still working"
+   *  hint with what the generation is actually doing. */
+  genProgress?: { active: boolean; phase?: string; attempt?: number; elapsedSeconds?: number };
   /** Populated when the agent called `request_tap_secret_from_user`. The UI
    *  renders an inline credentials form using these fields. */
   secretRequest?: {

--- a/ui/src/app/assistant/assistant-state.service.ts
+++ b/ui/src/app/assistant/assistant-state.service.ts
@@ -75,6 +75,11 @@ export interface AssistantTurn {
   segments: AssistantSegment[];
   done: boolean;
   errorMessage: string;
+  /** Last moment the user could SEE progress — turn start, a text delta, a
+   *  tool card appearing, or a tool result. Drives the "thinking — 45s"
+   *  elapsed on the streaming dots, so a long adaptive-thinking stretch
+   *  (which streams nothing visible) doesn't read as a hang. */
+  lastVisibleProgressAt?: number;
 }
 
 export type Turn = UserTurn | AssistantTurn;
@@ -198,7 +203,8 @@ export class AssistantStateService {
       thinkingExpanded: false,
       segments: [],
       done: false,
-      errorMessage: ''
+      errorMessage: '',
+      lastVisibleProgressAt: Date.now()
     };
     this.turns.push(assistantTurn);
     this.draft = '';
@@ -276,6 +282,10 @@ export class AssistantStateService {
   }
 
   private handleEvent(evt: AssistantEvent, turn: AssistantTurn): void {
+    // Anything the user can see counts as visible progress: streamed text, a
+    // tool card appearing, a result landing, a thinking ticker updating.
+    // Only iteration boundaries don't (nothing on screen changes).
+    if (evt.type !== 'iteration_start') turn.lastVisibleProgressAt = Date.now();
     switch (evt.type) {
       case 'iteration_start':
         break;

--- a/ui/src/app/assistant/assistant-state.service.ts
+++ b/ui/src/app/assistant/assistant-state.service.ts
@@ -80,6 +80,11 @@ export interface AssistantTurn {
    *  elapsed on the streaming dots, so a long adaptive-thinking stretch
    *  (which streams nothing visible) doesn't read as a hang. */
   lastVisibleProgressAt?: number;
+  /** When the last thinking_delta arrived. The turn's thinking renders as one
+   *  block at the TOP of the turn, so mid-turn reasoning (between tool calls)
+   *  lands far above where the user is reading — the streaming dots use this
+   *  to show the live thinking tail inline while summaries are arriving. */
+  lastThinkingDeltaAt?: number;
 }
 
 export type Turn = UserTurn | AssistantTurn;
@@ -291,6 +296,7 @@ export class AssistantStateService {
         break;
       case 'thinking_delta':
         turn.thinking += evt.text;
+        turn.lastThinkingDeltaAt = Date.now();
         break;
       case 'text_delta': {
         const tail = turn.segments[turn.segments.length - 1];

--- a/ui/src/app/assistant/assistant.component.css
+++ b/ui/src/app/assistant/assistant.component.css
@@ -496,6 +496,18 @@
   color: #8a8e96;
   font-variant-numeric: tabular-nums;
 }
+.streaming-thinking-tail {
+  margin-left: 10px;
+  font-size: 12px;
+  font-style: italic;
+  color: #8a8e96;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+  display: inline-block;
+  vertical-align: middle;
+}
 .dots {
   display: inline-flex;
   gap: 4px;

--- a/ui/src/app/assistant/assistant.component.css
+++ b/ui/src/app/assistant/assistant.component.css
@@ -490,6 +490,12 @@
   margin: 8px 0;
   color: #8a8e96;
 }
+.streaming-elapsed {
+  margin-left: 10px;
+  font-size: 12px;
+  color: #8a8e96;
+  font-variant-numeric: tabular-nums;
+}
 .dots {
   display: inline-flex;
   gap: 4px;

--- a/ui/src/app/assistant/assistant.component.html
+++ b/ui/src/app/assistant/assistant.component.html
@@ -103,12 +103,17 @@
                 </button>
 
                 <!-- Long-running call: say what's happening so the spinner
-                     doesn't read as a hang. AI generations legitimately take
-                     minutes, and transient provider errors retry server-side
-                     inside this same call. -->
-                <div class="tool-slow-hint" *ngIf="toolSlowHint(seg)">
-                  Still working — AI generations can take a few minutes, and temporary provider errors are retried automatically.
+                     doesn't read as a hang. For create_tap script generation
+                     the server reports its live phase; anything else gets the
+                     generic reassurance after 45s. -->
+                <div class="tool-slow-hint" *ngIf="toolGenHint(seg) as genHint; else genericSlowHint">
+                  {{ genHint }}
                 </div>
+                <ng-template #genericSlowHint>
+                  <div class="tool-slow-hint" *ngIf="toolSlowHint(seg)">
+                    Still working — AI generations can take a few minutes, and temporary provider errors are retried automatically.
+                  </div>
+                </ng-template>
 
                 <!-- Inline credentials form: rendered instead of the generic
                      tool body when this is a request_tap_secret_from_user

--- a/ui/src/app/assistant/assistant.component.html
+++ b/ui/src/app/assistant/assistant.component.html
@@ -210,6 +210,9 @@
                  after a tool completes while the model digests the result. -->
             <div class="streaming-indicator" *ngIf="!turn.done && state.streaming && !hasRunningTool(turn)">
               <span class="dots"><span></span><span></span><span></span></span>
+              <!-- After 10s with nothing visible (adaptive thinking streams no
+                   content), say how long — silence with a clock beats silence. -->
+              <span class="streaming-elapsed" *ngIf="streamingElapsedLabel(turn)">{{ streamingElapsedLabel(turn) }}</span>
             </div>
 
             <!-- Action links: Open tap / Open pipeline -->

--- a/ui/src/app/assistant/assistant.component.html
+++ b/ui/src/app/assistant/assistant.component.html
@@ -210,9 +210,15 @@
                  after a tool completes while the model digests the result. -->
             <div class="streaming-indicator" *ngIf="!turn.done && state.streaming && !hasRunningTool(turn)">
               <span class="dots"><span></span><span></span><span></span></span>
-              <!-- After 10s with nothing visible (adaptive thinking streams no
-                   content), say how long — silence with a clock beats silence. -->
-              <span class="streaming-elapsed" *ngIf="streamingElapsedLabel(turn)">{{ streamingElapsedLabel(turn) }}</span>
+              <!-- Live thinking tail while summaries arrive — mid-turn
+                   reasoning otherwise lands in the block at the turn's top,
+                   far above the reading position. -->
+              <span class="streaming-thinking-tail" *ngIf="streamingThinkingTail(turn) as tail; else elapsedOnly">{{ tail }}</span>
+              <!-- After 10s with nothing visible at all, say how long —
+                   silence with a clock beats silence. -->
+              <ng-template #elapsedOnly>
+                <span class="streaming-elapsed" *ngIf="streamingElapsedLabel(turn)">{{ streamingElapsedLabel(turn) }}</span>
+              </ng-template>
             </div>
 
             <!-- Action links: Open tap / Open pipeline -->

--- a/ui/src/app/assistant/assistant.component.ts
+++ b/ui/src/app/assistant/assistant.component.ts
@@ -118,6 +118,17 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
       (this.nowTick - seg.executingSince) >= 45000;
   }
 
+  /** Elapsed label for a silent streaming stretch — long adaptive-thinking
+   *  runs stream nothing visible, and bare dots read as a hang after a
+   *  while. Empty until 10s of no visible progress, then "thinking — 45s". */
+  streamingElapsedLabel(turn: AssistantTurn): string {
+    if (turn.done || !turn.lastVisibleProgressAt) return '';
+    const s = Math.floor((this.nowTick - turn.lastVisibleProgressAt) / 1000);
+    if (s < 10) return '';
+    const label = s < 60 ? s + 's' : Math.floor(s / 60) + 'm ' + String(s % 60).padStart(2, '0') + 's';
+    return 'thinking — ' + label;
+  }
+
   /** Per-card last-poll timestamps for the tap-generation progress poll. */
   private genPollLast = new Map<string, number>();
 

--- a/ui/src/app/assistant/assistant.component.ts
+++ b/ui/src/app/assistant/assistant.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewInit, Aft
 import { ActivatedRoute } from '@angular/router';
 import { AssistantStateService, AssistantTurn, ToolCard, TextSegment } from './assistant-state.service';
 import { SecretsService } from '../secrets.service';
+import { TapService } from '../tap.service';
 
 interface StarterPrompt {
   label: string;
@@ -45,6 +46,7 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
   constructor(
     public state: AssistantStateService,
     private secretsService: SecretsService,
+    private tapService: TapService,
     private route: ActivatedRoute,
     private zone: NgZone
   ) { }
@@ -54,7 +56,10 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
     this.scrollPending = true;
     this.zone.runOutsideAngular(() => {
       this.tickHandle = setInterval(() => {
-        if (this.state.streaming) this.zone.run(() => { this.nowTick = Date.now(); });
+        if (this.state.streaming) {
+          this.zone.run(() => { this.nowTick = Date.now(); });
+          this.pollTapGeneration();
+        }
       }, 1000);
     });
 
@@ -111,6 +116,48 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
   toolSlowHint(seg: ToolCard): boolean {
     return seg.status === 'running' && !!seg.executingSince &&
       (this.nowTick - seg.executingSince) >= 45000;
+  }
+
+  /** Per-card last-poll timestamps for the tap-generation progress poll. */
+  private genPollLast = new Map<string, number>();
+
+  /** While a `create_tap` with an `instruction` is executing, poll the
+   *  server's generation-progress endpoint (every ~3s per card, starting a
+   *  few seconds in) so the card can say what the 1–3 minute call is doing.
+   *  Best-effort: a failed poll just leaves the generic hint in place. */
+  private pollTapGeneration(): void {
+    const turn = this.state.turns[this.state.turns.length - 1];
+    if (!turn || turn.role !== 'assistant') return;
+    for (const seg of turn.segments) {
+      if (seg.kind !== 'tool' || seg.status !== 'running' || seg.name !== 'create_tap') continue;
+      const tapName = seg.input && seg.input.name;
+      if (!tapName || !seg.input.instruction || !seg.executingSince) continue;
+      if (this.nowTick - seg.executingSince < 4000) continue;
+      const last = this.genPollLast.get(seg.id) || 0;
+      if (this.nowTick - last < 3000) continue;
+      this.genPollLast.set(seg.id, this.nowTick);
+      this.tapService.generateStatus(tapName).subscribe({
+        next: (s) => this.zone.run(() => { seg.genProgress = s && s.active ? s : undefined; }),
+        error: () => { /* keep the generic hint */ }
+      });
+    }
+  }
+
+  /** Phase-specific text for a running create_tap generation; empty when no
+   *  live progress is known (the generic slow hint covers that case). */
+  toolGenHint(seg: ToolCard): string {
+    const p = seg.genProgress;
+    if (seg.status !== 'running' || !p || !p.active) return '';
+    const s = p.elapsedSeconds || 0;
+    const elapsed = s < 60 ? s + 's' : Math.floor(s / 60) + 'm ' + String(s % 60).padStart(2, '0') + 's';
+    switch (p.phase) {
+      case 'retrying-format':
+        return 'Model output needed reformatting — running a second attempt (' + elapsed + ' total).';
+      case 'storing':
+        return 'Storing the generated script…';
+      default:
+        return 'Generating the tap script with AI — ' + elapsed + ' so far (typically 1–3 minutes).';
+    }
   }
 
   /** Ensure the existing tap secrets list is loaded for the form dropdown.

--- a/ui/src/app/assistant/assistant.component.ts
+++ b/ui/src/app/assistant/assistant.component.ts
@@ -129,6 +129,17 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
     return 'thinking — ' + label;
   }
 
+  /** Live thinking tail for the streaming dots. The turn's full reasoning
+   *  renders in one block at the TOP of the turn, so mid-turn thinking
+   *  (between tool calls) would otherwise scroll in far above the reading
+   *  position. Shown only while summaries are actively arriving (a delta in
+   *  the last 8s) — a stale tail during a non-thinking wait would mislead. */
+  streamingThinkingTail(turn: AssistantTurn): string {
+    if (turn.done || !turn.thinking || !turn.lastThinkingDeltaAt) return '';
+    if (this.nowTick - turn.lastThinkingDeltaAt > 8000) return '';
+    return this.thinkingTicker(turn);
+  }
+
   /** Per-card last-poll timestamps for the tap-generation progress poll. */
   private genPollLast = new Map<string, number>();
 

--- a/ui/src/app/tap-create/tap-create.component.html
+++ b/ui/src/app/tap-create/tap-create.component.html
@@ -292,7 +292,7 @@
 
       <div class="testing-indicator" *ngIf="generating">
         <div class="spinner"></div>
-        <span>Generating script — this may take a minute...</span>
+        <span>{{ genProgressLabel() }}</span>
         <button class="indicator-stop-btn" (click)="stopActive()" title="Stop">
           <span class="material-icons">stop</span>
         </button>

--- a/ui/src/app/tap-create/tap-create.component.ts
+++ b/ui/src/app/tap-create/tap-create.component.ts
@@ -376,6 +376,7 @@ export class TapCreateComponent implements OnInit, OnDestroy {
     this.testing = false;
     this.applyingDiagnosis = false;
     this.brainstorming = false;
+    this.stopGenPolling();
   }
 
   nextStep(): void {
@@ -436,9 +437,16 @@ export class TapCreateComponent implements OnInit, OnDestroy {
     });
   }
 
+  // Live phase of the in-flight generate call, polled from
+  // /tap/generate/status so the minute-plus wait shows real progress
+  // instead of a static "may take a minute" line.
+  genProgress: any = null;
+  private genPollHandle?: ReturnType<typeof setInterval>;
+
   generateScript(): void {
     this.generating = true;
     this.error = '';
+    this.startGenPolling();
     this.activeSub = this.tapService.generateScript(this.description, this.tapName.trim(), this.scriptPath, this.secretName, this.tapType).subscribe({
       next: (result) => {
         this.script = result.script || '';
@@ -446,13 +454,51 @@ export class TapCreateComponent implements OnInit, OnDestroy {
         this.packages = result.packages || [];
         if (Array.isArray(result.injectedPrompts)) this.injectedPrompts = result.injectedPrompts;
         this.generating = false;
+        this.stopGenPolling();
         this.scriptDirty = true;
       },
       error: (err) => {
         this.error = 'Generation failed: ' + (err.error || err.message);
         this.generating = false;
+        this.stopGenPolling();
       }
     });
+  }
+
+  private startGenPolling(): void {
+    this.stopGenPolling();
+    const tap = this.tapName.trim();
+    if (!tap) return;
+    this.genPollHandle = setInterval(() => {
+      if (!this.generating) { this.stopGenPolling(); return; }
+      this.tapService.generateStatus(tap).subscribe({
+        next: (s) => { this.genProgress = s && s.active ? s : null; },
+        error: () => { /* progress is best-effort; the generate call itself reports the outcome */ }
+      });
+    }, 3000);
+  }
+
+  private stopGenPolling(): void {
+    if (this.genPollHandle) { clearInterval(this.genPollHandle); this.genPollHandle = undefined; }
+    this.genProgress = null;
+  }
+
+  /** Human line for the generating indicator; falls back to the static text
+   *  until the first poll lands. */
+  genProgressLabel(): string {
+    const p = this.genProgress;
+    if (!p || !p.active) return 'Generating script — this may take a minute...';
+    const mins = Math.floor((p.elapsedSeconds || 0) / 60);
+    const secs = (p.elapsedSeconds || 0) % 60;
+    const elapsed = mins > 0 ? mins + 'm ' + String(secs).padStart(2, '0') + 's' : secs + 's';
+    switch (p.phase) {
+      case 'retrying-format':
+        return 'Model output needed reformatting — running a second attempt (' + elapsed + ' total)...';
+      case 'storing':
+        return 'Storing the generated script...';
+      default:
+        return 'Generating script with AI — ' + elapsed + ' so far (typically 1–3 minutes)...';
+    }
   }
 
   regenerateScript(): void {

--- a/ui/src/app/tap.service.ts
+++ b/ui/src/app/tap.service.ts
@@ -36,6 +36,13 @@ export class TapService {
     return this.http.post<any>('/api/v1/tap/generate', { description, tapName, oldScriptPath: oldScriptPath || null, secretName: secretName || null, tapType: tapType || 'structured' });
   }
 
+  /** Live phase of an in-flight generateScript call for this tap — polled
+   *  while the blocking generate request runs, so the wait shows real
+   *  progress ({active, phase, attempt, elapsedSeconds}). */
+  generateStatus(tapName: string): Observable<any> {
+    return this.http.get<any>('/api/v1/tap/generate/status', { params: { tap: tapName } });
+  }
+
   storeScript(tapName: string, script: string, oldScriptPath?: string, storage?: string, baseCommitSha?: string): Observable<any> {
     return this.http.post<any>('/api/v1/tap/script', {
       tapName, script,


### PR DESCRIPTION
## Summary

A live Assistant session surfaced how much of the build flow runs in silence: tap script generation ran 3.5 minutes with no output (two ~100s codegen attempts, both failing the JSON envelope), the AI latency log claimed "1137ms" for a 104-second call, and long adaptive-thinking stretches showed bare dots indistinguishable from a hang. This PR adds feedback at every silent stage.

### Server
- **`TapGenerationProgress`** — in-memory phase tracker around script generation (`calling-model` → `retrying-format` → `storing`), exposed at `GET /api/v1/tap/generate/status` (capability `tap:read`; polled, deliberately unlogged per call).
- **Honest AI timing** — `AIHttp` now measures through SSE stream assembly and logs total + first-byte (`execute()` returns at headers; generation happens while the stream is consumed).
- **Parse-failure evidence** — `TapScriptGenerator` logs the head of an unparseable codegen response, so a systematic envelope break is diagnosable from logs instead of costing a silent extra generation per tap.
- **Visible thinking** — adaptive thinking requests now set `display: "summarized"` (the Claude 5 family defaults to `"omitted"`, which streams thinking blocks with empty text). Billing is identical; the thinking-form fallback ladder also catches a `thinking.display` rejection.
- **Assistant prompt** — announce expected duration before slow tools (script generation = 1–3 min); on a generation failure, write the script directly and say so (the standard recovery, not a retry loop).

### UI
- **Tap-create wizard** — the generate banner polls the status endpoint and shows the live phase + elapsed ("Generating script with AI — 1m 12s so far…", "Model output needed reformatting — second attempt…").
- **Assistant `create_tap` tool card** — same live phase replaces the generic 45s "still working" hint.
- **Streaming dots** — show an elapsed counter after 10s with no visible progress ("thinking — 45s"), and the live reasoning tail while thinking summaries are actively arriving (mid-turn reasoning otherwise lands in the block pinned at the turn's top, far above the reading position).

### Testing
- Full server suite passes (231); Angular production build clean.
- Verified live: the Assistant now writes known-API scripts directly instead of invoking generation (a weather tap went from 3.5 silent minutes + error to ~40s), the status polls fire on running tool cards, and thinking summaries render with ticker + elapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)