### PR TITLE
Destination-side typing: pull-based retrofit from the Catalog

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/DestSchemaAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/DestSchemaAPIController.scala
@@ -1,0 +1,92 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import ai.datris.auth.VersionActor
+import ai.datris.model.{DatrisException, SchemaField}
+import ai.datris.util.{APIKeyValidator, DestSchemaApply}
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Destination-side typing, pull-based (plans/destination-schema-after-load.md):
+  * GET infers a typed proposal on demand from landed rows; POST applies the
+  * (possibly edited) types — migrating the landed table first, then writing
+  * the typed config as a new version. Nothing is ever stored between the two. */
+@RestController
+@RequestMapping(Array("/api/v1"))
+class DestSchemaAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[DestSchemaAPIController])
+
+    /** Propose destination column types from landed data. Stateless: samples
+      * up to 1000 landed rows, infers, and returns the fields with per-column
+      * evidence (sample values; for stayed-string columns, the first value
+      * that blocked a type). `eligible: false` carries a `reason`:
+      * destination-not-supported, already-typed, or no-landed-rows. */
+    @GetMapping(path = Array("/pipeline/dest-types"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def propose(
+        @RequestHeader(name = "x-api-key", required = false) apiKey: String,
+        @RequestParam pipeline: String
+    ): ResponseEntity[String] = {
+        try {
+            logger.info("API endpoint GET /pipeline/dest-types called for pipeline: " + pipeline)
+            APIKeyValidator.validate(apiKey)
+            if (pipeline == null || pipeline.isEmpty)
+                throw new DatrisException("Pipeline name is required")
+
+            val proposal = DestSchemaApply.propose(pipeline)
+            new ResponseEntity[String](new Gson().toJson(proposal), HttpStatus.OK)
+        } catch {
+            case e: DatrisException =>
+                logger.warn("Dest-types proposal refused: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String]("{\"error\": " + new Gson().toJson(e.getMessage) + "}")
+            case e: Exception =>
+                logger.error("Error: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
+        }
+    }
+
+    /** Apply destination column types. Body:
+      * {"pipeline": "...", "fields": [{"name": "...", "type": "..."}, ...]}
+      * (`fields` must name every destination column — set unwanted ones to
+      * "string"). Destination-first: landed data is migrated before the config
+      * changes; any un-castable value fails the whole apply with the column
+      * named and nothing applied. The migration locks or replaces the table —
+      * don't apply while a run is in flight. */
+    @PostMapping(path = Array("/pipeline/dest-types"), consumes = Array(MediaType.APPLICATION_JSON_VALUE), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def apply(
+        @RequestHeader(name = "x-api-key", required = false) apiKey: String,
+        @RequestBody body: ApplyDestTypesRequest,
+        request: HttpServletRequest
+    ): ResponseEntity[String] = {
+        try {
+            logger.info("API endpoint POST /pipeline/dest-types called for pipeline: " + body.pipeline)
+            APIKeyValidator.validate(apiKey)
+            if (body.pipeline == null || body.pipeline.isEmpty)
+                throw new DatrisException("Pipeline name is required")
+
+            val applied = DestSchemaApply.apply(body.pipeline, body.fields, VersionActor.resolve(request))
+            new ResponseEntity[String](new Gson().toJson(applied), HttpStatus.OK)
+        } catch {
+            case e: DatrisException =>
+                logger.warn("Dest-types apply refused: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String]("{\"error\": " + new Gson().toJson(e.getMessage) + "}")
+            case e: Exception =>
+                logger.error("Error: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
+        }
+    }
+}
+
+/** Request body for apply — bound the same way PipelineConfig is on
+  * POST /pipeline. */
+case class ApplyDestTypesRequest(
+    pipeline: String = null,
+    fields: java.util.List[SchemaField] = null
+)

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -74,6 +74,10 @@ object CapabilityRoutes {
         Route("GET", "/api/v1/pipeline/version", "pipeline", "read"),
         Route("GET", "/api/v1/pipeline/version/diff", "pipeline", "read"),
         Route("POST", "/api/v1/pipeline/version/restore", "pipeline", "update"),
+        // Destination-side typing: proposing reads landed data; applying
+        // changes the pipeline definition (and may migrate the dest table).
+        Route("GET", "/api/v1/pipeline/dest-types", "pipeline", "read"),
+        Route("POST", "/api/v1/pipeline/dest-types", "pipeline", "update"),
 
         // Taps
         Route("GET", "/api/v1/tap", "tap", "read"),

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -59,6 +59,8 @@ object MCPToolRoutes {
         "get_job_status" -> Mapped("GET", "/api/v1/pipeline/status"),
         "kill_job" -> Mapped("POST", "/api/v1/job/kill"),
         "profile_data" -> Mapped("POST", "/api/v1/pipeline/profile"),
+        "get_dest_types" -> Mapped("GET", "/api/v1/pipeline/dest-types"),
+        "apply_dest_types" -> Mapped("POST", "/api/v1/pipeline/dest-types"),
 
         // Infrastructure
         "get_version" -> Local,

--- a/datrisserver/src/main/scala/ai/datris/util/DestSchemaApply.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DestSchemaApply.scala
@@ -78,15 +78,17 @@ object DestSchemaApply {
             throw new DatrisException("Pipeline not found: " + pipelineName)
 
         val destKind = inScopeDest(config).getOrElse(
-            return ineligible(pipelineName, ReasonNotSupported,
-                "This pipeline's destination does not support on-demand typing (postgres, snowflake, databricks only)")
+            return ineligible(
+                pipelineName,
+                ReasonNotSupported,
+                "This pipeline's destination does not support on-demand typing (postgres, snowflake, databricks only)"
+            )
         )
         if (!DestTypeInference.allString(effectiveFields(config)))
             return ineligible(pipelineName, ReasonAlreadyTyped, "Destination fields already carry types")
 
         val rows: Seq[Map[String, Any]] = sampleLanded(config, destKind).getOrElse(
-            return ineligible(pipelineName, ReasonNoLandedRows,
-                "No landed data to infer from — run the pipeline once first")
+            return ineligible(pipelineName, ReasonNoLandedRows, "No landed data to infer from — run the pipeline once first")
         )
 
         val names = effectiveFields(config).asScala.map(_.name).toList
@@ -111,14 +113,16 @@ object DestSchemaApply {
             case "snowflake" =>
                 val exists = SnowflakeConnectionUtil.withConnection(config.destination.database) { conn =>
                     val statement = conn.createStatement()
-                    try snowflakeTableExists(statement, config) finally Try(statement.close())
+                    try snowflakeTableExists(statement, config)
+                    finally Try(statement.close())
                 }
                 if (!exists) return None
                 SnowflakeQueryUtil.query(config.name, None, sampleLimit).results.asScala.map(_.asScala.toMap).toSeq
             case "databricks" =>
                 val exists = DatabricksConnectionUtil.withConnection(config.destination.database) { conn =>
                     val statement = conn.createStatement()
-                    try databricksTableExists(statement, config) finally Try(statement.close())
+                    try databricksTableExists(statement, config)
+                    finally Try(statement.close())
                 }
                 if (!exists) return None
                 DatabricksQueryUtil.query(config.name, None, sampleLimit).results.asScala.map(_.asScala.toMap).toSeq
@@ -215,7 +219,8 @@ object DestSchemaApply {
             val rs = statement.executeQuery(
                 "SELECT to_regclass('\"" + db.schema + "\".\"" + db.table + "\"')"
             )
-            try { rs.next() && rs.getString(1) != null } finally Try(rs.close())
+            try { rs.next() && rs.getString(1) != null }
+            finally Try(rs.close())
         }
     }
 
@@ -253,7 +258,8 @@ object DestSchemaApply {
         val jdbcUrl = secrets.jdbcUrl + "/" + postgresDbName(config)
         PostgresPool.withConnection(jdbcUrl, secrets.username, secrets.password) { conn =>
             val statement = conn.createStatement()
-            try f(statement) finally Try(statement.close())
+            try f(statement)
+            finally Try(statement.close())
         }
     }
 
@@ -283,7 +289,8 @@ object DestSchemaApply {
                 " WHERE TABLE_SCHEMA = " + sqlString(effectiveName(db.schema)) +
                 " AND TABLE_NAME = " + sqlString(effectiveName(db.table))
         )
-        try { rs.next() && rs.getLong(1) > 0 } finally Try(rs.close())
+        try { rs.next() && rs.getLong(1) > 0 }
+        finally Try(rs.close())
     }
 
     private def migrateSnowflake(statement: Statement, config: PipelineConfig, fields: java.util.List[SchemaField]): Unit = {
@@ -318,7 +325,8 @@ object DestSchemaApply {
                 " WHERE table_schema = " + sqlString(effectiveName(db.schema)) +
                 " AND table_name = " + sqlString(effectiveName(db.table))
         )
-        try { rs.next() && rs.getLong(1) > 0 } finally Try(rs.close())
+        try { rs.next() && rs.getLong(1) > 0 }
+        finally Try(rs.close())
     }
 
     private def migrateDatabricks(statement: Statement, config: PipelineConfig, fields: java.util.List[SchemaField]): Unit = {
@@ -350,7 +358,13 @@ object DestSchemaApply {
     /** One validation query for all typed columns: per column, count non-empty
       * values TRY_CAST rejects. Any nonzero count aborts with the column named.
       * `colRef` renders a column reference in the destination's dialect. */
-    private def validateCasts(statement: Statement, table: String, fields: java.util.List[SchemaField], colRef: String => String, tryCastExpr: (String, String) => String): Unit = {
+    private def validateCasts(
+        statement: Statement,
+        table: String,
+        fields: java.util.List[SchemaField],
+        colRef: String => String,
+        tryCastExpr: (String, String) => String
+    ): Unit = {
         val typed = fields.asScala.filter(f => !f.`type`.equalsIgnoreCase("string")).toList
         if (typed.isEmpty) return
         val counts = typed.map { f =>

--- a/datrisserver/src/main/scala/ai/datris/util/DestSchemaApply.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DestSchemaApply.scala
@@ -1,0 +1,371 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{DatrisEnvironment, DatrisException, PipelineConfig, SchemaField, SchemaProperties}
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.sql.Statement
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** GET response for /pipeline/dest-types: either a typed proposal inferred
+  * on demand from landed rows, or the reason there isn't one. Nothing about a
+  * proposal is ever stored — see plans/destination-schema-after-load.md. */
+case class DestTypesProposal(
+    pipeline: String,
+    eligible: Boolean,
+    reason: String, // null when eligible; else destination-not-supported | already-typed | no-landed-rows
+    message: String,
+    fields: java.util.List[InferredDestField],
+    sampleRowCount: Int
+)
+
+/** POST response for /pipeline/dest-types: what was applied. */
+case class DestTypesApplied(
+    pipeline: String,
+    fields: java.util.List[SchemaField],
+    migrated: Boolean, // true when a landed table was retyped (vs. config-only)
+    version: Int
+)
+
+/** Destination-side typing, pull-based (plans/destination-schema-after-load.md):
+  * `propose` samples what actually landed and infers types on demand;
+  * `apply` migrates the destination table to the (possibly edited) types and
+  * then writes the typed config as a new version. Always destination-first,
+  * config-second, so every intermediate state is safe. Any landed value that
+  * won't cast fails the whole apply naming the column, with config and data
+  * untouched.
+  *
+  * v1 scope is postgres, snowflake, and databricks; objectstore is deferred
+  * (its migration is a non-atomic background rewrite that would need stored
+  * status). Mongo is schemaless and vector destinations have no field schema —
+  * neither applies. */
+object DestSchemaApply {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    private val sampleLimit = 1000
+
+    private val ReasonNotSupported = "destination-not-supported"
+    private val ReasonAlreadyTyped = "already-typed"
+    private val ReasonNoLandedRows = "no-landed-rows"
+
+    /** Destination kind when this pipeline's dest supports on-demand typing. */
+    def inScopeDest(config: PipelineConfig): Option[String] = {
+        if (config == null || config.destination == null) None
+        else if (config.destination.database != null && config.destination.database.usePostgres) Some("postgres")
+        else if (config.destination.database != null && config.destination.database.useSnowflake) Some("snowflake")
+        else if (config.destination.database != null && config.destination.database.useDatabricks) Some("databricks")
+        else None
+    }
+
+    /** Effective dest fields (PipelineConfigIO.read already applies the
+      * source-schema fallback, so null-ness is not the test). */
+    private def effectiveFields(config: PipelineConfig): java.util.List[SchemaField] =
+        if (config.destination.schemaProperties == null) null
+        else config.destination.schemaProperties.fields
+
+    // ------------------------------------------------------------------
+    // Propose: sample landed rows, infer with evidence. Stateless.
+    // ------------------------------------------------------------------
+
+    def propose(pipelineName: String): DestTypesProposal = {
+        val config = PipelineConfigIO.read(DatrisEnvironment.current.pipelineTableName, pipelineName)
+        if (config == null)
+            throw new DatrisException("Pipeline not found: " + pipelineName)
+
+        val destKind = inScopeDest(config).getOrElse(
+            return ineligible(pipelineName, ReasonNotSupported,
+                "This pipeline's destination does not support on-demand typing (postgres, snowflake, databricks only)")
+        )
+        if (!DestTypeInference.allString(effectiveFields(config)))
+            return ineligible(pipelineName, ReasonAlreadyTyped, "Destination fields already carry types")
+
+        val rows: Seq[Map[String, Any]] = sampleLanded(config, destKind).getOrElse(
+            return ineligible(pipelineName, ReasonNoLandedRows,
+                "No landed data to infer from — run the pipeline once first")
+        )
+
+        val names = effectiveFields(config).asScala.map(_.name).toList
+        val fields = DestTypeInference.inferFieldsFromRecords(names, rows)
+        logger.info("Dest-types proposal for pipeline '" + pipelineName + "': inferred " + fields.size +
+            " columns from " + rows.size + " landed rows")
+        DestTypesProposal(pipelineName, eligible = true, reason = null, message = null, fields, rows.size)
+    }
+
+    private def ineligible(pipelineName: String, reason: String, message: String): DestTypesProposal =
+        DestTypesProposal(pipelineName, eligible = false, reason, message, fields = null, sampleRowCount = 0)
+
+    /** Up to [[sampleLimit]] landed rows, or None when nothing has landed yet
+      * (no table, or an empty one). */
+    private def sampleLanded(config: PipelineConfig, destKind: String): Option[Seq[Map[String, Any]]] = {
+        val rows: Seq[Map[String, Any]] = destKind match {
+            case "postgres" =>
+                if (!postgresTableExists(config)) return None
+                val db = config.destination.database
+                val sql = "SELECT * FROM \"" + db.schema + "\".\"" + db.table + "\""
+                PostgresQueryUtil.query(sql, postgresDbName(config), sampleLimit).asScala.map(_.asScala.toMap).toSeq
+            case "snowflake" =>
+                val exists = SnowflakeConnectionUtil.withConnection(config.destination.database) { conn =>
+                    val statement = conn.createStatement()
+                    try snowflakeTableExists(statement, config) finally Try(statement.close())
+                }
+                if (!exists) return None
+                SnowflakeQueryUtil.query(config.name, None, sampleLimit).results.asScala.map(_.asScala.toMap).toSeq
+            case "databricks" =>
+                val exists = DatabricksConnectionUtil.withConnection(config.destination.database) { conn =>
+                    val statement = conn.createStatement()
+                    try databricksTableExists(statement, config) finally Try(statement.close())
+                }
+                if (!exists) return None
+                DatabricksQueryUtil.query(config.name, None, sampleLimit).results.asScala.map(_.asScala.toMap).toSeq
+            case _ => return None
+        }
+        if (rows.isEmpty) None else Some(rows)
+    }
+
+    // ------------------------------------------------------------------
+    // Apply: migrate the landed table (if any), then write typed config.
+    // ------------------------------------------------------------------
+
+    def apply(pipelineName: String, fields: java.util.List[SchemaField], actor: String): DestTypesApplied = {
+        val config = PipelineConfigIO.read(DatrisEnvironment.current.pipelineTableName, pipelineName)
+        if (config == null)
+            throw new DatrisException("Pipeline not found: " + pipelineName)
+
+        val destKind = inScopeDest(config).getOrElse(
+            throw new DatrisException("Pipeline '" + pipelineName + "' destination does not support on-demand typing (postgres, snowflake, databricks only)")
+        )
+        if (!DestTypeInference.allString(effectiveFields(config)))
+            throw new DatrisException("Destination fields for pipeline '" + pipelineName + "' already carry types — edit the pipeline to change them")
+
+        val resolved = validateFields(config, fields)
+        if (!DestTypeInference.hasTypedField(resolved))
+            throw new DatrisException("All fields are string — nothing to apply")
+
+        val migrated = destKind match {
+            case "postgres" =>
+                val exists = postgresTableExists(config)
+                if (exists) migratePostgres(config, resolved)
+                exists
+            case "snowflake" =>
+                SnowflakeConnectionUtil.withConnection(config.destination.database) { conn =>
+                    val statement = conn.createStatement()
+                    try {
+                        val exists = snowflakeTableExists(statement, config)
+                        if (exists) migrateSnowflake(statement, config, resolved)
+                        exists
+                    } finally Try(statement.close())
+                }
+            case "databricks" =>
+                DatabricksConnectionUtil.withConnection(config.destination.database) { conn =>
+                    val statement = conn.createStatement()
+                    try {
+                        val exists = databricksTableExists(statement, config)
+                        if (exists) migrateDatabricks(statement, config, resolved)
+                        exists
+                    } finally Try(statement.close())
+                }
+        }
+
+        // Destination-first ordering succeeded — now the config write.
+        val existingProps = config.destination.schemaProperties
+        val newProps =
+            if (existingProps != null) existingProps.copy(fields = resolved)
+            else SchemaProperties(dbName = null, fields = resolved)
+        val updated = config.copy(destination = config.destination.copy(schemaProperties = newProps))
+        val versioned = PipelineConfigIO.writeVersioned(updated, "dest schema typed", actor)
+        logger.info("Dest types applied for pipeline '" + pipelineName + "' by " + actor +
+            (if (migrated) " (landed table migrated)" else " (config only — no landed table)"))
+        DestTypesApplied(pipelineName, resolved, migrated, versioned.version)
+    }
+
+    /** Applied fields must cover exactly the effective dest field names —
+      * types are the only thing apply may change. */
+    private[util] def validateFields(config: PipelineConfig, fields: java.util.List[SchemaField]): java.util.List[SchemaField] = {
+        if (fields == null || fields.isEmpty)
+            throw new DatrisException("fields is required: every destination column with its intended type")
+        val currentNames = effectiveFields(config).asScala.map(_.name.toLowerCase).toSet
+        val appliedNames = fields.asScala.map(_.name.toLowerCase).toSet
+        if (currentNames != appliedNames)
+            throw new DatrisException("Applied fields must have the same names as the destination columns: expected [" +
+                effectiveFields(config).asScala.map(_.name).mkString(", ") + "]")
+        val supported = Set("string", "boolean", "int", "bigint", "float", "double", "date", "timestamp")
+        fields.asScala.foreach { f =>
+            if (f.`type` == null || !supported.contains(f.`type`.toLowerCase))
+                throw new DatrisException("Unsupported type '" + f.`type` + "' for field '" + f.name + "'. Supported: " + supported.mkString(", "))
+        }
+        fields
+    }
+
+    // ------------------------------------------------------------------
+    // Postgres: in-place ALTER, one transaction.
+    // ------------------------------------------------------------------
+
+    private def postgresDbName(config: PipelineConfig): String =
+        if (DatrisEnvironment.current.multiTenant) DatrisEnvironment.current.environment
+        else config.destination.database.dbName
+
+    private def postgresTableExists(config: PipelineConfig): Boolean = {
+        val db = config.destination.database
+        withPostgres(config) { statement =>
+            val rs = statement.executeQuery(
+                "SELECT to_regclass('\"" + db.schema + "\".\"" + db.table + "\"')"
+            )
+            try { rs.next() && rs.getString(1) != null } finally Try(rs.close())
+        }
+    }
+
+    private def migratePostgres(config: PipelineConfig, fields: java.util.List[SchemaField]): Unit = {
+        val db = config.destination.database
+        val typed = fields.asScala.filter(f => !f.`type`.equalsIgnoreCase("string"))
+        if (typed.isEmpty) return
+        withPostgres(config) { statement =>
+            val conn = statement.getConnection
+            conn.setAutoCommit(false)
+            try {
+                typed.foreach { f =>
+                    val pgType = postgresType(f.`type`)
+                    // NULLIF: empty strings in landed TEXT become NULL, not a cast error.
+                    val sql = "ALTER TABLE \"" + db.schema + "\".\"" + db.table + "\" " +
+                        "ALTER COLUMN \"" + f.name + "\" TYPE " + pgType +
+                        " USING NULLIF(\"" + f.name + "\", '')::" + pgType
+                    logger.info("Dest-types migration (postgres): " + sql)
+                    statement.execute(sql)
+                }
+                conn.commit()
+            } catch {
+                case e: Exception =>
+                    Try(conn.rollback())
+                    throw new DatrisException("Postgres migration failed — no changes were applied. A landed value would not cast: " + e.getMessage)
+            } finally {
+                Try(conn.setAutoCommit(true))
+            }
+        }
+    }
+
+    private def withPostgres[T](config: PipelineConfig)(f: Statement => T): T = {
+        val secrets = SecretsRetrieverUtil.postgresSecrets()
+        Class.forName("org.postgresql.Driver")
+        val jdbcUrl = secrets.jdbcUrl + "/" + postgresDbName(config)
+        PostgresPool.withConnection(jdbcUrl, secrets.username, secrets.password) { conn =>
+            val statement = conn.createStatement()
+            try f(statement) finally Try(statement.close())
+        }
+    }
+
+    private def postgresType(t: String): String = t.toLowerCase match {
+        case "tinyint" | "smallint" => "int2"
+        case "float" => "float4"
+        case "double" => "float8"
+        case "string" => "text"
+        case other => other // int, bigint, boolean, date, timestamp
+    }
+
+    // ------------------------------------------------------------------
+    // Snowflake / Databricks: TRY_CAST-validate, then CREATE OR REPLACE
+    // TABLE AS SELECT. Neither can retype a landed varchar column in place.
+    // The swap drops constraints the loader's CREATE would have added (PK
+    // from keyFields) — MERGE upserts key on the configured keyFields, not
+    // the constraint, so loads keep working.
+    // ------------------------------------------------------------------
+
+    private def sqlString(s: String): String = "'" + s.replace("'", "''") + "'"
+
+    private def snowflakeTableExists(statement: Statement, config: PipelineConfig): Boolean = {
+        import SnowflakeConnectionUtil.{effectiveName, ident}
+        val db = config.destination.database
+        val rs = statement.executeQuery(
+            "SELECT COUNT(*) FROM " + ident(db.dbName) + ".INFORMATION_SCHEMA.TABLES" +
+                " WHERE TABLE_SCHEMA = " + sqlString(effectiveName(db.schema)) +
+                " AND TABLE_NAME = " + sqlString(effectiveName(db.table))
+        )
+        try { rs.next() && rs.getLong(1) > 0 } finally Try(rs.close())
+    }
+
+    private def migrateSnowflake(statement: Statement, config: PipelineConfig, fields: java.util.List[SchemaField]): Unit = {
+        import SnowflakeConnectionUtil.ident
+        val table = SnowflakeConnectionUtil.qualifiedTable(config.destination.database)
+        validateCasts(statement, table, fields, ident, (col, t) => "TRY_CAST(NULLIF(" + ident(col) + ", '') AS " + snowflakeType(t) + ")")
+
+        val selectList = fields.asScala.map { f =>
+            if (f.`type`.equalsIgnoreCase("string")) ident(f.name)
+            else "CAST(NULLIF(" + ident(f.name) + ", '') AS " + snowflakeType(f.`type`) + ") AS " + ident(f.name)
+        }.mkString(", ")
+        val sql = "CREATE OR REPLACE TABLE " + table + " COPY GRANTS AS SELECT " + selectList + " FROM " + table
+        logger.info("Dest-types migration (snowflake): " + sql)
+        statement.execute(sql)
+    }
+
+    private def snowflakeType(t: String): String = t.toLowerCase match {
+        case "string" => "VARCHAR"
+        case "int" | "integer" | "tinyint" | "smallint" | "bigint" => "NUMBER(38,0)"
+        case "float" | "double" => "FLOAT"
+        case "boolean" => "BOOLEAN"
+        case "date" => "DATE"
+        case "timestamp" => "TIMESTAMP_NTZ"
+        case other => other
+    }
+
+    private def databricksTableExists(statement: Statement, config: PipelineConfig): Boolean = {
+        import DatabricksConnectionUtil.{effectiveName, ident}
+        val db = config.destination.database
+        val rs = statement.executeQuery(
+            "SELECT COUNT(*) FROM " + ident(db.dbName) + ".information_schema.tables" +
+                " WHERE table_schema = " + sqlString(effectiveName(db.schema)) +
+                " AND table_name = " + sqlString(effectiveName(db.table))
+        )
+        try { rs.next() && rs.getLong(1) > 0 } finally Try(rs.close())
+    }
+
+    private def migrateDatabricks(statement: Statement, config: PipelineConfig, fields: java.util.List[SchemaField]): Unit = {
+        import DatabricksConnectionUtil.ident
+        val table = DatabricksConnectionUtil.qualifiedTable(config.destination.database)
+        validateCasts(statement, table, fields, ident, (col, t) => "try_cast(nullif(" + ident(col) + ", '') AS " + databricksType(t) + ")")
+
+        val selectList = fields.asScala.map { f =>
+            if (f.`type`.equalsIgnoreCase("string")) ident(f.name)
+            else "CAST(nullif(" + ident(f.name) + ", '') AS " + databricksType(f.`type`) + ") AS " + ident(f.name)
+        }.mkString(", ")
+        val sql = "CREATE OR REPLACE TABLE " + table + " AS SELECT " + selectList + " FROM " + table
+        logger.info("Dest-types migration (databricks): " + sql)
+        statement.execute(sql)
+    }
+
+    private def databricksType(t: String): String = t.toLowerCase match {
+        case "string" => "STRING"
+        case "int" | "integer" | "tinyint" | "smallint" => "INT"
+        case "bigint" => "BIGINT"
+        case "float" => "FLOAT"
+        case "double" => "DOUBLE"
+        case "boolean" => "BOOLEAN"
+        case "date" => "DATE"
+        case "timestamp" => "TIMESTAMP"
+        case other => other
+    }
+
+    /** One validation query for all typed columns: per column, count non-empty
+      * values TRY_CAST rejects. Any nonzero count aborts with the column named.
+      * `colRef` renders a column reference in the destination's dialect. */
+    private def validateCasts(statement: Statement, table: String, fields: java.util.List[SchemaField], colRef: String => String, tryCastExpr: (String, String) => String): Unit = {
+        val typed = fields.asScala.filter(f => !f.`type`.equalsIgnoreCase("string")).toList
+        if (typed.isEmpty) return
+        val counts = typed.map { f =>
+            "SUM(CASE WHEN NULLIF(" + colRef(f.name) + ", '') IS NOT NULL AND " + tryCastExpr(f.name, f.`type`) + " IS NULL THEN 1 ELSE 0 END)"
+        }.mkString(", ")
+        val rs = statement.executeQuery("SELECT " + counts + " FROM " + table)
+        try {
+            if (rs.next()) {
+                typed.zipWithIndex.foreach { case (f, i) =>
+                    val bad = rs.getLong(i + 1)
+                    if (bad > 0)
+                        throw new DatrisException("Cannot apply type '" + f.`type` + "' for column '" + f.name + "': " +
+                            bad + " landed value(s) do not cast. Set the field back to string or clean the data, then apply again. No changes were applied.")
+                }
+            }
+        } finally Try(rs.close())
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
@@ -81,16 +81,19 @@ object DestTypeInference {
         }
 
         if (decimalPattern.pattern.matcher(v).matches()) {
-            return try { v.toDouble; Some("double") } catch { case _: NumberFormatException => Some("string") }
+            return try { v.toDouble; Some("double") }
+            catch { case _: NumberFormatException => Some("string") }
         }
 
         if (datePattern.pattern.matcher(v).matches()) {
-            return try { LocalDate.parse(v, isoDate); Some("date") } catch { case _: Exception => Some("string") }
+            return try { LocalDate.parse(v, isoDate); Some("date") }
+            catch { case _: Exception => Some("string") }
         }
 
         if (timestampPattern.pattern.matcher(v).matches()) {
             // The date part must still be a real calendar date.
-            return try { LocalDate.parse(v.substring(0, 10), isoDate); Some("timestamp") } catch { case _: Exception => Some("string") }
+            return try { LocalDate.parse(v.substring(0, 10), isoDate); Some("timestamp") }
+            catch { case _: Exception => Some("string") }
         }
 
         Some("string")

--- a/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
@@ -1,0 +1,192 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.SchemaField
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.collection.JavaConverters._
+
+/** Why a column stayed `string`: the first landed value that would not parse,
+  * and the type the rest of the column's values would otherwise have earned.
+  * Lets the typing dialog say "stayed text — found 'N/A', would otherwise be
+  * int" so an override is an informed choice. */
+case class DestStringReason(value: String, blocked: String)
+
+/** One proposed destination column with the evidence behind it: up to
+  * [[DestTypeInference.maxSamples]] distinct landed values, and (for columns
+  * held at `string` by a dirty value) the reason. */
+case class InferredDestField(
+    name: String,
+    `type`: String,
+    samples: java.util.List[String],
+    stringReason: DestStringReason
+)
+
+/** Deterministic destination-type inference over string values.
+  *
+  * Classifies each non-empty value to its narrowest type, then widens per
+  * column until every value fits: boolean → int → bigint → double →
+  * date → timestamp → string. Any value that fits nothing typed makes the
+  * column `string` — inference must never produce a type a landed value would
+  * break, so all choices are conservative:
+  *   - empty/null values don't vote (they're NULL either way)
+  *   - leading-zero integers ("007", zip codes) stay string
+  *   - integers beyond Long stay string (double would silently lose precision)
+  *   - `_json` / `_xml` blob columns are never retyped (loaders map them natively)
+  *
+  * Emits only types every loader understands: boolean, int, bigint, double,
+  * date, timestamp, string. No AI call — see plans/destination-schema-after-load.md.
+  */
+object DestTypeInference {
+
+    private val NeverRetyped = Set("_json", "_xml")
+
+    /** Evidence caps for the typing dialog: how many distinct values are shown
+      * per column, and how long any shown value can be. */
+    private[util] val maxSamples = 5
+    private[util] val maxSampleLength = 80
+
+    private val intPattern = "^[+-]?\\d+$".r
+    private val decimalPattern = "^[+-]?(\\d+\\.\\d*|\\.\\d+|\\d+)([eE][+-]?\\d+)?$".r
+    private val datePattern = "^\\d{4}-\\d{2}-\\d{2}$".r
+    // ISO-ish timestamps: date + 'T' or space + time, optional fraction/offset/Z.
+    private val timestampPattern =
+        "^\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}(:\\d{2}(\\.\\d+)?)?([+-]\\d{2}:?\\d{2}|Z)?$".r
+
+    private val isoDate = DateTimeFormatter.ISO_LOCAL_DATE
+
+    /** Narrowest type for one value, or None for empty (doesn't vote). */
+    private[util] def classify(raw: String): Option[String] = {
+        if (raw == null) return None
+        val v = raw.trim
+        if (v.isEmpty) return None
+
+        if (v.equalsIgnoreCase("true") || v.equalsIgnoreCase("false")) return Some("boolean")
+
+        if (intPattern.pattern.matcher(v).matches()) {
+            val digits = v.dropWhile(c => c == '+' || c == '-')
+            // Leading zero on a multi-digit integer is an identifier, not a number.
+            if (digits.length > 1 && digits.head == '0') return Some("string")
+            return try {
+                val l = digits.toLong * (if (v.startsWith("-")) -1L else 1L)
+                if (l >= Int.MinValue && l <= Int.MaxValue) Some("int") else Some("bigint")
+            } catch {
+                case _: NumberFormatException => Some("string") // beyond Long
+            }
+        }
+
+        if (decimalPattern.pattern.matcher(v).matches()) {
+            return try { v.toDouble; Some("double") } catch { case _: NumberFormatException => Some("string") }
+        }
+
+        if (datePattern.pattern.matcher(v).matches()) {
+            return try { LocalDate.parse(v, isoDate); Some("date") } catch { case _: Exception => Some("string") }
+        }
+
+        if (timestampPattern.pattern.matcher(v).matches()) {
+            // The date part must still be a real calendar date.
+            return try { LocalDate.parse(v.substring(0, 10), isoDate); Some("timestamp") } catch { case _: Exception => Some("string") }
+        }
+
+        Some("string")
+    }
+
+    /** Least upper bound of two inferred types. */
+    private[util] def widen(a: String, b: String): String = {
+        if (a == b) return a
+        val pair = Set(a, b)
+        if (pair.contains("string")) return "string"
+        if (pair == Set("int", "bigint")) return "bigint"
+        if (pair.subsetOf(Set("int", "bigint", "double"))) return "double"
+        if (pair == Set("date", "timestamp")) return "timestamp"
+        "string" // boolean vs anything, temporal vs numeric, ...
+    }
+
+    /** Column type over all its values; string when nothing voted. */
+    private[util] def inferColumn(values: Iterable[String]): String = {
+        var current: String = null
+        val it = values.iterator
+        while (it.hasNext) {
+            classify(it.next()) match {
+                case Some(t) =>
+                    current = if (current == null) t else widen(current, t)
+                    if (current == "string") return "string" // can't narrow again
+                case None => ()
+            }
+        }
+        if (current == null) "string" else current
+    }
+
+    /** Column type plus the dialog evidence, in one walk: distinct sample
+      * values, and — when an unparseable value held an otherwise-typed column
+      * at `string` — the first such value and the type it blocked. */
+    private[util] def inferColumnWithEvidence(values: Iterable[String]): (String, java.util.List[String], DestStringReason) = {
+        val samples = new java.util.LinkedHashSet[String]()
+        var typedWidened: String = null // widen over values that parsed as something
+        var firstUnparseable: String = null
+
+        val it = values.iterator
+        while (it.hasNext) {
+            val raw = it.next()
+            classify(raw) match {
+                case Some(t) =>
+                    val v = truncate(raw.trim)
+                    if (samples.size < maxSamples) samples.add(v)
+                    if (t == "string") {
+                        if (firstUnparseable == null) firstUnparseable = v
+                    } else {
+                        typedWidened = if (typedWidened == null) t else widen(typedWidened, t)
+                    }
+                case None => ()
+            }
+        }
+
+        val inferredType =
+            if (firstUnparseable != null) "string"
+            else if (typedWidened == null) "string"
+            else typedWidened
+        // A reason only makes sense when a dirty value blocked a well-defined type.
+        val reason =
+            if (firstUnparseable != null && typedWidened != null && typedWidened != "string")
+                DestStringReason(firstUnparseable, typedWidened)
+            else null
+        (inferredType, new java.util.ArrayList[String](samples), reason)
+    }
+
+    private def truncate(v: String): String =
+        if (v.length <= maxSampleLength) v else v.substring(0, maxSampleLength) + "…"
+
+    /** Infer typed fields with per-column dialog evidence from records
+      * (name → value maps, e.g. rows sampled from the destination). Values are
+      * stringified; null stays a non-vote; names match case-insensitively.
+      * `_json`/`_xml` keep their samples but are never retyped and never carry
+      * a reason (they were never candidates). */
+    def inferFieldsFromRecords(names: List[String], records: Iterable[Map[String, Any]]): java.util.List[InferredDestField] = {
+        val lowerRecords = records.map(r => r.map { case (k, v) => k.toLowerCase -> v })
+        val fields = names.map { name =>
+            val values = lowerRecords.flatMap(_.get(name.toLowerCase)).map(v => if (v == null) null else v.toString)
+            val (inferredType, samples, reason) = inferColumnWithEvidence(values)
+            if (NeverRetyped.contains(name.toLowerCase))
+                InferredDestField(name, "string", samples, null)
+            else
+                InferredDestField(name, inferredType, samples, reason)
+        }
+        fields.asJava
+    }
+
+    /** True when every field is (still) type string — the population this
+      * feature targets. */
+    def allString(fields: java.util.List[SchemaField]): Boolean = {
+        fields != null && !fields.isEmpty && fields.asScala.forall(f => f.`type` == null || f.`type`.equalsIgnoreCase("string"))
+    }
+
+    /** True when at least one field is a non-string type — an all-string apply
+      * would be a no-op. */
+    def hasTypedField(fields: java.util.List[SchemaField]): Boolean =
+        fields != null && fields.asScala.exists(f => f.`type` != null && !f.`type`.equalsIgnoreCase("string"))
+}

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -33,7 +33,7 @@ class MCPToolRoutesSpec extends AnyFunSuite {
     )
 
     test("catalog has one row per MCP tool, no duplicates") {
-        assert(MCPToolRoutes.allToolNames.size == 63)
+        assert(MCPToolRoutes.allToolNames.size == 65)
         assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
     }
 

--- a/datrisserver/src/test/scala/ai/datris/util/DestSchemaApplySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/DestSchemaApplySpec.scala
@@ -60,16 +60,15 @@ class DestSchemaApplySpec extends AnyFunSuite {
 
     test("validateFields rejects a missing, extra, or renamed column") {
         assertThrows[DatrisException](DestSchemaApply.validateFields(pg, List(SchemaField("a", "int")).asJava))
-        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
-            List(SchemaField("a", "int"), SchemaField("b", "int"), SchemaField("c", "int")).asJava))
-        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
-            List(SchemaField("a", "int"), SchemaField("renamed", "int")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(
+            pg,
+            List(SchemaField("a", "int"), SchemaField("b", "int"), SchemaField("c", "int")).asJava
+        ))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, List(SchemaField("a", "int"), SchemaField("renamed", "int")).asJava))
     }
 
     test("validateFields rejects unsupported types") {
-        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
-            List(SchemaField("a", "uuid"), SchemaField("b", "string")).asJava))
-        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
-            List(SchemaField("a", null), SchemaField("b", "string")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, List(SchemaField("a", "uuid"), SchemaField("b", "string")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, List(SchemaField("a", null), SchemaField("b", "string")).asJava))
     }
 }

--- a/datrisserver/src/test/scala/ai/datris/util/DestSchemaApplySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/DestSchemaApplySpec.scala
@@ -1,0 +1,75 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{Database, DatrisException, Destination, PipelineConfig, SchemaField, SchemaProperties}
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+/** Pure guards of destination-side typing: which destinations are in scope,
+  * and what an apply request may change (types only — never the column set).
+  * The database-touching paths (sampling, migration) are covered by live E2E,
+  * not unit tests. */
+class DestSchemaApplySpec extends AnyFunSuite {
+
+    private def config(db: Database, fields: List[SchemaField] = List(SchemaField("a", "string"), SchemaField("b", "string"))): PipelineConfig =
+        PipelineConfig(
+            name = "p",
+            destination = Destination(
+                schemaProperties = SchemaProperties(dbName = null, fields = fields.asJava),
+                database = db
+            )
+        )
+
+    // ---- inScopeDest ----
+
+    test("postgres, snowflake, and databricks destinations are in scope") {
+        assert(DestSchemaApply.inScopeDest(config(Database(usePostgres = true))) == Some("postgres"))
+        assert(DestSchemaApply.inScopeDest(config(Database(useSnowflake = true))) == Some("snowflake"))
+        assert(DestSchemaApply.inScopeDest(config(Database(useDatabricks = true))) == Some("databricks"))
+    }
+
+    test("mongo, destination-less, and null configs are out of scope") {
+        assert(DestSchemaApply.inScopeDest(config(Database(useMongoDB = true))) == None)
+        assert(DestSchemaApply.inScopeDest(PipelineConfig(name = "p")) == None)
+        assert(DestSchemaApply.inScopeDest(null) == None)
+    }
+
+    // ---- validateFields ----
+
+    private val pg = config(Database(usePostgres = true))
+
+    test("validateFields accepts a full rename-free retype") {
+        val fields = List(SchemaField("a", "int"), SchemaField("b", "string")).asJava
+        assert(DestSchemaApply.validateFields(pg, fields) == fields)
+    }
+
+    test("validateFields matches names case-insensitively") {
+        val fields = List(SchemaField("A", "int"), SchemaField("B", "double")).asJava
+        assert(DestSchemaApply.validateFields(pg, fields) == fields)
+    }
+
+    test("validateFields requires fields") {
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, null))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, new java.util.ArrayList[SchemaField]()))
+    }
+
+    test("validateFields rejects a missing, extra, or renamed column") {
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg, List(SchemaField("a", "int")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
+            List(SchemaField("a", "int"), SchemaField("b", "int"), SchemaField("c", "int")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
+            List(SchemaField("a", "int"), SchemaField("renamed", "int")).asJava))
+    }
+
+    test("validateFields rejects unsupported types") {
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
+            List(SchemaField("a", "uuid"), SchemaField("b", "string")).asJava))
+        assertThrows[DatrisException](DestSchemaApply.validateFields(pg,
+            List(SchemaField("a", null), SchemaField("b", "string")).asJava))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/DestTypeInferenceSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/DestTypeInferenceSpec.scala
@@ -1,0 +1,167 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.SchemaField
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+/** The widening lattice is the safety boundary of destination-side typing: a
+  * type it emits must hold for every value it saw. Each rule that keeps a
+  * column `string` (leading zeros, over-Long integers, mixed kinds) exists
+  * because the typed column would otherwise break a real landed value. */
+class DestTypeInferenceSpec extends AnyFunSuite {
+
+    private def col(values: String*): String = DestTypeInference.inferColumn(values)
+
+    // ---- classify / single-column lattice ----
+
+    test("integers within Int range infer int") {
+        assert(col("1", "42", "-7", "+5") == "int")
+    }
+
+    test("integers beyond Int range widen to bigint") {
+        assert(col("1", "3000000000") == "bigint")
+    }
+
+    test("integers beyond Long stay string (double would lose precision)") {
+        assert(col("99999999999999999999999") == "string")
+    }
+
+    test("decimals infer double; ints mixed with decimals widen to double") {
+        assert(col("1.5", ".5", "2.") == "double")
+        assert(col("1", "2.5") == "double")
+        assert(col("1e5", "2.5E-3") == "double")
+    }
+
+    test("booleans infer boolean, case-insensitively") {
+        assert(col("true", "FALSE", "True") == "boolean")
+    }
+
+    test("boolean mixed with anything else is string") {
+        assert(col("true", "1") == "string")
+        assert(col("false", "2026-01-01") == "string")
+    }
+
+    test("ISO dates infer date; invalid calendar dates stay string") {
+        assert(col("2026-01-31", "1999-12-01") == "date")
+        assert(col("2026-13-45") == "string")
+    }
+
+    test("ISO timestamps infer timestamp; date+timestamp widens to timestamp") {
+        assert(col("2026-01-31T10:15:30", "2026-01-31 10:15:30.123", "2026-01-31T10:15:30Z") == "timestamp")
+        assert(col("2026-01-31", "2026-01-31T10:15:30") == "timestamp")
+    }
+
+    test("date or timestamp mixed with numerics is string") {
+        assert(col("2026-01-31", "42") == "string")
+    }
+
+    test("leading-zero integers (zip codes, ids) stay string") {
+        assert(col("07030", "10001") == "string")
+        // a single zero is a number, not an identifier
+        assert(col("0", "1") == "int")
+    }
+
+    test("empty and null values don't vote; all-empty column is string") {
+        assert(col("", "5", null, "7") == "int")
+        assert(col("", "", "") == "string")
+        assert(col() == "string")
+    }
+
+    test("free text is string and poisons any typed column") {
+        assert(col("hello") == "string")
+        assert(col("1", "2", "N/A") == "string")
+    }
+
+    // ---- evidence: samples + string reason ----
+
+    private def evidence(values: String*): (String, List[String], DestStringReason) = {
+        val (t, samples, reason) = DestTypeInference.inferColumnWithEvidence(values)
+        (t, samples.asScala.toList, reason)
+    }
+
+    test("evidence agrees with inferColumn and collects distinct samples in order") {
+        val (t, samples, reason) = evidence("1", "2", "1", "3")
+        assert(t == "int")
+        assert(samples == List("1", "2", "3"))
+        assert(reason == null)
+    }
+
+    test("evidence caps samples at 5 distinct values and skips empties") {
+        val (t, samples, _) = evidence("", "1", "2", null, "3", "4", "5", "6", "7")
+        assert(t == "int")
+        assert(samples == List("1", "2", "3", "4", "5"))
+    }
+
+    test("evidence truncates long values") {
+        val long = "x" * 200
+        val (_, samples, _) = evidence(long)
+        assert(samples.head.length == DestTypeInference.maxSampleLength + 1) // + ellipsis
+        assert(samples.head.endsWith("…"))
+    }
+
+    test("a dirty value blocking an otherwise-typed column yields a reason") {
+        val (t, _, reason) = evidence("1", "2", "N/A", "3")
+        assert(t == "string")
+        assert(reason == DestStringReason("N/A", "int"))
+    }
+
+    test("the reason reports the first dirty value even when it comes first") {
+        val (t, _, reason) = evidence("N/A", "1.5", "2")
+        assert(t == "string")
+        assert(reason == DestStringReason("N/A", "double"))
+    }
+
+    test("no reason when the column is plain text or mixed typed kinds") {
+        // plain text: nothing typed was blocked
+        assert(evidence("hello", "world")._3 == null)
+        // mixed kinds (boolean vs int) widen to string without a dirty value
+        val (t, _, reason) = evidence("true", "1")
+        assert(t == "string")
+        assert(reason == null)
+    }
+
+    // ---- field assembly ----
+
+    test("inferFieldsFromRecords matches names case-insensitively, stringifies values, and never retypes _json/_xml") {
+        val fields = DestTypeInference.inferFieldsFromRecords(
+            List("id", "active", "_json"),
+            Seq(
+                Map[String, Any]("ID" -> "3", "Active" -> "true", "_json" -> "{\"a\":1}"),
+                Map[String, Any]("id" -> "4", "active" -> "false", "_json" -> "{\"b\":2}")
+            )
+        ).asScala.toList
+        assert(fields.map(f => f.name -> f.`type`) ==
+            List("id" -> "int", "active" -> "boolean", "_json" -> "string"))
+        // _json keeps its samples but never carries a reason
+        assert(fields(2).samples.asScala.nonEmpty)
+        assert(fields(2).stringReason == null)
+    }
+
+    test("inferFieldsFromRecords attaches per-column evidence") {
+        val fields = DestTypeInference.inferFieldsFromRecords(
+            List("qty"),
+            Seq(Map[String, Any]("qty" -> "1"), Map[String, Any]("qty" -> "N/A"))
+        ).asScala.toList
+        assert(fields.head.`type` == "string")
+        assert(fields.head.stringReason == DestStringReason("N/A", "int"))
+        assert(fields.head.samples.asScala.toList == List("1", "N/A"))
+    }
+
+    // ---- helpers used by propose/apply ----
+
+    test("allString and hasTypedField") {
+        val allStr = List(SchemaField("a", "string"), SchemaField("b", "STRING")).asJava
+        val typed = List(SchemaField("a", "string"), SchemaField("b", "int")).asJava
+        assert(DestTypeInference.allString(allStr))
+        assert(!DestTypeInference.allString(typed))
+        assert(!DestTypeInference.hasTypedField(allStr))
+        assert(DestTypeInference.hasTypedField(typed))
+        assert(!DestTypeInference.allString(new java.util.ArrayList[SchemaField]()))
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -631,6 +631,129 @@ paths:
         '500':
           description: Error
 
+  /api/v1/pipeline/dest-types:
+    get:
+      tags: [Pipelines]
+      summary: Propose destination column types from landed data
+      description: >-
+        Agent-created pipelines store every destination column as text. This
+        stateless call samples up to 1000 rows that already landed in the
+        destination (postgres, snowflake, or databricks), infers real column
+        types deterministically, and returns them with per-column evidence:
+        a few distinct sample values, and — for columns kept as string by a
+        dirty value — the offending value and the type it blocked. Nothing is
+        stored or changed.
+      parameters:
+        - name: pipeline
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The proposal, or the reason there is none
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pipeline:
+                    type: string
+                  eligible:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum: [destination-not-supported, already-typed, no-landed-rows]
+                    description: Present when eligible is false.
+                  message:
+                    type: string
+                  sampleRowCount:
+                    type: integer
+                  fields:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum: [string, boolean, int, bigint, double, date, timestamp]
+                        samples:
+                          type: array
+                          description: Up to 5 distinct landed values, truncated.
+                          items:
+                            type: string
+                        stringReason:
+                          type: object
+                          description: Why the column stayed string, when a dirty value blocked a type.
+                          properties:
+                            value:
+                              type: string
+                            blocked:
+                              type: string
+        '400':
+          description: Pipeline not found
+        '500':
+          description: Error
+    post:
+      tags: [Pipelines]
+      summary: Apply destination column types
+      description: >-
+        Applies column types to an all-string destination. Destination-first:
+        if data has already landed the table is migrated before the config
+        changes — postgres retypes in place, snowflake/databricks validate
+        every landed value with TRY_CAST and then swap the table. Any landed
+        value that will not cast fails the whole apply with the column named
+        and nothing changed. On success the pipeline definition is updated as
+        a new version. The migration locks or replaces the table — do not
+        apply while a run is in flight.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [pipeline, fields]
+              properties:
+                pipeline:
+                  type: string
+                fields:
+                  type: array
+                  description: Every destination column with its intended type (keep a column as-is with type string).
+                  items:
+                    type: object
+                    required: [name, type]
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                        enum: [string, boolean, int, bigint, float, double, date, timestamp]
+      responses:
+        '200':
+          description: What was applied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pipeline:
+                    type: string
+                  migrated:
+                    type: boolean
+                    description: True when a landed table was retyped (vs. config-only).
+                  version:
+                    type: integer
+                  fields:
+                    type: array
+                    items:
+                      type: object
+        '400':
+          description: Unsupported destination, already typed, invalid fields, or a landed value would not cast
+        '500':
+          description: Error
+
   # ── File Upload & AI ────────────────────────────────────────
 
   /api/v1/pipeline/upload:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1704,6 +1704,46 @@ def _all_tools():
             }
         ),
         Tool(
+            name="get_dest_types",
+            description="Propose real column types for a pipeline whose destination columns are all stored as text (the default for agent-created pipelines). Stateless: samples up to 1000 rows that already landed in the destination, infers types deterministically, and returns per-column evidence — a few sample values, plus (for columns kept as string by a dirty value) the offending value and the type it blocked. Only for postgres, snowflake, and databricks destinations; `eligible: false` with a `reason` of destination-not-supported, already-typed, or no-landed-rows (run the pipeline once first) otherwise. Nothing is stored or changed by this call.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "pipeline": {
+                        "type": "string",
+                        "description": "Pipeline name"
+                    },
+                },
+                "required": ["pipeline"]
+            }
+        ),
+        Tool(
+            name="apply_dest_types",
+            description="Apply destination column types to an all-string pipeline. REQUIRES explicit user approval first. Landed data is migrated before the config changes (postgres retypes in place; snowflake/databricks validate then swap the table) — the migration locks or replaces the table, so do NOT apply while a run is in flight. Any landed value that will not cast fails the whole apply with the column named and NOTHING changed — then either re-apply with that field set back to string, or fix the data. `fields` must list EVERY destination column (same names as get_dest_types returned) with its intended type; keep a column as-is by passing type string.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "pipeline": {
+                        "type": "string",
+                        "description": "Pipeline name"
+                    },
+                    "fields": {
+                        "type": "array",
+                        "description": "Every destination column with its intended type. Types: string, boolean, int, bigint, float, double, date, timestamp.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "type": {"type": "string"}
+                            },
+                            "required": ["name", "type"]
+                        }
+                    },
+                },
+                "required": ["pipeline", "fields"]
+            }
+        ),
+        Tool(
             name="get_version",
             description="Get the Datris server version.",
             inputSchema={
@@ -2990,6 +3030,13 @@ def _dispatch(name: str, args: dict) -> str:
         if args.get("sample_size"):
             data["sampleSize"] = str(args["sample_size"])
         return _upload_content("/api/v1/pipeline/profile", args["content"], args["filename"], data)
+
+    elif name == "get_dest_types":
+        return _call("get", "/api/v1/pipeline/dest-types", params={"pipeline": args["pipeline"]})
+
+    elif name == "apply_dest_types":
+        return _call("post", "/api/v1/pipeline/dest-types",
+                     json={"pipeline": args["pipeline"], "fields": args["fields"]})
 
     elif name == "get_version":
         return _call("get", "/api/v1/version")

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { PipelineEditComponent } from './pipeline-edit/pipeline-edit.component';
 import { PipelineConfigFormComponent } from './pipeline-config-form/pipeline-config-form.component';
 import { PipelineDqTxEditorComponent } from './pipeline-dq-tx-editor/pipeline-dq-tx-editor.component';
 import { PipelineViewComponent } from './pipeline-view/pipeline-view.component';
+import { DestTypesDialogComponent } from './dest-types-dialog/dest-types-dialog.component';
 import { PipelineStatusComponent } from './pipeline-status/pipeline-status.component';
 import { PipelineDetailComponent } from './pipeline-detail/pipeline-detail.component';
 import { SearchComponent } from './search/search.component';
@@ -52,6 +53,7 @@ import { NgxEchartsModule } from 'ngx-echarts';
     PipelineConfigFormComponent,
     PipelineDqTxEditorComponent,
     PipelineViewComponent,
+    DestTypesDialogComponent,
     PipelineStatusComponent,
     PipelineDetailComponent,
     SearchComponent,

--- a/ui/src/app/dest-types-dialog/dest-types-dialog.component.css
+++ b/ui/src/app/dest-types-dialog/dest-types-dialog.component.css
@@ -1,0 +1,219 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  width: 640px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+}
+
+.modal-close:hover {
+  color: var(--text-primary);
+}
+
+.modal-body {
+  padding: 20px;
+  max-height: 65vh;
+  overflow-y: auto;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-color);
+}
+
+.pipeline-name-label {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.loading-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  padding: 12px 0;
+}
+
+.spin {
+  animation: dest-types-spin 1s linear infinite;
+}
+
+@keyframes dest-types-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.ineligible-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: var(--bg-card-alt);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--text-secondary);
+}
+
+.dialog-hint {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.types-table-wrap {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: auto;
+}
+
+.types-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.types-table th {
+  text-align: left;
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-card-alt);
+}
+
+.types-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  vertical-align: top;
+}
+
+.types-table tr:last-child td {
+  border-bottom: none;
+}
+
+.col-name {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.type-select {
+  background: var(--bg-card-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 13px;
+}
+
+.string-reason {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #d9a441;
+  max-width: 220px;
+}
+
+.primary-btn {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-green));
+  color: #0a0e1a;
+  cursor: pointer;
+}
+
+.primary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary-btn {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.col-samples {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.success-box {
+  margin-top: 12px;
+  background: rgba(0, 200, 120, 0.1);
+  border: 1px solid rgba(0, 200, 120, 0.35);
+  color: var(--text-primary);
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 13px;
+}
+
+.error-box {
+  margin-top: 12px;
+  background: rgba(255, 80, 80, 0.1);
+  border: 1px solid rgba(255, 80, 80, 0.35);
+  color: var(--text-primary);
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 13px;
+  white-space: pre-wrap;
+}

--- a/ui/src/app/dest-types-dialog/dest-types-dialog.component.html
+++ b/ui/src/app/dest-types-dialog/dest-types-dialog.component.html
@@ -1,0 +1,84 @@
+<div class="modal-overlay" (click)="close()">
+  <div class="modal dest-types-modal" (click)="$event.stopPropagation()">
+    <div class="modal-header">
+      <h2 class="modal-title">Set Destination Column Types</h2>
+      <button class="modal-close" (click)="close()">
+        <span class="material-icons">close</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <div class="pipeline-name-label">Pipeline: <strong>{{ pipeline }}</strong></div>
+
+      <div class="loading-row" *ngIf="loading">
+        <span class="material-icons spin">progress_activity</span>
+        Inferring types from landed data…
+      </div>
+
+      <ng-container *ngIf="!loading && proposal && !appliedResult">
+        <!-- Ineligible: explain instead of proposing -->
+        <div class="ineligible-box" *ngIf="!proposal.eligible">
+          <span class="material-icons">info</span>
+          <span>
+            {{ proposal.message }}
+            <ng-container *ngIf="proposal.reason === 'no-landed-rows'">
+              Types are inferred from data that has already landed in the destination.
+            </ng-container>
+          </span>
+        </div>
+
+        <ng-container *ngIf="proposal.eligible">
+          <p class="dialog-hint">
+            Proposed from <strong>{{ proposal.sampleRowCount }}</strong> landed
+            row{{ proposal.sampleRowCount === 1 ? '' : 's' }}. Adjust any column,
+            then Apply — the destination table is retyped and the pipeline
+            definition is updated as a new version. Every landed value is
+            validated first; a value that won't cast fails the apply with
+            nothing changed. Don't apply while a run is in flight.
+          </p>
+          <div class="types-table-wrap">
+            <table class="types-table">
+              <thead>
+                <tr>
+                  <th>Column</th>
+                  <th>Type</th>
+                  <th>Sample values</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let f of fields">
+                  <td class="col-name" [title]="f.name">{{ f.name }}</td>
+                  <td>
+                    <select class="type-select" [(ngModel)]="f.type" [disabled]="!auth.canWrite()">
+                      <option *ngFor="let t of types" [value]="t">{{ t }}</option>
+                    </select>
+                    <div class="string-reason" *ngIf="f.stringReason">
+                      stayed text — found "{{ f.stringReason.value }}", would otherwise be {{ f.stringReason.blocked }}
+                    </div>
+                  </td>
+                  <td class="col-samples" [title]="samplesFor(f)">{{ samplesFor(f) || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </ng-container>
+      </ng-container>
+
+      <div class="success-box" *ngIf="appliedResult">
+        Types applied.
+        {{ appliedResult.migrated ? 'The landed data was migrated to the new types.' : 'No data had landed yet — the table will be created typed on the first load.' }}
+        (Pipeline version {{ appliedResult.version }}.)
+      </div>
+      <div class="error-box" *ngIf="error">{{ error }}</div>
+    </div>
+    <div class="modal-footer">
+      <button class="secondary-btn" (click)="close()">{{ appliedResult ? 'Close' : 'Cancel' }}</button>
+      <button class="primary-btn"
+              *ngIf="auth.canWrite() && proposal?.eligible && !appliedResult"
+              (click)="apply()"
+              [disabled]="applying || !hasTypedField()"
+              [title]="hasTypedField() ? '' : 'All columns are set to string — nothing to apply'">
+        {{ applying ? 'Applying…' : 'Apply Types' }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/ui/src/app/dest-types-dialog/dest-types-dialog.component.ts
+++ b/ui/src/app/dest-types-dialog/dest-types-dialog.component.ts
@@ -1,0 +1,77 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { PipelineService } from '../pipeline.service';
+import { AuthService } from '../auth.service';
+
+/** Destination-side typing dialog: shows the types inferred on demand from
+ *  landed data (with per-column sample values as evidence), lets the user
+ *  adjust any column, and applies — which migrates the landed table first and
+ *  then writes the typed config as a new pipeline version. Stateless on the
+ *  server: closing without applying leaves nothing behind. */
+@Component({
+    selector: 'app-dest-types-dialog',
+    templateUrl: './dest-types-dialog.component.html',
+    styleUrls: ['./dest-types-dialog.component.css'],
+    standalone: false
+})
+export class DestTypesDialogComponent implements OnInit {
+  @Input() pipeline = '';
+  @Output() closed = new EventEmitter<void>();
+  /** Emitted after a successful apply so the opener can refresh its rows
+   *  (the badge clears itself once the config carries types). */
+  @Output() applied = new EventEmitter<void>();
+
+  loading = true;
+  proposal: any = null;
+  /** Editable copy of the proposed fields: {name, type, samples, stringReason}. */
+  fields: any[] = [];
+  types = ['string', 'boolean', 'int', 'bigint', 'float', 'double', 'date', 'timestamp'];
+
+  applying = false;
+  appliedResult: any = null;
+  error = '';
+
+  constructor(private pipelineService: PipelineService, public auth: AuthService) {}
+
+  ngOnInit(): void {
+    this.pipelineService.getDestTypes(this.pipeline).subscribe({
+      next: (proposal) => {
+        this.proposal = proposal;
+        this.fields = (proposal?.fields || []).map((f: any) => ({ ...f }));
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err.error?.error || err.error || err.message || 'Failed to infer types';
+        this.loading = false;
+      }
+    });
+  }
+
+  hasTypedField(): boolean {
+    return this.fields.some(f => f.type && f.type.toLowerCase() !== 'string');
+  }
+
+  samplesFor(f: any): string {
+    return (f.samples || []).join(', ');
+  }
+
+  apply(): void {
+    this.applying = true;
+    this.error = '';
+    const fields = this.fields.map(f => ({ name: f.name, type: f.type }));
+    this.pipelineService.applyDestTypes(this.pipeline, fields).subscribe({
+      next: (result) => {
+        this.applying = false;
+        this.appliedResult = result;
+        this.applied.emit();
+      },
+      error: (err) => {
+        this.applying = false;
+        this.error = err.error?.error || err.error || err.message || 'Apply failed';
+      }
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/ui/src/app/pipeline-view/pipeline-view.component.css
+++ b/ui/src/app/pipeline-view/pipeline-view.component.css
@@ -196,3 +196,39 @@
   from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* "Stored as text" banner — quiet, sits above the config JSON. */
+.text-types-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  background: rgba(217, 164, 65, 0.1);
+  border: 1px solid rgba(217, 164, 65, 0.3);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.text-types-banner .material-icons {
+  font-size: 18px;
+  color: #d9a441;
+}
+
+.banner-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid rgba(217, 164, 65, 0.5);
+  border-radius: 6px;
+  background: transparent;
+  color: #d9a441;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.banner-btn:hover {
+  background: rgba(217, 164, 65, 0.15);
+}

--- a/ui/src/app/pipeline-view/pipeline-view.component.html
+++ b/ui/src/app/pipeline-view/pipeline-view.component.html
@@ -38,8 +38,20 @@
     <pre>{{ error }}</pre>
   </div>
 
+  <!-- Destination-typing banner: this dataset is stored all-text on a typable
+       destination. Quiet by design — a line, not a modal. -->
+  <div class="text-types-banner" *ngIf="isAllText()">
+    <span class="material-icons">text_fields</span>
+    <span>All destination columns are stored as text.</span>
+    <button class="banner-btn" *ngIf="auth.canWrite()" (click)="showDestTypes = true">Set types…</button>
+  </div>
+
   <div class="config-container" *ngIf="configJson">
     <pre class="config-json" [innerText]="configJson"></pre>
   </div>
   <div class="copy-toast" *ngIf="copySuccess">Copied to clipboard</div>
 </div>
+
+<app-dest-types-dialog *ngIf="showDestTypes"
+                       [pipeline]="name"
+                       (closed)="showDestTypes = false"></app-dest-types-dialog>

--- a/ui/src/app/pipeline-view/pipeline-view.component.ts
+++ b/ui/src/app/pipeline-view/pipeline-view.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PipelineService } from '../pipeline.service';
 import { AuthService } from '../auth.service';
+import { isAllTextDestination } from '../shared/dest-types';
 
 @Component({
     selector: 'app-pipeline-view',
@@ -17,6 +18,7 @@ export class PipelineViewComponent implements OnInit, OnDestroy {
   copySuccess = false;
   confirmDelete = false;
   deleteLoading = false;
+  showDestTypes = false;
   private refreshInterval: any = null;
 
   constructor(private route: ActivatedRoute, private router: Router, private pipelineService: PipelineService, public auth: AuthService) { }
@@ -46,6 +48,12 @@ export class PipelineViewComponent implements OnInit, OnDestroy {
         this.error = err.error || err.message || 'Failed to load pipeline';
       }
     });
+  }
+
+  /** "Stored as text" banner condition — computed from the loaded config, so
+   *  it clears on the next refresh after types are applied. */
+  isAllText(): boolean {
+    return isAllTextDestination(this.config);
   }
 
   copyConfig(): void {

--- a/ui/src/app/pipeline.service.ts
+++ b/ui/src/app/pipeline.service.ts
@@ -53,6 +53,17 @@ export class PipelineService {
     return this.http.post<any>('/api/v1/pipeline/generate', formData);
   }
 
+  // --- Destination-side typing ----------------------------------------------
+  // Stateless propose/apply pair: GET infers types on demand from landed
+  // rows; POST migrates the destination table and writes the typed config.
+  getDestTypes(name: string): Observable<any> {
+    return this.http.get<any>('/api/v1/pipeline/dest-types?pipeline=' + encodeURIComponent(name));
+  }
+
+  applyDestTypes(name: string, fields: Array<{name: string, type: string}>): Observable<any> {
+    return this.http.post<any>('/api/v1/pipeline/dest-types', { pipeline: name, fields });
+  }
+
   // --- Definition version history -------------------------------------------
   getPipelineVersions(name: string): Observable<any[]> {
     return this.http.get<any[]>('/api/v1/pipeline/versions?name=' + encodeURIComponent(name));

--- a/ui/src/app/pipelines/pipelines.component.html
+++ b/ui/src/app/pipelines/pipelines.component.html
@@ -80,7 +80,12 @@
                    (click)="$event.stopPropagation()"
                    #nameInput>
           </td>
-          <td class="embed-details" [title]="getDestinations(ds)">{{ getDestinations(ds) || '—' }}</td>
+          <td class="embed-details" [title]="getDestinations(ds)">
+            {{ getDestinations(ds) || '—' }}
+            <button class="text-type-badge" *ngIf="isAllText(ds)"
+                    (click)="openDestTypesDialog($event, ds.name)"
+                    title="All destination columns are stored as text — set real types">text</button>
+          </td>
           <td>
             <span *ngIf="pipelineToTap[ds.name]" class="embed-connection" [title]="pipelineToTap[ds.name]">← {{ pipelineToTap[ds.name] }}</span>
             <span *ngIf="!pipelineToTap[ds.name]" class="embed-muted">—</span>
@@ -159,7 +164,12 @@
             <span *ngIf="!pipelineToTap[ds.name]" class="tap-none">—</span>
           </td>
           <td>{{ getSourceType(ds) }}</td>
-          <td>{{ getDestinations(ds) }}</td>
+          <td>
+            {{ getDestinations(ds) }}
+            <button class="text-type-badge" *ngIf="isAllText(ds)"
+                    (click)="openDestTypesDialog($event, ds.name)"
+                    title="All destination columns are stored as text — set real types">text</button>
+          </td>
           <td class="actions-cell">
             <button class="action-btn view-btn" (click)="viewPipeline($event, ds.name)" title="View configuration"><span class="material-icons">visibility</span></button>
             <button class="action-btn ingest-btn" (click)="openUploadModal($event, ds.name)" title="Ingest data" *ngIf="auth.canWrite()"><span class="material-icons">upload_file</span></button>
@@ -191,6 +201,12 @@
     <p>No pipelines registered. Use the Create Pipeline button, the API or MCP server to create one.</p>
   </div>
 </div>
+
+<!-- Destination-typing dialog (opened from the "text" badge) -->
+<app-dest-types-dialog *ngIf="destTypesPipeline"
+                       [pipeline]="destTypesPipeline"
+                       (closed)="destTypesPipeline = ''"
+                       (applied)="loadPipelines()"></app-dest-types-dialog>
 
 <!-- Pipeline Architecture Diagram Modal -->
 <div class="modal-overlay" *ngIf="showDiagram" (click)="showDiagram = false">

--- a/ui/src/app/pipelines/pipelines.component.ts
+++ b/ui/src/app/pipelines/pipelines.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy, ViewChildren, ElementRef, QueryList, Input, HostListener } from '@angular/core';
 import { Router } from '@angular/router';
 import { PipelineService } from '../pipeline.service';
+import { isAllTextDestination } from '../shared/dest-types';
 import { isColumnDragActive } from '../shared/resizable-columns.directive';
 import { PipelineStatusService } from '../pipeline-status.service';
 import { TapService } from '../tap.service';
@@ -44,6 +45,10 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   private refreshInterval: any;
 
   deleteCatalogTarget = '';
+
+  // Destination-typing dialog (the Catalog "text" badge). Holds the pipeline
+  // name the dialog is open for, or '' when closed.
+  destTypesPipeline = '';
 
   // Upload modal
   showUploadModal = false;
@@ -309,6 +314,17 @@ export class PipelinesComponent implements OnInit, OnDestroy {
     if (dataset.destination.chroma) dests.push('Chroma');
     if (dataset.destination.pgvector) dests.push('pgvector');
     return dests.join(', ');
+  }
+
+  /** "text" badge condition: in-scope destination whose columns are all
+   *  still stored as text. Computed from the config each render. */
+  isAllText(dataset: any): boolean {
+    return isAllTextDestination(dataset);
+  }
+
+  openDestTypesDialog(event: Event, name: string): void {
+    event.stopPropagation();
+    this.destTypesPipeline = name;
   }
 
   // Upload modal

--- a/ui/src/app/shared/dest-types.ts
+++ b/ui/src/app/shared/dest-types.ts
@@ -1,0 +1,12 @@
+/** True when this pipeline's destination supports on-demand typing
+ *  (postgres/snowflake/databricks) and every effective destination column is
+ *  still stored as text — the condition behind the Catalog "text" badge.
+ *  Computed from config already in hand; never stored. The server enforces
+ *  the same rule, so a stale positive just opens a dialog that explains. */
+export function isAllTextDestination(config: any): boolean {
+  const db = config?.destination?.database;
+  if (!db || !(db.usePostgres || db.useSnowflake || db.useDatabricks)) return false;
+  const fields = config?.destination?.schemaProperties?.fields;
+  if (!Array.isArray(fields) || fields.length === 0) return false;
+  return fields.every((f: any) => !f?.type || String(f.type).toLowerCase() === 'string');
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -153,6 +153,29 @@ tr:hover .embed-name-edit-btn { opacity: 1; }
   letter-spacing: 0.03em;
 }
 
+/* Destination-typing badge: shown when every destination column is still
+   stored as text on a typable destination. Clicking opens the typing dialog;
+   the badge clears itself once the config carries types. */
+.text-type-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(217, 164, 65, 0.14);
+  color: #d9a441;
+  border: none;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.text-type-badge:hover {
+  background: rgba(217, 164, 65, 0.28);
+}
+
 .embed-cron {
   font-family: var(--font-mono);
   font-size: 12px;


### PR DESCRIPTION
## What

Agent-created pipelines land every destination column as TEXT (all-string MCP ingest) and stayed that way forever — weak DQ, wrong warehouse types, useless ORDER BY/aggregation on numerics. This adds the pull-based fix from the destination-side-types plan: no triggers, no proposal store, no prompt choreography. Typing is a user-initiated action from the Catalog.

## How

- **`GET /api/v1/pipeline/dest-types`** — stateless: samples up to 1000 landed rows, runs deterministic widening inference (`DestTypeInference`, salvaged from the shelved `feature/destination-schema-after-load` branch), and returns per-column evidence: up to 5 distinct sample values, plus — for columns kept as string by a dirty value — the offending value and the type it blocked ("stayed text — found 'N/A', would otherwise be int"). Ineligible pipelines get a reason: `destination-not-supported` | `already-typed` | `no-landed-rows`.
- **`POST /api/v1/pipeline/dest-types`** — applies (possibly edited) types, destination-first: Postgres `ALTER … TYPE … USING NULLIF(...)::type` in one transaction; Snowflake/Databricks TRY_CAST-validate 100% of landed values then `CREATE OR REPLACE TABLE … AS SELECT CAST(...)` swap. Any un-castable value fails the whole apply naming the column, with config and data untouched. Config is then written via `writeVersioned` — table first, config second, so every intermediate state is safe.
- **UI** — computed (never stored) "text" badge on all-string typable pipelines in the Catalog rows and pipeline view; opens an editable typing dialog with the per-column samples and stayed-string reasons. The badge clears itself once the config carries types.
- **MCP** — `get_dest_types` / `apply_dest_types` tools (apply requires explicit user approval per its description). No Assistant prompt changes.
- **OpenAPI** — both endpoints documented.

## Scope

v1 = Postgres, Snowflake, Databricks. Objectstore deferred (its migration is a non-atomic background rewrite that would need stored status). Mongo (schemaless) and vector destinations (no field schema) are not applicable. Wizard-typed pipelines are untouched — every guard checks the effective fields are still all-string.

## Backward compatibility

Nothing changes for any pipeline until a user opens the dialog and applies. No background reads, no new writes on any existing path; MCP ingest stays `allStrings: true`. No changes to `PipelineConfig`, `SchemaField`, `EntityVersion`, or any loader — typed table + typed config means the existing load paths already enforce (Postgres COPY, Snowflake COPY INTO/MERGE via typed temp table, Databricks CAST select).

## Testing

- 37 new tests: full inference lattice + evidence collection (samples, truncation, string reasons), apply guards (scope, field-name immutability, type whitelist). Full suite 259/259 green; UI production build clean.
- Live E2E: the Postgres path was verified end-to-end through the in-platform Assistant on a local rebuild (all-text landing detected, typed via the new tools). The Postgres ALTER migration itself was previously live-verified on the shelved branch (29 TEXT columns in 1.3s, data intact, post-migration upsert clean). Snowflake/Databricks migrations are implemented but have not run against real warehouses yet — flagged in the plan as a pre-release verify item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)