### PR TITLE
Assistant prompt: hard anti-fabrication rule for tool outcomes

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
@@ -528,6 +528,17 @@ class AssistantAPIController {
             "- This narrows nothing in the rules above: keep asking, proposing, confirming, and waiting exactly where they tell you to — scope/source choices, a plan to approve, destructive-action confirmation, acting only when explicitly authorized. The point is only this: once the next step is already decided or authorized and you are merely narrating it, perform it instead of ending the turn.\n"
         )
         sb.append("\n")
+        sb.append("## Never narrate a tool call you didn't make\n\n")
+        sb.append(
+            "- **Every claim about an action's outcome — \"run submitted\", \"types applied\", \"N records loaded\", \"status: success\" — must be backed by a tool result you actually received in this conversation.** Tool results are your ONLY window into what happened; you cannot know an outcome any other way. Writing an outcome you did not observe is fabrication — worse than reporting an error, because the user makes real decisions on it.\n"
+        )
+        sb.append(
+            "- **When the user approves an action (\"yes\", \"run it\", \"go ahead\"), your response must BEGIN with the tool calls that perform it — never with prose describing them as done.** Words like \"applied\", \"submitted\", \"triggered\", or a past-tense verb about platform state are permitted only AFTER the corresponding tool result exists in this turn.\n"
+        )
+        sb.append(
+            "- If you notice you are writing what a tool \"returned\" without having called it, stop mid-sentence and make the call. If a call failed or was never made, say exactly that — \"I have not run it yet\" is always an acceptable answer; an invented success never is.\n"
+        )
+        sb.append("\n")
         sb.append("## Safety + finish\n\n")
         sb.append(
             "- **Destructive operations gate**: NEVER call `delete_tap`, `delete_pipeline`, `delete_tap_secret`, or `update_secret` on an existing secret without explicit user confirmation in the chat. If the user asks to delete or overwrite something, restate what will be removed and ask the user to confirm before proceeding.\n"


### PR DESCRIPTION
## Summary

A live E2E caught the in-platform Assistant narrating an entire confirm-and-run sequence — "Types applied… Run submitted (2,400 records fetched)… first load complete ✅" — **with zero tool calls made**. Server logs show no requests in the window, and the user acted on a fabricated success report until "show me the data" found an empty destination. `AgentLoop` ends the turn on any text-only response, so invented prose became the final answer.

## Change

One new section in `buildSystemPrompt` (11 lines, prompt-only):

- Every claim about an action's outcome ("run submitted", "types applied", "N records loaded") must be backed by a tool result actually received in the conversation — tool results are the model's only window into what happened.
- A response to a user approval ("yes", "run it") must **begin** with the tool calls that perform it, never with prose describing them as done.
- "I have not run it yet" is always an acceptable answer; an invented success never is.

## Notes

- Prompt-level only; no loop-level backstop yet. If fabrication recurs despite this, the next escalation is an `AgentLoop` nudge on text-only turns that follow a user approval.
- Independent of PR #67 (different section of the same prompt builder; merges cleanly in either order).

## Testing

Full server suite passes (231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)