### PR TITLE
Agent policy: per-action auto/approve/deny for agents, with a human approval queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,13 @@ OPENAI_API_KEY=
 # AUDIT_LOG_RETENTION_DAYS=90
 # AUDIT_LOG_READS=false
 
+# Agent policy. USE_AGENT_POLICY=true lets an admin decide, per action, whether
+# agents run it on their own, wait for a person to approve it, or are refused —
+# Configuration → Agent Policy; queued actions appear under Activity →
+# Approvals. With it on and no rules set, nothing changes.
+# See https://docs.datris.ai/agent-policy.
+# USE_AGENT_POLICY=false
+
 # Hardening (recommended for any internet-reachable deployment):
 # SESSION_COOKIE_SECURE=true marks the login cookie Secure so it is only sent
 #   over HTTPS. Leave unset for local HTTP dev; set true wherever TLS terminates.

--- a/datrisserver/src/main/resources/application.yaml
+++ b/datrisserver/src/main/resources/application.yaml
@@ -48,6 +48,11 @@ auditLog:
   retentionDays: 90       # Mongo TTL on entries; 0 = never expire
   logReads: false         # also record query/search/metadata/GET routes (high volume)
   emitLogLine: true       # mirror each entry to logger ai.datris.audit (JSON under the production profile)
+# Agent policy: per-action auto / approve / deny for agent-initiated requests,
+# with a human approval queue (Configuration → Agent Policy, Activity →
+# Approvals). Off by default; with it on and no policy saved, nothing changes
+# until an admin sets an action to approve or deny. Env var: USE_AGENT_POLICY.
+useAgentPolicy: "false"
 
 # CORS allowed origins (comma-separated). Use "*" for any origin (dev only).
 # Production: lock down to specific origins, e.g. "https://app.datris.ai,https://admin.datris.ai"

--- a/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
@@ -43,6 +43,15 @@ class StartupRunner extends ApplicationRunner {
     @Value("${auditLog.emitLogLine:true}")
     var auditLogEmitLogLine: Boolean = _
 
+    // Agent policy — approval gate for agent-initiated actions. Off by
+    // default; needs a restart to flip, like the sibling flags.
+    @Value("${useAgentPolicy:false}")
+    var useAgentPolicy: Boolean = _
+
+    // Where an approved agent action is replayed to (this server).
+    @Value("${server.port:8080}")
+    var serverPort: Int = _
+
     @Value("${secrets.apiKeysSecretName:}")
     var apiKeysSecretName: String = _
 
@@ -175,6 +184,11 @@ class StartupRunner extends ApplicationRunner {
         if (!ai.datris.util.TapScriptRunner.useTapRunner)
             ai.datris.util.TapScriptRunner.warnInProcess("startup")
         initDatrisEnvironment()
+        ai.datris.policy.PolicyReplay.port = serverPort
+        if (useAgentPolicy)
+            logger.info(
+                "Agent policy enabled: collections=" + environment + "-agent-policy, " + environment + "-pending-action; approvals replay to port " + serverPort
+            )
         if (useAuditLog)
             logger.info("Audit log enabled: collection=" + environment + "-audit-log, retentionDays=" + auditLogRetentionDays +
                 ", logReads=" + auditLogLogReads + ", emitLogLine=" + auditLogEmitLogLine)
@@ -327,6 +341,9 @@ class StartupRunner extends ApplicationRunner {
             useAuditLog = useAuditLog,
             auditLogTableName = environment + "-audit-log",
             auditLogRetentionDays = auditLogRetentionDays,
+            useAgentPolicy = useAgentPolicy,
+            agentPolicyTableName = environment + "-agent-policy",
+            pendingActionTableName = environment + "-pending-action",
             auditLogLogReads = auditLogLogReads,
             auditLogEmitLogLine = auditLogEmitLogLine
         )

--- a/datrisserver/src/main/scala/ai/datris/api/ApprovalsAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/ApprovalsAPIController.scala
@@ -1,0 +1,219 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.{AuditActor, AuditLog}
+import ai.datris.config.RequiresRole
+import ai.datris.model.UserContext
+import ai.datris.policy._
+import com.google.common.base.Throwables
+import com.google.gson.{Gson, JsonArray, JsonObject, JsonParser}
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+import java.time.Instant
+
+/** Pending agent actions parked by the policy, and the human decisions on
+  * them. Agents see only what they queued; people see everything. Deciding
+  * is for admins and editors — and never for an agent, whatever key it
+  * holds. */
+@RestController
+@RequestMapping(Array("/api/v1/approvals"))
+class ApprovalsAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[ApprovalsAPIController])
+    private val gson = new Gson()
+    private val ResultBodyClip = 4000
+
+    @GetMapping(produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def list(
+        @RequestParam(name = "state", required = false) state: String,
+        @RequestParam(name = "actor", required = false) actor: String,
+        @RequestParam(name = "limit", required = false) limit: Integer,
+        request: HttpServletRequest
+    ): ResponseEntity[String] = {
+        try {
+            val out = new JsonObject()
+            out.addProperty("enabled", PolicyIO.enabled)
+            val arr = new JsonArray()
+            if (PolicyIO.enabled) {
+                val st = Option(state).map(_.trim).filter(_.nonEmpty)
+                if (st.exists(s => !PendingAction.States.contains(s)))
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String](
+                        errorJson("state must be one of " + PendingAction.States.toSeq.sorted.mkString(", "))
+                    )
+                val actorFilter =
+                    if (PolicyActor.isAgent(request)) Some(PolicyActor.label(request))
+                    else Option(actor).map(_.trim).filter(_.nonEmpty)
+                val lim = Option(limit).map(_.intValue()).getOrElse(100)
+                PendingActionIO.list(st, actorFilter, lim).foreach(pa => arr.add(pa.toPublicJson))
+            }
+            out.add("approvals", arr)
+            new ResponseEntity[String](gson.toJson(out), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error listing approvals: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    @GetMapping(path = Array("/{id}"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def get(@PathVariable("id") id: String, request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            if (!PolicyIO.enabled) return disabled()
+            visible(id, request) match {
+                case Some(pa) => new ResponseEntity[String](gson.toJson(pa.toPublicJson), HttpStatus.OK)
+                case None => notFound(id)
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("Error reading approval: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    @PostMapping(path = Array("/{id}/approve"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    @RequiresRole(Array("admin", "editor"))
+    def approve(@PathVariable("id") id: String, request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            if (!PolicyIO.enabled) return disabled()
+            if (PolicyActor.isAgent(request))
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body[String](errorJson("agents may not decide approvals"))
+            val pa = PendingActionIO.get(id).getOrElse(return notFound(id))
+            if (pa.isExpired())
+                return ResponseEntity.status(HttpStatus.GONE).body[String](stateJson(
+                    pa.copy(state = PendingAction.Expired),
+                    "this approval expired before a decision was made"
+                ))
+            if (!pa.isPending)
+                return ResponseEntity.status(HttpStatus.CONFLICT).body[String](stateJson(pa, "this approval was already decided"))
+
+            // Approve what was proposed, not what the agent would propose now.
+            val currentVersion = for { t <- pa.resourceType; n <- pa.resourceName; v <- PolicyGate.currentVersion(t, n) } yield v
+            (pa.resourceVersion, currentVersion) match {
+                case (Some(queued), Some(live)) if queued != live =>
+                    val out = pa.toPublicJson
+                    out.addProperty("error", "stale")
+                    out.addProperty("errorKind", "approval_stale")
+                    out.addProperty("liveVersion", live)
+                    out.addProperty(
+                        "message",
+                        "The " + pa.resourceType.getOrElse(
+                            "resource"
+                        ) + " changed (version " + queued + " → " + live + ") since this action was queued. Reject it and have the agent propose again."
+                    )
+                    return ResponseEntity.status(HttpStatus.CONFLICT).body[String](gson.toJson(out))
+                case _ =>
+            }
+
+            val approver = approverLabel(request)
+            val token = PendingAction.newToken()
+            val now = Instant.now()
+            val moved = PendingActionIO.transition(
+                pa.id,
+                PendingAction.Pending,
+                PendingAction.Approved,
+                "decidedBy" -> approver,
+                "decidedAt" -> now.toString,
+                "replayToken" -> token
+            )
+            if (!moved)
+                return ResponseEntity.status(HttpStatus.CONFLICT).body[String](errorJson("this approval was decided concurrently"))
+            AuditLog.record(request, "approval", "approve", "approval", pa.id, metadata = decisionMd(pa))
+
+            val result =
+                try PolicyReplay.execute(pa, token, UserContext.get().map(_.username))
+                catch {
+                    case e: Exception =>
+                        logger.error("Approval " + pa.id + " replay failed: " + e.getMessage, e)
+                        PolicyReplay.Result(0, "replay failed: " + e.getMessage)
+                }
+            val ok = result.status >= 200 && result.status < 300
+            PendingActionIO.transition(
+                pa.id,
+                PendingAction.Approved,
+                if (ok) PendingAction.Executed else PendingAction.Failed,
+                "executedAt" -> Instant.now().toString,
+                "resultStatus" -> (result.status: java.lang.Integer),
+                "resultBody" -> Option(result.body).getOrElse("").take(ResultBodyClip)
+            )
+            logger.info("Approval " + pa.id + " (" + pa.action + ") approved by " + approver + " → HTTP " + result.status)
+            val updated = PendingActionIO.get(pa.id).getOrElse(pa)
+            new ResponseEntity[String](gson.toJson(updated.toPublicJson), if (ok) HttpStatus.OK else HttpStatus.BAD_GATEWAY)
+        } catch {
+            case e: Exception =>
+                logger.error("Error approving " + id + ": " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    @PostMapping(path = Array("/{id}/reject"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    @RequiresRole(Array("admin", "editor"))
+    def reject(@PathVariable("id") id: String, @RequestBody(required = false) body: String, request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            if (!PolicyIO.enabled) return disabled()
+            if (PolicyActor.isAgent(request))
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body[String](errorJson("agents may not decide approvals"))
+            val pa = PendingActionIO.get(id).getOrElse(return notFound(id))
+            if (!pa.isPending || pa.isExpired())
+                return ResponseEntity.status(HttpStatus.CONFLICT).body[String](stateJson(pa, "this approval is no longer pending"))
+            val note = Option(body).flatMap { b =>
+                try {
+                    val el = JsonParser.parseString(b)
+                    if (el.isJsonObject && el.getAsJsonObject.has("note")) Some(el.getAsJsonObject.get("note").getAsString.take(500)) else None
+                } catch { case _: Exception => None }
+            }
+            val approver = approverLabel(request)
+            val sets = Seq[(String, Any)]("decidedBy" -> approver, "decidedAt" -> Instant.now().toString) ++ note.map(n => "decisionNote" -> (n: Any))
+            val moved = PendingActionIO.transition(pa.id, PendingAction.Pending, PendingAction.Rejected, sets: _*)
+            if (!moved)
+                return ResponseEntity.status(HttpStatus.CONFLICT).body[String](errorJson("this approval was decided concurrently"))
+            AuditLog.record(request, "approval", "reject", "approval", pa.id, metadata = decisionMd(pa))
+            logger.info("Approval " + pa.id + " (" + pa.action + ") rejected by " + approver)
+            val updated = PendingActionIO.get(pa.id).getOrElse(pa)
+            new ResponseEntity[String](gson.toJson(updated.toPublicJson), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error rejecting " + id + ": " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    private def visible(id: String, request: HttpServletRequest): Option[PendingAction] =
+        PendingActionIO.get(id).filter(pa => !PolicyActor.isAgent(request) || pa.actor.label == PolicyActor.label(request))
+
+    private def approverLabel(request: HttpServletRequest): String =
+        UserContext.get().map(_.username).getOrElse(AuditActor.resolve(request).label)
+
+    private def decisionMd(pa: PendingAction): JsonObject = {
+        val m = new JsonObject()
+        m.addProperty("policyAction", pa.action)
+        pa.resourceType.foreach(m.addProperty("resourceType", _))
+        pa.resourceName.foreach(m.addProperty("resource", _))
+        m.addProperty("originalActor", pa.actor.label)
+        m.addProperty("originalActorType", pa.actor.actorType)
+        pa.reason.foreach(m.addProperty("reason", _))
+        m
+    }
+
+    private def stateJson(pa: PendingAction, message: String): String = {
+        val out = pa.toPublicJson
+        out.addProperty("error", message)
+        gson.toJson(out)
+    }
+
+    private def disabled(): ResponseEntity[String] =
+        ResponseEntity.status(HttpStatus.NOT_FOUND).body[String]("{\"error\":\"agent policy is disabled\",\"enabled\":false}")
+
+    private def notFound(id: String): ResponseEntity[String] =
+        ResponseEntity.status(HttpStatus.NOT_FOUND).body[String](errorJson("no approval " + id))
+
+    private def errorJson(msg: String): String =
+        "{\"error\":\"" + Option(msg).getOrElse("").replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ") + "\"}"
+}

--- a/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/AssistantAPIController.scala
@@ -534,6 +534,13 @@ class AssistantAPIController {
             "- This narrows nothing in the rules above: keep asking, proposing, confirming, and waiting exactly where they tell you to — scope/source choices, a plan to approve, destructive-action confirmation, acting only when explicitly authorized. The point is only this: once the next step is already decided or authorized and you are merely narrating it, perform it instead of ending the turn.\n"
         )
         sb.append("\n")
+        sb.append("## Actions that wait for approval\n\n")
+        sb.append(
+            "- **A `pending_approval` result means the action was NOT performed.** This instance's agent policy may require a person to approve certain changes (deletes, destination-type migrations, whatever the administrator chose). When a tool returns `status: pending_approval`, say so plainly — the action is queued as approval `<approvalId>` and waiting under Activity → Approvals — and never describe it as done. Do not re-issue the call to retry it (you get the same id back). You may poll `get_approval` with `wait_seconds` between polls for a short while; after a few polls tell the user you will check back when they ask.\n"
+        )
+        sb.append(
+            "- **`errorKind: policy_denied` means the action is refused for agents on this instance.** Report that and stop; do not look for another route to the same effect, and never ask the user for a key or credential to get around it. Call `get_agent_policy` first when you are about to delete something or migrate a destination table, so you can tell the user in advance whether it will run or queue.\n\n"
+        )
         sb.append("## Never narrate a tool call you didn't make\n\n")
         sb.append(
             "- **Every claim about an action's outcome — \"run submitted\", \"types applied\", \"N records loaded\", \"status: success\" — must be backed by a tool result you actually received in this conversation.** Tool results are your ONLY window into what happened; you cannot know an outcome any other way. Writing an outcome you did not observe is fabrication — worse than reporting an error, because the user makes real decisions on it.\n"

--- a/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
@@ -465,7 +465,13 @@ object KeysAPIController {
         ("metadata", Seq("read"), Seq.empty),
         ("config", Seq("read", "write"), Seq.empty),
         ("mcp", Seq("tool"), Seq.empty),
-        ("audit", Seq("read"), Seq.empty)
+        ("audit", Seq("read"), Seq.empty),
+        // Agent policy: any key may read it; `policy:update` exists for the UI's
+        // own key — PolicyInterceptor refuses it from agents regardless.
+        ("policy", Seq("read", "update"), Seq.empty),
+        // Approvals: agents read/poll what they queued (owner=self); deciding
+        // is a person's job — the interceptor refuses agents even with the cap.
+        ("approval", Seq("read", "decide"), Seq("owner"))
     )
 
     /** Capability templates the Keys-UI wizard offers as starting points.

--- a/datrisserver/src/main/scala/ai/datris/api/OpsChatAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/OpsChatAPIController.scala
@@ -370,6 +370,10 @@ class OpsChatAPIController {
             "- **Tap secrets are tagged `_type=tap`.** You can read and rotate them but you can only modify secrets the platform owns (the MCP layer enforces this). If a rotation fails with an ownership error, surface that clearly — don't retry.\n\n"
         )
 
+        sb.append("## Actions that wait for approval\n\n")
+        sb.append(
+            "- **A `pending_approval` result means the action was NOT performed.** The agent policy on this instance may require a person to approve some actions. When a tool returns `status: pending_approval`, say the action is queued (approval `<approvalId>`, under Activity → Approvals on this same page) and never describe it as done; do not re-issue the call. `errorKind: policy_denied` means it is refused for agents here — report that and stop.\n\n"
+        )
         sb.append("## When the snapshot looks empty\n\n")
         sb.append(
             "If the dashboard snapshot has no failures, no stale taps, and no volume anomalies, the platform is healthy. Say so plainly. Offer to spot-check anything the operator names, but don't fabricate problems to solve.\n\n"

--- a/datrisserver/src/main/scala/ai/datris/api/PolicyAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/PolicyAPIController.scala
@@ -1,0 +1,82 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActor
+import ai.datris.config.RequiresRole
+import ai.datris.model.DatrisEnvironment
+import ai.datris.policy.{AgentPolicy, PendingActionIO, PolicyActor, PolicyIO, PolicyRoutes}
+import com.google.common.base.Throwables
+import com.google.gson.{Gson, JsonArray, JsonObject}
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** The agent policy document: what agents may do on their own, what waits
+  * for a person, what is refused. Anyone may read it (agents use it to know
+  * what will queue before they act); only an admin — never an agent — may
+  * change it. */
+@RestController
+@RequestMapping(Array("/api/v1/policy"))
+class PolicyAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[PolicyAPIController])
+    private val gson = new Gson()
+
+    @GetMapping(produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def get(): ResponseEntity[String] = {
+        try {
+            val out = new JsonObject()
+            out.addProperty("enabled", PolicyIO.enabled)
+            if (PolicyIO.enabled) {
+                out.add("policy", PolicyIO.current.toJson)
+                out.addProperty("pendingCount", PendingActionIO.countPendingAll())
+            } else {
+                out.add("policy", AgentPolicy.Empty.toJson)
+                out.addProperty("pendingCount", 0)
+            }
+            out.add("recommended", AgentPolicy.Recommended.toJson)
+            val actions = new JsonArray()
+            PolicyRoutes.catalog.foreach(actions.add)
+            out.add("actions", actions)
+            new ResponseEntity[String](gson.toJson(out), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error reading agent policy: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    @PutMapping(consumes = Array(MediaType.APPLICATION_JSON_VALUE), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    @RequiresRole(Array("admin"))
+    def put(@RequestBody body: String, request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            if (!PolicyIO.enabled)
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body[String](
+                    "{\"error\":\"agent policy is disabled\",\"hint\":\"set USE_AGENT_POLICY=true and recreate the datris container\"}"
+                )
+            if (PolicyActor.isAgent(request))
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body[String](errorJson("agents may not change the agent policy"))
+            AgentPolicy.fromJson(body) match {
+                case Left(err) => ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String](errorJson(err))
+                case Right(p) =>
+                    val saved = PolicyIO.write(p, AuditActor.resolve(request).label)
+                    logger.info("Agent policy updated to version " + saved.version + " by " + saved.updatedBy.getOrElse("?"))
+                    val out = new JsonObject()
+                    out.addProperty("enabled", true)
+                    out.add("policy", saved.toJson)
+                    new ResponseEntity[String](gson.toJson(out), HttpStatus.OK)
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("Error updating agent policy: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    private def errorJson(msg: String): String =
+        "{\"error\":\"" + Option(msg).getOrElse("").replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ") + "\"}"
+}

--- a/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
@@ -44,6 +44,7 @@ class VersionAPIController {
                 "useUserAuth" -> DatrisEnvironment.values.useUserAuth.toString,
                 "useApiKeys" -> DatrisEnvironment.values.useApiKeys.toString,
                 "useAuditLog" -> DatrisEnvironment.values.useAuditLog.toString,
+                "useAgentPolicy" -> DatrisEnvironment.values.useAgentPolicy.toString,
                 "postgresDatabase" -> DatrisEnvironment.current.postgresDatabase,
                 "mongodbDatabase" -> mongodbDatabase,
                 "useTapRunner" -> ai.datris.util.TapScriptRunner.useTapRunner.toString

--- a/datrisserver/src/main/scala/ai/datris/audit/AuditActor.scala
+++ b/datrisserver/src/main/scala/ai/datris/audit/AuditActor.scala
@@ -25,6 +25,17 @@ object AuditActor {
       * Agent Monitor's activity buffer while that buffer still holds it. */
     val HeaderAgentSession = "X-Datris-Agent-Session"
 
+    /** Free-text intent an agent may attach to a mutating call (the MCP
+      * tools' optional `reason` argument). Stored in audit metadata and on
+      * pending approvals; never interpreted. */
+    val HeaderReason = "X-Datris-Reason"
+
+    /** Request attribute (the approval id) PolicyInterceptor sets on the
+      * replay of an approved agent action. The replay carries the ui key on
+      * behalf of the approver; with this attribute present the approver is
+      * recorded as a plain user — it is their decision being executed. */
+    val ApprovalReplayAttr = "ai.datris.policy.approvalReplay"
+
     /** Sent by TapScriptRunner on outbound HTTP-tap endpoint calls. NOT used
       * for inbound actor resolution — a tap's identity on the platform
       * callback comes from its per-run token (label `tap:<name>`), which
@@ -103,6 +114,8 @@ object AuditActor {
     def resolve(request: HttpServletRequest): AuditActorInfo = {
         val onBehalfOf = Option(request.getAttribute(OnBehalfOfAttr)).collect { case u: User => u }
         val carrier = Option(request.getAttribute(CarrierKeyLabelAttr)).collect { case s: String => s }
-        from(ResolvedKeyAccess.fromRequest(request), UserContext.get(), onBehalfOf, carrier)
+        val replay = request.getAttribute(ApprovalReplayAttr) != null
+        val sessionUser = UserContext.get().orElse(if (replay) onBehalfOf else None)
+        from(ResolvedKeyAccess.fromRequest(request), sessionUser, if (replay) None else onBehalfOf, carrier)
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -155,8 +155,24 @@ object CapabilityRoutes {
         // Audit log — admin surface. Full-access keys hold it implicitly; a
         // scoped key needs `audit:read` explicitly (see the Keys catalog).
         Route("GET", "/api/v1/audit-log", "audit", "read"),
-        Route("GET", "/api/v1/audit-log/**", "audit", "read")
+        Route("GET", "/api/v1/audit-log/**", "audit", "read"),
+
+        // Agent policy — readable by anyone (agents consult it before acting);
+        // writable only by an admin, and never by an agent (PolicyInterceptor
+        // hard rule, independent of capability).
+        Route("GET", "/api/v1/policy", "policy", "read"),
+        Route("PUT", "/api/v1/policy", "policy", "update"),
+
+        // Approvals — agents list/poll their own; people decide.
+        Route("GET", "/api/v1/approvals", "approval", "read"),
+        Route("GET", "/api/v1/approvals/**", "approval", "read"),
+        Route("POST", "/api/v1/approvals/*/approve", "approval", "decide"),
+        Route("POST", "/api/v1/approvals/*/reject", "approval", "decide")
     )
+
+    /** Every `resource:action` pair the table grants — the vocabulary the
+      * agent policy is allowed to use. */
+    lazy val allActionKeys: Set[String] = routes.map(r => r.resource + ":" + r.action).toSet
 
     def lookup(method: String, path: String): RouteCheck = {
         if (skipPatterns.exists(p => matcher.`match`(p, path))) return RouteCheck.Skip

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -132,7 +132,12 @@ object MCPToolRoutes {
         "restore_pipeline_version" -> Mapped("POST", "/api/v1/pipeline/version/restore"),
 
         // Agent workflow helper — no REST call at all
-        "wait_seconds" -> Local
+        "wait_seconds" -> Local,
+
+        // Agent policy / approvals
+        "get_agent_policy" -> Mapped("GET", "/api/v1/policy"),
+        "list_pending_approvals" -> Mapped("GET", "/api/v1/approvals"),
+        "get_approval" -> Mapped("GET", "/api/v1/approvals/example")
     )
 
     val allToolNames: Seq[String] = tools.map(_._1)

--- a/datrisserver/src/main/scala/ai/datris/config/AuditInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/AuditInterceptor.scala
@@ -69,6 +69,13 @@ class AuditInterceptor extends HandlerInterceptor {
                     o.addProperty("agentSession", sid.take(64))
                     o
                 }.orElse(metadata)
+                // An agent's stated intent for a mutating call (optional `reason`
+                // argument on the MCP tools). Recorded verbatim, never acted on.
+                val withReason = Option(request.getHeader(AuditActor.HeaderReason)).map(_.trim).filter(_.nonEmpty).map { r =>
+                    val o = withSession.getOrElse(new JsonObject())
+                    if (!o.has("reason")) o.addProperty("reason", r.take(500))
+                    o
+                }.orElse(withSession)
 
                 AuditLog.submit(AuditEntry(
                     ts = Instant.now(),
@@ -82,7 +89,7 @@ class AuditInterceptor extends HandlerInterceptor {
                     durationMs = durationMs,
                     errorMessage = errorMessage,
                     request = Some(AuditLog.requestInfo(request)),
-                    metadata = withSession
+                    metadata = withReason
                 ))
             }
         } catch {

--- a/datrisserver/src/main/scala/ai/datris/config/PolicyBodyCacheFilter.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/PolicyBodyCacheFilter.scala
@@ -1,0 +1,72 @@
+package ai.datris.config
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.policy.{PolicyGate, PolicyIO}
+import jakarta.servlet.{FilterChain, ReadListener, ServletInputStream}
+import jakarta.servlet.http.{HttpServletRequest, HttpServletRequestWrapper, HttpServletResponse}
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.util.StreamUtils
+
+import java.io.{BufferedReader, ByteArrayInputStream, InputStreamReader}
+import java.nio.charset.StandardCharsets
+
+/** Reads small JSON write bodies up front so PolicyInterceptor can park the
+  * request for approval BEFORE the controller consumes the stream. Unlike
+  * AuditBodyCacheFilter (which caches lazily as the controller reads), this
+  * has to read eagerly — an approval decision needs the whole body while the
+  * controller has not run yet. The controller then reads the same bytes
+  * from the wrapper, unchanged. Inert while `useAgentPolicy` is off. */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+class PolicyBodyCacheFilter extends OncePerRequestFilter {
+
+    override def shouldNotFilter(request: HttpServletRequest): Boolean = {
+        if (!PolicyIO.enabled) return true
+        val method = request.getMethod
+        val isWrite = method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE"
+        val uri = request.getRequestURI
+        val ct = Option(request.getContentType).getOrElse("").toLowerCase
+        val len = request.getContentLengthLong
+        !(isWrite && uri != null && uri.startsWith("/api/") && ct.contains("application/json") && len != 0 && len <= PolicyGate.MaxBodyBytes)
+    }
+
+    override def doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit = {
+        val bytes = StreamUtils.copyToByteArray(request.getInputStream)
+        if (bytes.length > PolicyGate.MaxBodyBytes) {
+            // Chunked body that turned out larger than the cap: hand the
+            // bytes on without the attribute, so the request is not queueable.
+            chain.doFilter(new CachedBodyRequest(request, bytes), response)
+        } else {
+            request.setAttribute(PolicyGate.BodyAttr, bytes)
+            chain.doFilter(new CachedBodyRequest(request, bytes), response)
+        }
+    }
+}
+
+/** A request whose body is served from a byte array, re-readable. */
+class CachedBodyRequest(request: HttpServletRequest, bytes: Array[Byte]) extends HttpServletRequestWrapper(request) {
+
+    override def getInputStream: ServletInputStream = {
+        val in = new ByteArrayInputStream(bytes)
+        new ServletInputStream {
+            override def isFinished: Boolean = in.available() == 0
+            override def isReady: Boolean = true
+            override def setReadListener(listener: ReadListener): Unit = {}
+            override def read(): Int = in.read()
+            override def read(b: Array[Byte], off: Int, len: Int): Int = in.read(b, off, len)
+        }
+    }
+
+    override def getReader: BufferedReader =
+        new BufferedReader(new InputStreamReader(getInputStream, Option(request.getCharacterEncoding).getOrElse(StandardCharsets.UTF_8.name())))
+
+    override def getContentLength: Int = bytes.length
+    override def getContentLengthLong: Long = bytes.length.toLong
+}

--- a/datrisserver/src/main/scala/ai/datris/config/PolicyInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/PolicyInterceptor.scala
@@ -1,0 +1,240 @@
+package ai.datris.config
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.{AuditActor, AuditLog}
+import ai.datris.policy._
+import com.google.gson.JsonObject
+import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/** The agent policy gate. Runs after CapabilityInterceptor (a key that may
+  * not do something at all is refused there, as today) and before the role
+  * and audit interceptors.
+  *
+  * For an agent-initiated request whose action the policy marks:
+  *   - `auto`    → continue, nothing changes.
+  *   - `deny`    → 403 with a parseable body; recorded as a security denial.
+  *   - `approve` → the request is NOT executed. It is stored as a
+  *                 [[PendingAction]] and the caller gets 202 with an
+  *                 `approvalId`. A human approves or rejects it later; on
+  *                 approval the stored request is replayed through this same
+  *                 chain carrying `X-Datris-Approval`, which this interceptor
+  *                 recognizes and consumes (single use) instead of gating.
+  *
+  * Humans are never gated (see [[PolicyActor]]). Two rules are not policy
+  * but hard-wired: an agent can never change the policy, and can never
+  * decide an approval. Inert while `useAgentPolicy` is off. */
+@Component
+class PolicyInterceptor extends HandlerInterceptor {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    override def preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean = {
+        if (!PolicyIO.enabled) return true
+
+        val approvalHeader = Option(request.getHeader(PolicyReplay.HeaderApproval)).map(_.trim).filter(_.nonEmpty)
+        if (approvalHeader.isDefined) return handleReplay(request, response, approvalHeader.get)
+
+        if (!PolicyActor.isAgent(request)) return true
+
+        val method = request.getMethod
+        val path = request.getRequestURI
+        val actionKey = PolicyRoutes.actionKey(method, path).getOrElse(return true)
+
+        // Hard rules, independent of the policy document.
+        if (actionKey == "policy:update" || actionKey == "approval:decide")
+            return deny(request, response, actionKey, "agents may not change the agent policy or decide approvals", hardRule = true)
+
+        if (!PolicyRoutes.isGateable(actionKey)) return true
+
+        val resourceType = PolicyRoutes.resourceType(actionKey)
+        val resourceName = PolicyGate.resourceName(request)
+        val policy = PolicyIO.current
+        policy.decide(actionKey, Some(resourceType), resourceName) match {
+            case PolicyMode.Auto => true
+            case PolicyMode.Deny => deny(request, response, actionKey, "denied by agent policy", hardRule = false)
+            case PolicyMode.Approve => queue(request, response, policy, actionKey, resourceType, resourceName)
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    private def deny(request: HttpServletRequest, response: HttpServletResponse, actionKey: String, reason: String, hardRule: Boolean): Boolean = {
+        val actor = AuditActor.resolve(request)
+        logger.info("agent policy: {} {} action={} actor={} outcome=deny", Array[AnyRef](request.getMethod, request.getRequestURI, actionKey, actor.label): _*)
+        val body = new JsonObject()
+        body.addProperty("error", reason)
+        body.addProperty("errorKind", "policy_denied")
+        body.addProperty("action", actionKey)
+        body.addProperty(
+            "message",
+            "The agent policy on this Datris instance does not allow agents to perform '" + actionKey + "'. " +
+                (if (hardRule) "This rule cannot be changed by policy: only a person can do this. "
+                 else "An administrator can change this under Configuration → Agent Policy. ") +
+                "Tell the user; do not retry."
+        )
+        PolicyGate.writeJson(response, HttpServletResponse.SC_FORBIDDEN, body)
+        AuditLog.denied(request, reason + " (" + actionKey + ")", HttpServletResponse.SC_FORBIDDEN, required = Some(actionKey))
+        false
+    }
+
+    private def queue(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        policy: AgentPolicy,
+        actionKey: String,
+        resourceType: String,
+        resourceName: Option[String]
+    ): Boolean = {
+        val actor = AuditActor.resolve(request)
+        if (!PolicyGate.isQueueable(request)) {
+            val body = new JsonObject()
+            body.addProperty("status", "not_queueable")
+            body.addProperty("action", actionKey)
+            body.addProperty(
+                "message",
+                "This action requires human approval under the agent policy, but its request body cannot be stored for later replay " +
+                    "(file uploads and very large bodies are not queueable). Ask the user to perform it in the Datris UI."
+            )
+            PolicyGate.writeJson(response, HttpServletResponse.SC_CONFLICT, body)
+            AuditLog.record(
+                request,
+                "policy",
+                "not-queueable",
+                resourceType,
+                resourceName.orNull,
+                outcome = "denied",
+                httpStatus = HttpServletResponse.SC_CONFLICT,
+                metadata = md(actionKey, None, request)
+            )
+            return false
+        }
+
+        val bodyStr = PolicyGate.bodyString(request)
+        val query = Option(request.getQueryString).filter(_.nonEmpty)
+        val hash = PendingAction.hashOf(actor.label, request.getMethod, request.getRequestURI, query, bodyStr)
+
+        try {
+            val existing = PendingActionIO.findPendingDuplicate(hash, actor.label)
+            val pa = existing.getOrElse {
+                if (PendingActionIO.countPending(actor.label) >= policy.limits.maxPendingPerActor) {
+                    val body = new JsonObject()
+                    body.addProperty("error", "too many pending approvals for this agent")
+                    body.addProperty("errorKind", "policy_queue_full")
+                    body.addProperty("message", "Wait for a person to decide the existing pending approvals before requesting more.")
+                    PolicyGate.writeJson(response, 429, body)
+                    return false
+                }
+                val now = Instant.now()
+                val created = PendingAction(
+                    id = PendingAction.newId(),
+                    action = actionKey,
+                    resourceType = Some(resourceType),
+                    resourceName = resourceName,
+                    resourceVersion = resourceName.flatMap(n => PolicyGate.currentVersion(resourceType, n)),
+                    actor = actor,
+                    reason = reasonOf(request),
+                    agentSession = Option(request.getHeader(AuditActor.HeaderAgentSession)).map(_.trim).filter(_.nonEmpty).map(_.take(64)),
+                    method = request.getMethod,
+                    path = request.getRequestURI,
+                    query = query,
+                    contentType = Option(request.getContentType).filter(_.nonEmpty),
+                    body = bodyStr,
+                    bodyHash = hash,
+                    createdAt = now,
+                    expiresAt = now.plus(policy.limits.pendingTtlHours.toLong, ChronoUnit.HOURS),
+                    state = PendingAction.Pending
+                )
+                PendingActionIO.insert(created)
+                logger.info(
+                    "agent policy: {} {} action={} actor={} outcome=queued id={}",
+                    Array[AnyRef](request.getMethod, request.getRequestURI, actionKey, actor.label, created.id): _*
+                )
+                AuditLog.record(
+                    request,
+                    "policy",
+                    "queued",
+                    resourceType,
+                    resourceName.orNull,
+                    httpStatus = HttpServletResponse.SC_ACCEPTED,
+                    metadata = md(actionKey, Some(created.id), request)
+                )
+                created
+            }
+
+            val body = new JsonObject()
+            body.addProperty("status", "pending_approval")
+            body.addProperty("approvalId", pa.id)
+            body.addProperty("action", actionKey)
+            body.addProperty("resourceType", resourceType)
+            resourceName.foreach(body.addProperty("resource", _))
+            body.addProperty("expiresAt", pa.expiresAt.toString)
+            body.addProperty("duplicate", existing.isDefined)
+            body.addProperty(
+                "message",
+                "This action was NOT performed. The agent policy requires a person to approve '" + actionKey + "' first; it is queued as approval " + pa.id + ". " +
+                    "Tell the user it is waiting for approval in Datris (Activity → Approvals). " +
+                    "To wait for the decision, poll get_approval with this id, pausing with wait_seconds between polls; " +
+                    "do not re-issue the action — a retry returns this same id."
+            )
+            PolicyGate.writeJson(response, HttpServletResponse.SC_ACCEPTED, body)
+            false
+        } catch {
+            case e: Exception =>
+                logger.error("agent policy: could not queue " + actionKey + " for approval: " + e.getMessage, e)
+                val body = new JsonObject()
+                body.addProperty("error", "could not queue the action for approval: " + e.getMessage)
+                body.addProperty("errorKind", "policy_queue_error")
+                PolicyGate.writeJson(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, body)
+                false
+        }
+    }
+
+    /** `X-Datris-Approval: <id>.<token>` on a replay of an approved action. */
+    private def handleReplay(request: HttpServletRequest, response: HttpServletResponse, header: String): Boolean = {
+        val dot = header.indexOf('.')
+        val (id, token) = if (dot > 0) (header.substring(0, dot), header.substring(dot + 1)) else (header, "")
+        val ok =
+            try PendingActionIO.consumeReplay(id, token)
+            catch { case e: Exception => logger.warn("approval replay lookup failed: " + e.getMessage); None }
+        ok match {
+            case Some(pa) =>
+                request.setAttribute(AuditActor.ApprovalReplayAttr, pa.id)
+                val m = new JsonObject()
+                m.addProperty("approvalId", pa.id)
+                m.addProperty("originalActor", pa.actor.label)
+                m.addProperty("originalActorType", pa.actor.actorType)
+                pa.decidedBy.foreach(m.addProperty("approvedBy", _))
+                pa.reason.foreach(m.addProperty("reason", _))
+                request.setAttribute(AuditLog.MetadataAttr, m)
+                true
+            case None =>
+                val body = new JsonObject()
+                body.addProperty("error", "invalid, already used, or unapproved approval token")
+                body.addProperty("errorKind", "policy_replay_rejected")
+                PolicyGate.writeJson(response, HttpServletResponse.SC_FORBIDDEN, body)
+                AuditLog.denied(request, "approval replay rejected for " + id, HttpServletResponse.SC_FORBIDDEN)
+                false
+        }
+    }
+
+    private def reasonOf(request: HttpServletRequest): Option[String] =
+        Option(request.getHeader(AuditActor.HeaderReason)).map(_.trim).filter(_.nonEmpty).map(_.take(500))
+
+    private def md(actionKey: String, approvalId: Option[String], request: HttpServletRequest): JsonObject = {
+        val m = new JsonObject()
+        m.addProperty("policyAction", actionKey)
+        approvalId.foreach(m.addProperty("approvalId", _))
+        reasonOf(request).foreach(m.addProperty("reason", _))
+        m
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/config/WebMvcConfig.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/WebMvcConfig.scala
@@ -27,6 +27,9 @@ class WebMvcConfig extends WebMvcConfigurer {
     @Autowired
     var auditInterceptor: AuditInterceptor = _
 
+    @Autowired
+    var policyInterceptor: PolicyInterceptor = _
+
     @Value("${cors.allowedOrigins:*}")
     var allowedOrigins: String = _
 
@@ -42,9 +45,13 @@ class WebMvcConfig extends WebMvcConfigurer {
         //      capability check. If none was attached by TenantInterceptor
         //      (no x-api-key), falls back to deriving one from UserContext
         //      so logged-in browser flows are first-class identities too.
-        //   4. RoleEnforcementInterceptor — gates @RequiresRole methods using
+        //   4. PolicyInterceptor — the agent policy gate. After the
+        //      capability check (a key that may not do something at all is
+        //      refused there) and before audit, because it answers requests
+        //      itself (202 queued / 403 denied) and records those entries.
+        //   5. RoleEnforcementInterceptor — gates @RequiresRole methods using
         //      UserContext.
-        //   5. AuditInterceptor — MUST stay last. afterCompletion runs in
+        //   6. AuditInterceptor — MUST stay last. afterCompletion runs in
         //      reverse order, so last-registered runs first and still sees
         //      UserContext / TenantContext / the ResolvedKey before the
         //      earlier interceptors clear them. Denials upstream never reach
@@ -56,6 +63,9 @@ class WebMvcConfig extends WebMvcConfigurer {
             .addPathPatterns("/api/**")
             .excludePathPatterns("/minio-events")
         registry.addInterceptor(capabilityInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/minio-events")
+        registry.addInterceptor(policyInterceptor)
             .addPathPatterns("/api/**")
             .excludePathPatterns("/minio-events")
         registry.addInterceptor(roleEnforcementInterceptor)

--- a/datrisserver/src/main/scala/ai/datris/model/DatrisEnvironment.scala
+++ b/datrisserver/src/main/scala/ai/datris/model/DatrisEnvironment.scala
@@ -87,6 +87,8 @@ object DatrisEnvironment {
             userTableName = env + "-user",
             userSessionTableName = env + "-user-session",
             auditLogTableName = env + "-audit-log",
+            agentPolicyTableName = env + "-agent-policy",
+            pendingActionTableName = env + "-pending-action",
             postgresDatabase = env
         )
     }
@@ -239,7 +241,13 @@ case class DatrisEnvironment(
     auditLogTableName: String = null,
     auditLogRetentionDays: Int = 90, // 0 = never expire
     auditLogLogReads: Boolean = false, // query/search/metadata/GET routes
-    auditLogEmitLogLine: Boolean = true
+    auditLogEmitLogLine: Boolean = true,
+    // Agent policy: auto / approve / deny per action for agent-initiated
+    // requests, with a human approval queue (see ai.datris.policy). Off by
+    // default; with it on and no policy saved, everything is still `auto`.
+    useAgentPolicy: Boolean = false,
+    agentPolicyTableName: String = null,
+    pendingActionTableName: String = null
 ) {
 
     /** Append-only definition-version collections. Derived from the live table

--- a/datrisserver/src/main/scala/ai/datris/policy/AgentPolicy.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/AgentPolicy.scala
@@ -1,0 +1,193 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import com.google.gson.{JsonObject, JsonParser}
+
+import scala.collection.JavaConverters._
+
+/** What the policy says about an agent-initiated action. Ordered: a
+  * resource-level override may only move an action to the right. */
+sealed abstract class PolicyMode(val name: String, val rank: Int)
+object PolicyMode {
+    case object Auto extends PolicyMode("auto", 0)
+    case object Approve extends PolicyMode("approve", 1)
+    case object Deny extends PolicyMode("deny", 2)
+
+    val All: Seq[PolicyMode] = Seq(Auto, Approve, Deny)
+
+    def parse(s: String): Option[PolicyMode] = All.find(_.name == Option(s).map(_.trim.toLowerCase).orNull)
+
+    def stricter(a: PolicyMode, b: PolicyMode): PolicyMode = if (b.rank > a.rank) b else a
+}
+
+case class PolicyLimits(pendingTtlHours: Int = 24, maxPendingPerActor: Int = 50)
+
+/** The agent policy: for every `resource:action[:sub]` key the capability
+  * layer already classifies, whether an agent-initiated request runs
+  * (`auto`), is parked for a human (`approve`), or is refused (`deny`).
+  *
+  * Keys are matched most-specific first: `pipeline:update:dest-types` →
+  * `pipeline:update` → `pipeline:*`. Anything unmatched is `auto`, so an
+  * empty policy changes nothing.
+  *
+  * `overrides` are keyed by the target resource (`pipeline:<name>` /
+  * `tap:<name>`) and hold the same action map; an override can only
+  * tighten the default for that resource, never loosen it. */
+case class AgentPolicy(
+    version: Int = 0,
+    actions: Map[String, PolicyMode] = Map.empty,
+    overrides: Map[String, Map[String, PolicyMode]] = Map.empty,
+    limits: PolicyLimits = PolicyLimits(),
+    updatedAt: Option[String] = None,
+    updatedBy: Option[String] = None
+) {
+
+    def isEmpty: Boolean = actions.isEmpty && overrides.isEmpty
+
+    /** The mode for `actionKey` against a specific resource. */
+    def decide(actionKey: String, resourceType: Option[String], resourceName: Option[String]): PolicyMode = {
+        val base = AgentPolicy.lookup(actions, actionKey).getOrElse(PolicyMode.Auto)
+        val override_ = for {
+            t <- resourceType
+            n <- resourceName
+            m <- overrides.get(t + ":" + n)
+            mode <- AgentPolicy.lookup(m, actionKey)
+        } yield mode
+        override_.map(PolicyMode.stricter(base, _)).getOrElse(base)
+    }
+
+    def toJson: JsonObject = {
+        val o = new JsonObject()
+        o.addProperty("version", version)
+        val a = new JsonObject()
+        actions.toSeq.sortBy(_._1).foreach { case (k, v) => a.addProperty(k, v.name) }
+        o.add("actions", a)
+        val ov = new JsonObject()
+        overrides.toSeq.sortBy(_._1).foreach { case (res, m) =>
+            val inner = new JsonObject()
+            m.toSeq.sortBy(_._1).foreach { case (k, v) => inner.addProperty(k, v.name) }
+            ov.add(res, inner)
+        }
+        o.add("overrides", ov)
+        val l = new JsonObject()
+        l.addProperty("pendingTtlHours", limits.pendingTtlHours)
+        l.addProperty("maxPendingPerActor", limits.maxPendingPerActor)
+        o.add("limits", l)
+        updatedAt.foreach(o.addProperty("updatedAt", _))
+        updatedBy.foreach(o.addProperty("updatedBy", _))
+        o
+    }
+}
+
+object AgentPolicy {
+
+    val Empty: AgentPolicy = AgentPolicy()
+
+    /** One-click starting point the UI offers: pause before anything
+      * destructive or table-rewriting, refuse secret writes outright. */
+    val Recommended: AgentPolicy = AgentPolicy(
+        actions = Map(
+            "pipeline:delete" -> PolicyMode.Approve,
+            "tap:delete" -> PolicyMode.Approve,
+            "job:kill" -> PolicyMode.Approve,
+            "pipeline:update:dest-types" -> PolicyMode.Approve,
+            "secret:write" -> PolicyMode.Deny,
+            "code-repo:write" -> PolicyMode.Deny,
+            "config:write" -> PolicyMode.Deny
+        )
+    )
+
+    /** `pipeline:update:dest-types` → `pipeline:update` → `pipeline:*`. */
+    private[policy] def lookup(m: Map[String, PolicyMode], actionKey: String): Option[PolicyMode] = {
+        if (m.isEmpty) return None
+        val parts = actionKey.split(":").toList
+        val candidates = (parts.length to 2 by -1).map(n => parts.take(n).mkString(":")) :+ (parts.head + ":*")
+        candidates.iterator.map(m.get).collectFirst { case Some(v) => v }
+    }
+
+    private val OverrideKey = "^(pipeline|tap):[A-Za-z0-9_.-]{1,128}$".r
+
+    /** Parse + validate. Every action key must be one the capability layer
+      * knows (or `resource:*` for a known resource), every mode one of
+      * auto/approve/deny, every override key `pipeline:<name>` / `tap:<name>`. */
+    def fromJson(json: String): Either[String, AgentPolicy] = {
+        val root =
+            try {
+                val el = JsonParser.parseString(json)
+                if (!el.isJsonObject) return Left("policy must be a JSON object")
+                el.getAsJsonObject
+            } catch {
+                case e: Exception => return Left("policy is not valid JSON: " + e.getMessage)
+            }
+        val errors = List.newBuilder[String]
+
+        def parseActions(obj: JsonObject, where: String): Map[String, PolicyMode] =
+            obj.entrySet().asScala.flatMap { e =>
+                val key = e.getKey.trim
+                if (!PolicyRoutes.isKnownActionKey(key)) {
+                    errors += where + ": unknown action '" + key + "'"
+                    None
+                } else if (!e.getValue.isJsonPrimitive) {
+                    errors += where + ": mode for '" + key + "' must be a string"
+                    None
+                } else PolicyMode.parse(e.getValue.getAsString) match {
+                    case Some(mode) => Some(key -> mode)
+                    case None =>
+                        errors += where + ": mode for '" + key + "' must be auto, approve or deny (was '" + e.getValue.getAsString + "')"
+                        None
+                }
+            }.toMap
+
+        val actions =
+            if (!root.has("actions") || root.get("actions").isJsonNull) Map.empty[String, PolicyMode]
+            else if (!root.get("actions").isJsonObject) { errors += "actions must be an object"; Map.empty[String, PolicyMode] }
+            else parseActions(root.getAsJsonObject("actions"), "actions")
+
+        val overrides =
+            if (!root.has("overrides") || root.get("overrides").isJsonNull) Map.empty[String, Map[String, PolicyMode]]
+            else if (!root.get("overrides").isJsonObject) { errors += "overrides must be an object"; Map.empty[String, Map[String, PolicyMode]] }
+            else root.getAsJsonObject("overrides").entrySet().asScala.flatMap { e =>
+                val key = e.getKey.trim
+                if (OverrideKey.findFirstIn(key).isEmpty) {
+                    errors += "overrides: key '" + key + "' must be pipeline:<name> or tap:<name>"
+                    None
+                } else if (!e.getValue.isJsonObject) {
+                    errors += "overrides: value for '" + key + "' must be an object"
+                    None
+                } else Some(key -> parseActions(e.getValue.getAsJsonObject, "overrides." + key))
+            }.toMap
+
+        var limits = PolicyLimits()
+        if (root.has("limits") && root.get("limits").isJsonObject) {
+            val l = root.getAsJsonObject("limits")
+            def intField(name: String, default: Int, min: Int, max: Int): Int =
+                if (!l.has(name) || l.get(name).isJsonNull) default
+                else
+                    try {
+                        val v = l.get(name).getAsInt
+                        if (v < min || v > max) { errors += "limits." + name + " must be between " + min + " and " + max; default }
+                        else v
+                    } catch {
+                        case _: Exception => errors += "limits." + name + " must be an integer"; default
+                    }
+            limits = PolicyLimits(
+                pendingTtlHours = intField("pendingTtlHours", 24, 1, 24 * 30),
+                maxPendingPerActor = intField("maxPendingPerActor", 50, 1, 1000)
+            )
+        }
+
+        val version =
+            if (root.has("version") && root.get("version").isJsonPrimitive)
+                try root.get("version").getAsInt
+                catch { case _: Exception => 0 }
+            else 0
+
+        val errs = errors.result()
+        if (errs.nonEmpty) Left(errs.mkString("; "))
+        else Right(AgentPolicy(version = version, actions = actions, overrides = overrides, limits = limits))
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
@@ -153,7 +153,10 @@ object PendingAction {
 
     private def opt(d: Document, k: String): Option[String] = Option(d.getString(k)).filter(_.nonEmpty)
     private def optInt(d: Document, k: String): Option[Int] = Option(d.getInteger(k)).map(_.intValue())
-    private def optInstant(d: Document, k: String): Option[Instant] = opt(d, k).flatMap(s => try Some(Instant.parse(s)) catch { case _: Exception => None })
+    private def optInstant(d: Document, k: String): Option[Instant] = opt(d, k).flatMap(s =>
+        try Some(Instant.parse(s))
+        catch { case _: Exception => None }
+    )
 
     def fromDocument(d: Document): PendingAction = {
         val actorDoc = Option(d.get("actor", classOf[Document])).getOrElse(new Document())

--- a/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
@@ -1,0 +1,297 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActorInfo
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.{LogRedactUtil, MongoDBUtil, NoSQLDbUtil}
+import com.google.gson.{JsonObject, JsonParser}
+import com.mongodb.client.model.{Filters, IndexOptions, Sorts, Updates}
+import org.bson.Document
+import org.bson.conversions.Bson
+import org.slf4j.LoggerFactory
+
+import java.security.{MessageDigest, SecureRandom}
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/** An agent request the policy parked for a human. Holds everything needed
+  * to replay it verbatim once approved: method, path, query, content type,
+  * body. Never holds a replay token in its public JSON. */
+case class PendingAction(
+    id: String,
+    action: String,
+    resourceType: Option[String],
+    resourceName: Option[String],
+    resourceVersion: Option[Int],
+    actor: AuditActorInfo,
+    reason: Option[String],
+    agentSession: Option[String],
+    method: String,
+    path: String,
+    query: Option[String],
+    contentType: Option[String],
+    body: Option[String],
+    bodyHash: String,
+    createdAt: Instant,
+    expiresAt: Instant,
+    state: String, // pending | approved | rejected | expired | executed | failed
+    decidedBy: Option[String] = None,
+    decidedAt: Option[Instant] = None,
+    decisionNote: Option[String] = None,
+    replayToken: Option[String] = None,
+    replayConsumedAt: Option[Instant] = None,
+    executedAt: Option[Instant] = None,
+    resultStatus: Option[Int] = None,
+    resultBody: Option[String] = None
+) {
+
+    def isPending: Boolean = state == PendingAction.Pending
+    def isExpired(now: Instant = Instant.now()): Boolean = isPending && now.isAfter(expiresAt)
+
+    /** The body as parsed JSON with secret-looking values masked — what the
+      * approval card shows. Replay uses the raw `body`, never this. */
+    def bodyPreview: Option[com.google.gson.JsonElement] =
+        body.flatMap { b =>
+            try Some(LogRedactUtil.redactJson(JsonParser.parseString(b)))
+            catch { case _: Exception => None }
+        }
+
+    def toPublicJson: JsonObject = {
+        val o = new JsonObject()
+        o.addProperty("id", id)
+        o.addProperty("action", action)
+        resourceType.foreach(o.addProperty("resourceType", _))
+        resourceName.foreach(o.addProperty("resource", _))
+        resourceVersion.foreach(v => o.addProperty("resourceVersion", v))
+        o.add("actor", actor.toJson)
+        reason.foreach(o.addProperty("reason", _))
+        agentSession.foreach(o.addProperty("agentSession", _))
+        val rq = new JsonObject()
+        rq.addProperty("method", method)
+        rq.addProperty("path", path)
+        query.foreach(q => rq.addProperty("query", LogRedactUtil.redactQueryString(q)))
+        contentType.foreach(rq.addProperty("contentType", _))
+        bodyPreview.foreach(rq.add("body", _))
+        o.add("request", rq)
+        o.addProperty("createdAt", createdAt.toString)
+        o.addProperty("expiresAt", expiresAt.toString)
+        o.addProperty("state", if (isExpired()) PendingAction.Expired else state)
+        decidedBy.foreach(o.addProperty("decidedBy", _))
+        decidedAt.foreach(d => o.addProperty("decidedAt", d.toString))
+        decisionNote.foreach(o.addProperty("decisionNote", _))
+        executedAt.foreach(d => o.addProperty("executedAt", d.toString))
+        resultStatus.foreach(s => o.addProperty("resultStatus", s))
+        resultBody.foreach(o.addProperty("resultBody", _))
+        o
+    }
+
+    def toDocument: Document = {
+        val d = new Document()
+        d.put("_id", id)
+        d.put("action", action)
+        resourceType.foreach(d.put("resourceType", _))
+        resourceName.foreach(d.put("resourceName", _))
+        resourceVersion.foreach(v => d.put("resourceVersion", v: java.lang.Integer))
+        d.put("actor", Document.parse(actor.toJson.toString))
+        reason.foreach(d.put("reason", _))
+        agentSession.foreach(d.put("agentSession", _))
+        d.put("method", method)
+        d.put("path", path)
+        query.foreach(d.put("query", _))
+        contentType.foreach(d.put("contentType", _))
+        body.foreach(d.put("body", _))
+        d.put("bodyHash", bodyHash)
+        d.put("createdAt", createdAt.toString)
+        d.put("createdAtDate", java.util.Date.from(createdAt))
+        d.put("expiresAt", expiresAt.toString)
+        d.put("expiresAtDate", java.util.Date.from(expiresAt))
+        d.put("state", state)
+        decidedBy.foreach(d.put("decidedBy", _))
+        decidedAt.foreach(x => d.put("decidedAt", x.toString))
+        decisionNote.foreach(d.put("decisionNote", _))
+        replayToken.foreach(d.put("replayToken", _))
+        replayConsumedAt.foreach(x => d.put("replayConsumedAt", x.toString))
+        executedAt.foreach(x => d.put("executedAt", x.toString))
+        resultStatus.foreach(s => d.put("resultStatus", s: java.lang.Integer))
+        resultBody.foreach(d.put("resultBody", _))
+        d
+    }
+}
+
+object PendingAction {
+    val Pending = "pending"
+    val Approved = "approved"
+    val Rejected = "rejected"
+    val Expired = "expired"
+    val Executed = "executed"
+    val Failed = "failed"
+
+    val States: Set[String] = Set(Pending, Approved, Rejected, Expired, Executed, Failed)
+
+    private val random = new SecureRandom()
+
+    def newId(): String = "pa_" + hex(8)
+    def newToken(): String = hex(24)
+
+    private def hex(bytes: Int): String = {
+        val b = new Array[Byte](bytes)
+        random.nextBytes(b)
+        b.map("%02x".format(_)).mkString
+    }
+
+    def hashOf(actorLabel: String, method: String, path: String, query: Option[String], body: Option[String]): String = {
+        val md = MessageDigest.getInstance("SHA-256")
+        val s = actorLabel + "\n" + method + "\n" + path + "\n" + query.getOrElse("") + "\n" + body.getOrElse("")
+        md.digest(s.getBytes("UTF-8")).map("%02x".format(_)).mkString
+    }
+
+    private def opt(d: Document, k: String): Option[String] = Option(d.getString(k)).filter(_.nonEmpty)
+    private def optInt(d: Document, k: String): Option[Int] = Option(d.getInteger(k)).map(_.intValue())
+    private def optInstant(d: Document, k: String): Option[Instant] = opt(d, k).flatMap(s => try Some(Instant.parse(s)) catch { case _: Exception => None })
+
+    def fromDocument(d: Document): PendingAction = {
+        val actorDoc = Option(d.get("actor", classOf[Document])).getOrElse(new Document())
+        val actor = AuditActorInfo(
+            actorType = Option(actorDoc.getString("type")).getOrElse("api-key"),
+            label = Option(actorDoc.getString("label")).getOrElse("anonymous"),
+            keyLabel = Option(actorDoc.getString("keyLabel")),
+            keyId = Option(actorDoc.getString("keyId")),
+            username = Option(actorDoc.getString("username")),
+            role = Option(actorDoc.getString("role")),
+            legacyFullAccess = Option(actorDoc.getBoolean("legacyFullAccess")).exists(_.booleanValue())
+        )
+        PendingAction(
+            id = d.getString("_id"),
+            action = d.getString("action"),
+            resourceType = opt(d, "resourceType"),
+            resourceName = opt(d, "resourceName"),
+            resourceVersion = optInt(d, "resourceVersion"),
+            actor = actor,
+            reason = opt(d, "reason"),
+            agentSession = opt(d, "agentSession"),
+            method = d.getString("method"),
+            path = d.getString("path"),
+            query = opt(d, "query"),
+            contentType = opt(d, "contentType"),
+            body = Option(d.getString("body")),
+            bodyHash = Option(d.getString("bodyHash")).getOrElse(""),
+            createdAt = optInstant(d, "createdAt").getOrElse(Instant.EPOCH),
+            expiresAt = optInstant(d, "expiresAt").getOrElse(Instant.EPOCH),
+            state = Option(d.getString("state")).getOrElse(Pending),
+            decidedBy = opt(d, "decidedBy"),
+            decidedAt = optInstant(d, "decidedAt"),
+            decisionNote = opt(d, "decisionNote"),
+            replayToken = opt(d, "replayToken"),
+            replayConsumedAt = optInstant(d, "replayConsumedAt"),
+            executedAt = optInstant(d, "executedAt"),
+            resultStatus = optInt(d, "resultStatus"),
+            resultBody = opt(d, "resultBody")
+        )
+    }
+}
+
+/** Mongo-backed store for pending actions: `{env}-pending-action`, TTL on
+  * `expiresAtDate` so abandoned requests disappear on their own. */
+object PendingActionIO {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val indexed = mutable.Set[String]()
+    val MaxListLimit = 500
+
+    private def collection(): com.mongodb.client.MongoCollection[Document] =
+        NoSQLDbUtil match {
+            case m: MongoDBUtil =>
+                val table = DatrisEnvironment.current.pendingActionTableName
+                val coll = m.collection(table)
+                ensureIndexes(table, coll)
+                coll
+            case _ => throw new IllegalStateException("Agent policy approvals require the MongoDB config store")
+        }
+
+    private def ensureIndexes(table: String, coll: com.mongodb.client.MongoCollection[Document]): Unit = synchronized {
+        if (indexed.contains(table)) return
+        try {
+            // expireAfter 0 → delete once expiresAtDate is in the past. Only
+            // documents still pending matter; decided ones keep the same date
+            // so history is trimmed on the same schedule.
+            coll.createIndex(new Document("expiresAtDate", 1), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS))
+            coll.createIndex(new Document("state", 1))
+            coll.createIndex(new Document("actor.label", 1))
+            coll.createIndex(new Document("bodyHash", 1))
+            coll.createIndex(new Document("createdAtDate", -1))
+            indexed += table
+        } catch {
+            case e: Exception => logger.warn("Could not ensure pending-action indexes on " + table + ": " + e.getMessage)
+        }
+    }
+
+    def insert(pa: PendingAction): Unit = collection().insertOne(pa.toDocument)
+
+    def get(id: String): Option[PendingAction] =
+        Option(collection().find(Filters.eq("_id", id)).first()).map(PendingAction.fromDocument)
+
+    /** A still-pending action with the same actor + request bytes, so an
+      * agent that retries gets the existing approval id back. */
+    def findPendingDuplicate(hash: String, actorLabel: String): Option[PendingAction] =
+        Option(collection().find(Filters.and(
+            Filters.eq("bodyHash", hash),
+            Filters.eq("actor.label", actorLabel),
+            Filters.eq("state", PendingAction.Pending)
+        )).first()).map(PendingAction.fromDocument).filter(!_.isExpired())
+
+    def countPending(actorLabel: String): Long =
+        collection().countDocuments(Filters.and(Filters.eq("actor.label", actorLabel), Filters.eq("state", PendingAction.Pending)))
+
+    def countPendingAll(): Long =
+        try collection().countDocuments(Filters.eq("state", PendingAction.Pending))
+        catch { case _: Exception => 0L }
+
+    def list(state: Option[String], actorLabel: Option[String], limit: Int): List[PendingAction] = {
+        val parts = List.newBuilder[Bson]
+        state.foreach(s => parts += Filters.eq("state", s))
+        actorLabel.foreach(a => parts += Filters.eq("actor.label", a))
+        val all = parts.result()
+        val filter: Bson = if (all.isEmpty) new Document() else Filters.and(all.asJava)
+        collection().find(filter)
+            .sort(Sorts.descending("createdAtDate"))
+            .limit(math.max(1, math.min(limit, MaxListLimit)))
+            .asScala.map(PendingAction.fromDocument).toList
+    }
+
+    /** Conditional state transition: only applies when the document is still
+      * in `from`. Returns true when this call made the change. */
+    def transition(id: String, from: String, to: String, sets: (String, Any)*): Boolean = {
+        val updates = (Updates.set("state", to) +: sets.map { case (k, v) => Updates.set(k, v) }).asJava
+        val r = collection().updateOne(Filters.and(Filters.eq("_id", id), Filters.eq("state", from)), Updates.combine(updates))
+        r.getModifiedCount == 1
+    }
+
+    /** Single-use consumption of an approval's replay token: succeeds only
+      * for an approved action whose token matches and has not been used.
+      * Returns the action so the interceptor can attribute the replay. */
+    def consumeReplay(id: String, token: String): Option[PendingAction] = {
+        if (id == null || id.isEmpty || token == null || token.isEmpty) return None
+        val coll = collection()
+        val r = coll.updateOne(
+            Filters.and(
+                Filters.eq("_id", id),
+                Filters.eq("state", PendingAction.Approved),
+                Filters.eq("replayToken", token),
+                Filters.exists("replayConsumedAt", false)
+            ),
+            Updates.set("replayConsumedAt", Instant.now().toString)
+        )
+        if (r.getModifiedCount == 1) Option(coll.find(Filters.eq("_id", id)).first()).map(PendingAction.fromDocument) else None
+    }
+
+    def set(id: String, sets: (String, Any)*): Unit = {
+        if (sets.isEmpty) return
+        collection().updateOne(Filters.eq("_id", id), Updates.combine(sets.map { case (k, v) => Updates.set(k, v) }.asJava))
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyActor.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyActor.scala
@@ -1,0 +1,45 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActor
+import ai.datris.auth.{ResolvedKeyAccess, TapRunTokens}
+import ai.datris.model.UserContext
+import jakarta.servlet.http.HttpServletRequest
+
+/** Decides whether a request is agent-initiated — the only requests the
+  * policy applies to. Humans are the approvers and are never gated.
+  *
+  *   - Browser session, no MCP session header → human.
+  *   - Anything the MCP server relayed (it always forwards
+  *     `X-Datris-Agent-Session`) → agent, including the in-platform
+  *     Assistant / Ops chat acting on behalf of a logged-in user.
+  *   - A programmatic key that is not the platform's own `ui` key and not the
+  *     anonymous no-keys identity → agent (external MCP clients, CLI scripts).
+  *   - A tap's per-run callback token → not an agent (read-only, and a tap is
+  *     not a decision-maker).
+  *   - `ui` key with no session header → the UI itself → human. */
+object PolicyActor {
+
+    def isAgent(request: HttpServletRequest): Boolean = {
+        val agentSession = Option(request.getHeader(AuditActor.HeaderAgentSession)).exists(_.trim.nonEmpty)
+        if (UserContext.get().isDefined && !agentSession) return false
+        ResolvedKeyAccess.fromRequest(request) match {
+            case Some(rk) if TapRunTokens.isTapLabel(rk.label) => false
+            case Some(_) if agentSession => true
+            case Some(rk) =>
+                rk.label != AuditActor.UiKeyLabel &&
+                    rk.label != AuditActor.Anonymous &&
+                    !rk.label.startsWith("session:")
+            case None => agentSession
+        }
+    }
+
+    /** The label the pending action is filed under — the same string the
+      * audit log uses, so the two can be joined. */
+    def label(request: HttpServletRequest): String =
+        AuditActor.resolve(request).label
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyActor.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyActor.scala
@@ -32,8 +32,8 @@ object PolicyActor {
             case Some(_) if agentSession => true
             case Some(rk) =>
                 rk.label != AuditActor.UiKeyLabel &&
-                    rk.label != AuditActor.Anonymous &&
-                    !rk.label.startsWith("session:")
+                rk.label != AuditActor.Anonymous &&
+                !rk.label.startsWith("session:")
             case None => agentSession
         }
     }

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyGate.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyGate.scala
@@ -1,0 +1,97 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.{PipelineConfigIO, TapConfigIO}
+import com.google.gson.{JsonObject, JsonParser}
+import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.springframework.web.servlet.HandlerMapping
+
+import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
+
+/** Request-shape helpers shared by PolicyInterceptor and the approvals
+  * controller: which resource a request targets, its current definition
+  * version, the cached body, and JSON responses. */
+object PolicyGate {
+
+    /** Request attribute holding the pre-read body bytes (see
+      * PolicyBodyCacheFilter). Absent for multipart / oversize bodies. */
+    val BodyAttr = "ai.datris.policy.body"
+
+    /** Largest body that can be parked for replay. */
+    val MaxBodyBytes: Int = 256 * 1024
+
+    private val NameFields = Seq("name", "pipeline", "pipelineName", "tapName", "tap", "label")
+    private val PathVarNames = Seq("name", "pipeline", "tapName", "label")
+
+    def bodyBytes(request: HttpServletRequest): Option[Array[Byte]] =
+        Option(request.getAttribute(BodyAttr)).collect { case b: Array[Byte] => b }
+
+    def bodyString(request: HttpServletRequest): Option[String] =
+        bodyBytes(request).filter(_.nonEmpty).map(b => new String(b, StandardCharsets.UTF_8))
+
+    /** Can this request be stored and replayed verbatim? JSON (or empty)
+      * bodies under the size cap only — multipart uploads are not. */
+    def isQueueable(request: HttpServletRequest): Boolean = {
+        val ct = Option(request.getContentType).getOrElse("").toLowerCase
+        val len = request.getContentLengthLong
+        val hasBody = len > 0 || (len < 0 && ct.nonEmpty)
+        if (!hasBody) return true
+        ct.contains("application/json") && len <= MaxBodyBytes && bodyBytes(request).isDefined
+    }
+
+    /** Path variable → `?name=` → JSON body field. */
+    def resourceName(request: HttpServletRequest): Option[String] = {
+        val fromPath = Option(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+            .collect { case m: java.util.Map[_, _] => m.asInstanceOf[java.util.Map[String, String]].asScala }
+            .flatMap(vars => PathVarNames.flatMap(vars.get).headOption)
+        fromPath
+            .orElse(Option(request.getParameter("name")).map(_.trim).filter(_.nonEmpty))
+            .orElse(fromBody(request))
+            .map(_.take(256))
+    }
+
+    private def fromBody(request: HttpServletRequest): Option[String] =
+        bodyString(request).flatMap { s =>
+            try {
+                val el = JsonParser.parseString(s)
+                if (!el.isJsonObject) None
+                else {
+                    val obj = el.getAsJsonObject
+                    NameFields.collectFirst {
+                        case f if obj.has(f) && obj.get(f).isJsonPrimitive => obj.get(f).getAsString
+                    }.map(_.trim).filter(_.nonEmpty)
+                }
+            } catch {
+                case _: Exception => None
+            }
+        }
+
+    /** The live definition version of a pipeline or tap, for the
+      * approve-what-was-proposed check. None when the resource does not
+      * exist yet (creates) or the type is not versioned. */
+    def currentVersion(resourceType: String, name: String): Option[Int] =
+        try {
+            val env = DatrisEnvironment.current
+            resourceType match {
+                case "pipeline" => Option(PipelineConfigIO.read(env.pipelineTableName, name)).map(_.version)
+                case "tap" => Option(TapConfigIO.read(env.tapTableName, name)).map(_.version)
+                case _ => None
+            }
+        } catch {
+            case _: Exception => None
+        }
+
+    def writeJson(response: HttpServletResponse, status: Int, body: JsonObject): Unit = {
+        response.setStatus(status)
+        response.setContentType("application/json")
+        response.setCharacterEncoding("UTF-8")
+        response.getWriter.write(body.toString)
+        response.getWriter.flush()
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyIO.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyIO.scala
@@ -1,0 +1,75 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.NoSQLDbUtil
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+/** The one policy document per environment, `{env}-agent-policy` / key
+  * `default`. Read on every gated request through a short cache so a policy
+  * edit applies within seconds without a restart. */
+object PolicyIO {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val DocKey = "default"
+    private val CacheMs = 5000L
+
+    private case class Cached(table: String, policy: AgentPolicy, at: Long)
+    private val cache = new AtomicReference[Cached](null)
+
+    def enabled: Boolean = {
+        val v = DatrisEnvironment.values
+        v != null && v.useAgentPolicy
+    }
+
+    def current: AgentPolicy = {
+        val table = DatrisEnvironment.current.agentPolicyTableName
+        val now = System.currentTimeMillis()
+        val c = cache.get()
+        if (c != null && c.table == table && now - c.at < CacheMs) return c.policy
+        val policy = read(table)
+        cache.set(Cached(table, policy, now))
+        policy
+    }
+
+    private def read(table: String): AgentPolicy =
+        try {
+            NoSQLDbUtil.getItemJSON(table, "key", DocKey, "value") match {
+                case Some(json) =>
+                    AgentPolicy.fromJson(json) match {
+                        case Right(p) => p
+                        case Left(err) =>
+                            // A stored policy that no longer validates (an action
+                            // key retired from CapabilityRoutes, say) must not
+                            // silently become "auto everything". Fail closed on
+                            // the parts that still parse would be ideal, but the
+                            // parser is all-or-nothing; log loudly and keep the
+                            // last good cached value if there is one.
+                            logger.error("Stored agent policy is invalid (" + err + "); keeping the last good policy in memory")
+                            Option(cache.get()).map(_.policy).getOrElse(AgentPolicy.Empty)
+                    }
+                case None => AgentPolicy.Empty
+            }
+        } catch {
+            case e: Exception =>
+                logger.warn("Could not read agent policy: " + e.getMessage)
+                Option(cache.get()).map(_.policy).getOrElse(AgentPolicy.Empty)
+        }
+
+    def write(policy: AgentPolicy, by: String): AgentPolicy = {
+        val prev = current
+        val next = policy.copy(version = prev.version + 1, updatedAt = Some(Instant.now().toString), updatedBy = Some(by))
+        NoSQLDbUtil.putItemJSON(DatrisEnvironment.current.agentPolicyTableName, "key", DocKey, "value", next.toJson.toString)
+        cache.set(null)
+        next
+    }
+
+    def invalidate(): Unit = cache.set(null)
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyReplay.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyReplay.scala
@@ -1,0 +1,84 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActor
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.SecretsUtil
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.{HttpEntityEnclosingRequestBase, HttpPatch, HttpPost, HttpPut}
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.util.EntityUtils
+import org.slf4j.LoggerFactory
+
+import java.nio.charset.StandardCharsets
+
+/** Executes an approved pending action by re-sending the original request
+  * to this server through the normal interceptor chain, so capability,
+  * policy and audit see it exactly like a fresh call.
+  *
+  * Identity on the replay: the platform's own `ui` key (when keys are on)
+  * plus `X-Datris-On-Behalf-Of: <approver>`, which TenantInterceptor turns
+  * into `session:<approver>` — the human who clicked Approve is the actor.
+  * `X-Datris-Approval: <id>.<token>` lets PolicyInterceptor recognize the
+  * replay and consume the single-use token instead of gating it again. */
+object PolicyReplay {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    /** Set by StartupRunner from `server.port`. */
+    @volatile var port: Int = 8080
+
+    val HeaderApproval = "X-Datris-Approval"
+
+    private class HttpDeleteWithBody(uri: String) extends HttpEntityEnclosingRequestBase {
+        setURI(java.net.URI.create(uri))
+        override def getMethod: String = "DELETE"
+    }
+
+    case class Result(status: Int, body: String)
+
+    def execute(pa: PendingAction, token: String, approver: Option[String]): Result = {
+        val url = "http://127.0.0.1:" + port + pa.path + pa.query.map("?" + _).getOrElse("")
+        val req: HttpEntityEnclosingRequestBase = pa.method.toUpperCase match {
+            case "POST" => new HttpPost(url)
+            case "PUT" => new HttpPut(url)
+            case "PATCH" => new HttpPatch(url)
+            case "DELETE" => new HttpDeleteWithBody(url)
+            case other => throw new IllegalArgumentException("Cannot replay HTTP method " + other)
+        }
+        pa.body.foreach { b =>
+            req.setEntity(new StringEntity(b, StandardCharsets.UTF_8))
+            req.setHeader("Content-Type", pa.contentType.getOrElse("application/json"))
+        }
+        req.setHeader(HeaderApproval, pa.id + "." + token)
+        approver.foreach(req.setHeader(AuditActor.HeaderOnBehalfOf, _))
+        uiApiKey().foreach(req.setHeader("x-api-key", _))
+        val config = RequestConfig.custom().setConnectTimeout(5000).setSocketTimeout(10 * 60 * 1000).build()
+        val client = HttpClients.custom().setDefaultRequestConfig(config).build()
+        try {
+            val resp = client.execute(req)
+            val body = Option(resp.getEntity).map(e => EntityUtils.toString(e, StandardCharsets.UTF_8)).getOrElse("")
+            Result(resp.getStatusLine.getStatusCode, body)
+        } finally {
+            try client.close()
+            catch { case _: Exception => }
+        }
+    }
+
+    /** The reserved `ui` key's value, from Vault. Only needed when API keys
+      * are on; in keys-off mode the request is anonymous like any other. */
+    private def uiApiKey(): Option[String] = {
+        val env = DatrisEnvironment.values
+        if (env == null || !env.useApiKeys) return None
+        val path = DatrisEnvironment.current.environment + "/ui-api-key"
+        val key = SecretsUtil.getSecretMap(path).flatMap(m => Option(m.get("apiKey"))).filter(_.nonEmpty)
+        if (key.isEmpty)
+            logger.error("Agent policy replay needs the ui API key at " + path + " but it is missing — the approved action cannot be executed")
+        key
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyRoutes.scala
@@ -1,0 +1,71 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.auth.{CapabilityRoutes, RouteCheck}
+import org.springframework.util.AntPathMatcher
+
+/** Turns a request into the policy action key it is judged by.
+  *
+  * The vocabulary IS the capability table: an action key is the
+  * `resource:action` [[CapabilityRoutes]] already assigns the route, so a
+  * policy can only name something the capability layer classifies. The
+  * small sub-action table below refines one route where a single
+  * capability covers materially different operations — the first is the
+  * destination-type migration, which shares `pipeline:update` with an
+  * ordinary config save but rewrites a landed table. */
+object PolicyRoutes {
+
+    private val matcher = new AntPathMatcher()
+
+    /** (method, path pattern, action key). The parent `resource:action`
+      * must still be what CapabilityRoutes returns for the same route. */
+    private val subActions: Seq[(String, String, String)] = Seq(
+        ("POST", "/api/v1/pipeline/dest-types", "pipeline:update:dest-types")
+    )
+
+    /** Every key a policy may name. */
+    val knownActionKeys: Set[String] = CapabilityRoutes.allActionKeys ++ subActions.map(_._3)
+
+    private val knownResources: Set[String] = knownActionKeys.map(_.split(":")(0))
+
+    def isKnownActionKey(key: String): Boolean =
+        knownActionKeys.contains(key) || (key.endsWith(":*") && knownResources.contains(key.dropRight(2)))
+
+    /** The action key for a request, or None when the route is skip-class or
+      * unmapped (policy never applies there — capability enforcement is the
+      * only gate on unmapped routes, as today). */
+    def actionKey(method: String, path: String): Option[String] = {
+        subActions.find { case (m, p, _) => m.equalsIgnoreCase(method) && matcher.`match`(p, path) } match {
+            case Some((_, _, key)) => Some(key)
+            case None =>
+                CapabilityRoutes.lookup(method, path) match {
+                    case RouteCheck.Require(resource, action) => Some(resource + ":" + action)
+                    case _ => None
+                }
+        }
+    }
+
+    def resourceType(actionKey: String): String = actionKey.split(":")(0)
+
+    private val ReadActions = Set("read")
+    private val ReadResources = Set("query", "search", "metadata", "mcp")
+
+    /** Reads are never policy-gated: pausing a listing for approval is
+      * meaningless and capabilities already scope what can be read. Policy
+      * management and approval decisions are governed by the hard rules in
+      * PolicyActor (agents may never do either), not by the policy itself. */
+    def isGateable(actionKey: String): Boolean = {
+        val parts = actionKey.split(":")
+        val resource = parts(0)
+        val action = if (parts.length > 1) parts(1) else ""
+        !ReadActions.contains(action) && !ReadResources.contains(resource) &&
+            resource != "policy" && resource != "approval"
+    }
+
+    /** Sorted list for the UI / GET /policy, grouped by resource. */
+    def catalog: Seq[String] = knownActionKeys.filter(isGateable).toSeq.sorted
+}

--- a/datrisserver/src/main/scala/ai/datris/policy/PolicyRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PolicyRoutes.scala
@@ -63,7 +63,7 @@ object PolicyRoutes {
         val resource = parts(0)
         val action = if (parts.length > 1) parts(1) else ""
         !ReadActions.contains(action) && !ReadResources.contains(resource) &&
-            resource != "policy" && resource != "approval"
+        resource != "policy" && resource != "approval"
     }
 
     /** Sorted list for the UI / GET /policy, grouped by resource. */

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -33,7 +33,7 @@ class MCPToolRoutesSpec extends AnyFunSuite {
     )
 
     test("catalog has one row per MCP tool, no duplicates") {
-        assert(MCPToolRoutes.allToolNames.size == 65)
+        assert(MCPToolRoutes.allToolNames.size == 68)
         assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
     }
 

--- a/datrisserver/src/test/scala/ai/datris/policy/AgentPolicySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/AgentPolicySpec.scala
@@ -1,0 +1,84 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class AgentPolicySpec extends AnyFunSuite {
+
+    private def policy(json: String): AgentPolicy = AgentPolicy.fromJson(json) match {
+        case Right(p) => p
+        case Left(err) => fail("expected a valid policy: " + err)
+    }
+
+    test("empty policy → everything auto") {
+        val p = AgentPolicy.Empty
+        assert(p.decide("tap:delete", Some("tap"), Some("x")) == PolicyMode.Auto)
+        assert(p.decide("pipeline:update:dest-types", Some("pipeline"), Some("x")) == PolicyMode.Auto)
+    }
+
+    test("exact key, parent key and resource wildcard resolve most-specific first") {
+        val p = policy("""{"actions":{"pipeline:*":"deny","pipeline:update":"approve","pipeline:update:dest-types":"auto"}}""")
+        assert(p.decide("pipeline:update:dest-types", Some("pipeline"), Some("a")) == PolicyMode.Auto)
+        assert(p.decide("pipeline:update", Some("pipeline"), Some("a")) == PolicyMode.Approve)
+        assert(p.decide("pipeline:delete", Some("pipeline"), Some("a")) == PolicyMode.Deny)
+        assert(p.decide("tap:delete", Some("tap"), Some("a")) == PolicyMode.Auto)
+    }
+
+    test("a sub-action inherits its parent's mode when not named") {
+        val p = policy("""{"actions":{"pipeline:update":"approve"}}""")
+        assert(p.decide("pipeline:update:dest-types", Some("pipeline"), Some("a")) == PolicyMode.Approve)
+    }
+
+    test("override may only tighten, never loosen") {
+        val p = policy("""{"actions":{"tap:run":"approve","tap:delete":"deny"},"overrides":{"tap:prices":{"tap:run":"auto","tap:delete":"approve"}}}""")
+        // tries to loosen approve → auto: ignored
+        assert(p.decide("tap:run", Some("tap"), Some("prices")) == PolicyMode.Approve)
+        // tries to loosen deny → approve: ignored
+        assert(p.decide("tap:delete", Some("tap"), Some("prices")) == PolicyMode.Deny)
+        val q = policy("""{"actions":{"tap:run":"auto"},"overrides":{"tap:prices":{"tap:run":"approve"}}}""")
+        assert(q.decide("tap:run", Some("tap"), Some("prices")) == PolicyMode.Approve)
+        assert(q.decide("tap:run", Some("tap"), Some("other")) == PolicyMode.Auto)
+        assert(q.decide("tap:run", Some("tap"), None) == PolicyMode.Auto)
+    }
+
+    test("unknown action keys are rejected on parse, naming the key") {
+        val r = AgentPolicy.fromJson("""{"actions":{"tap:delete":"approve","widget:frob":"deny"}}""")
+        assert(r.isLeft)
+        assert(r.left.get.contains("widget:frob"))
+    }
+
+    test("resource wildcard is accepted only for known resources") {
+        assert(AgentPolicy.fromJson("""{"actions":{"tap:*":"approve"}}""").isRight)
+        assert(AgentPolicy.fromJson("""{"actions":{"nothing:*":"approve"}}""").isLeft)
+    }
+
+    test("bad modes and bad override keys are rejected") {
+        assert(AgentPolicy.fromJson("""{"actions":{"tap:delete":"maybe"}}""").left.get.contains("maybe"))
+        assert(AgentPolicy.fromJson("""{"overrides":{"widget:x":{"tap:run":"approve"}}}""").left.get.contains("widget:x"))
+        assert(AgentPolicy.fromJson("""{"overrides":{"tap:x":{"nope:run":"approve"}}}""").left.get.contains("nope:run"))
+    }
+
+    test("limits are bounded and default when absent") {
+        assert(policy("""{}""").limits == PolicyLimits(24, 50))
+        assert(policy("""{"limits":{"pendingTtlHours":48,"maxPendingPerActor":5}}""").limits == PolicyLimits(48, 5))
+        assert(AgentPolicy.fromJson("""{"limits":{"pendingTtlHours":0}}""").isLeft)
+        assert(AgentPolicy.fromJson("""{"limits":{"maxPendingPerActor":"lots"}}""").isLeft)
+    }
+
+    test("toJson round-trips through fromJson") {
+        val p = policy("""{"version":3,"actions":{"tap:delete":"approve","secret:write":"deny"},"overrides":{"pipeline:orders":{"pipeline:update":"approve"}},"limits":{"pendingTtlHours":12,"maxPendingPerActor":7}}""")
+        val back = policy(p.toJson.toString)
+        assert(back == p)
+    }
+
+    test("recommended template validates against the live route table") {
+        assert(AgentPolicy.fromJson(AgentPolicy.Recommended.toJson.toString).isRight)
+        assert(AgentPolicy.Recommended.decide("pipeline:update:dest-types", Some("pipeline"), Some("a")) == PolicyMode.Approve)
+        assert(AgentPolicy.Recommended.decide("secret:write", Some("secret"), Some("a")) == PolicyMode.Deny)
+        assert(AgentPolicy.Recommended.decide("tap:run", Some("tap"), Some("a")) == PolicyMode.Auto)
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/policy/AgentPolicySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/AgentPolicySpec.scala
@@ -70,7 +70,9 @@ class AgentPolicySpec extends AnyFunSuite {
     }
 
     test("toJson round-trips through fromJson") {
-        val p = policy("""{"version":3,"actions":{"tap:delete":"approve","secret:write":"deny"},"overrides":{"pipeline:orders":{"pipeline:update":"approve"}},"limits":{"pendingTtlHours":12,"maxPendingPerActor":7}}""")
+        val p = policy(
+            """{"version":3,"actions":{"tap:delete":"approve","secret:write":"deny"},"overrides":{"pipeline:orders":{"pipeline:update":"approve"}},"limits":{"pendingTtlHours":12,"maxPendingPerActor":7}}"""
+        )
         val back = policy(p.toJson.toString)
         assert(back == p)
     }

--- a/datrisserver/src/test/scala/ai/datris/policy/PendingActionSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/PendingActionSpec.scala
@@ -1,0 +1,78 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActorInfo
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class PendingActionSpec extends AnyFunSuite {
+
+    private val now = Instant.parse("2026-08-30T10:00:00Z")
+
+    private def sample(state: String = PendingAction.Pending, expiresAt: Instant = now.plus(1, ChronoUnit.DAYS)) = PendingAction(
+        id = "pa_0123456789abcdef",
+        action = "tap:delete",
+        resourceType = Some("tap"),
+        resourceName = Some("prices"),
+        resourceVersion = Some(7),
+        actor = AuditActorInfo(actorType = "api-key", label = "research-agent", keyLabel = Some("research-agent"), keyId = Some("k_1")),
+        reason = Some("replacing with v2"),
+        agentSession = Some("sess-1"),
+        method = "DELETE",
+        path = "/api/v1/tap",
+        query = Some("name=prices&apiKey=SECRETVALUE"),
+        contentType = None,
+        body = Some("""{"name":"prices","password":"hunter2"}"""),
+        bodyHash = "abc",
+        createdAt = now,
+        expiresAt = expiresAt,
+        state = state,
+        replayToken = Some("topsecret")
+    )
+
+    test("document round-trips every field, including the replay token") {
+        val pa = sample().copy(decidedBy = Some("todd"), decidedAt = Some(now), resultStatus = Some(200), resultBody = Some("ok"))
+        val back = PendingAction.fromDocument(pa.toDocument)
+        assert(back == pa)
+    }
+
+    test("public JSON never exposes the replay token and redacts secret-looking values") {
+        val json = sample().toPublicJson.toString
+        assert(!json.contains("topsecret"))
+        assert(!json.contains("hunter2"))
+        assert(!json.contains("SECRETVALUE"))
+        assert(json.contains("\"id\":\"pa_0123456789abcdef\""))
+        assert(json.contains("\"reason\":\"replacing with v2\""))
+        assert(json.contains("\"resource\":\"prices\""))
+    }
+
+    test("a pending action past its expiry reads as expired") {
+        assert(!sample().isExpired(now))
+        val old = sample(expiresAt = now.minus(1, ChronoUnit.MINUTES))
+        assert(old.isExpired(now))
+        assert(old.toPublicJson.get("state").getAsString == PendingAction.Expired)
+        // decided ones never flip to expired
+        assert(!sample(state = PendingAction.Executed, expiresAt = now.minus(1, ChronoUnit.DAYS)).isExpired(now))
+    }
+
+    test("hash is stable for the same request and differs by actor, body and query") {
+        val a = PendingAction.hashOf("agent", "DELETE", "/api/v1/tap", Some("name=x"), None)
+        assert(a == PendingAction.hashOf("agent", "DELETE", "/api/v1/tap", Some("name=x"), None))
+        assert(a != PendingAction.hashOf("other", "DELETE", "/api/v1/tap", Some("name=x"), None))
+        assert(a != PendingAction.hashOf("agent", "DELETE", "/api/v1/tap", Some("name=y"), None))
+        assert(a != PendingAction.hashOf("agent", "DELETE", "/api/v1/tap", Some("name=x"), Some("{}")))
+    }
+
+    test("ids and tokens are distinct and well-formed") {
+        val ids = (1 to 50).map(_ => PendingAction.newId())
+        assert(ids.distinct.size == 50)
+        ids.foreach(id => assert(id.matches("pa_[0-9a-f]{16}"), id))
+        assert(PendingAction.newToken().matches("[0-9a-f]{48}"))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/policy/PolicyActorSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/PolicyActorSpec.scala
@@ -1,0 +1,62 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditActor
+import ai.datris.config.TenantInterceptor
+import ai.datris.model.{Capability, ResolvedKey, User, UserContext}
+import jakarta.servlet.http.HttpServletRequest
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.funsuite.AnyFunSuite
+
+class PolicyActorSpec extends AnyFunSuite {
+
+    private def key(label: String) = ResolvedKey(None, label, Capability.parseList(Seq("tap:delete")), isLegacyFullAccess = false)
+
+    private def req(key: Option[ResolvedKey], agentSession: Boolean = false, session: Option[User] = None): HttpServletRequest = {
+        val r = mock(classOf[HttpServletRequest])
+        when(r.getMethod).thenReturn("DELETE")
+        when(r.getRequestURI).thenReturn("/api/v1/tap")
+        when(r.getAttribute(TenantInterceptor.ResolvedKeyAttr)).thenAnswer(_ => key.orNull)
+        when(r.getHeader(AuditActor.HeaderAgentSession)).thenAnswer(_ => if (agentSession) "sess-1" else null)
+        session match {
+            case Some(u) => UserContext.set(u)
+            case None => UserContext.clear()
+        }
+        r
+    }
+
+    private val todd = User("todd", "hash", User.RoleAdmin, "t", "t", null)
+
+    test("a browser session with no MCP session header is a human") {
+        assert(!PolicyActor.isAgent(req(Some(key("session:todd")), session = Some(todd))))
+        UserContext.clear()
+    }
+
+    test("anything relayed by the MCP server is an agent — including the Assistant acting for a user") {
+        assert(PolicyActor.isAgent(req(Some(key("session:todd")), agentSession = true)))
+        assert(PolicyActor.isAgent(req(Some(key("ui")), agentSession = true)))
+        assert(PolicyActor.isAgent(req(Some(key("anonymous")), agentSession = true)))
+        assert(PolicyActor.isAgent(req(None, agentSession = true)))
+    }
+
+    test("an external programmatic key is an agent") {
+        assert(PolicyActor.isAgent(req(Some(key("claude-desktop")))))
+        assert(PolicyActor.isAgent(req(Some(key("research-agent")))))
+    }
+
+    test("the ui key, the anonymous identity and a relabeled session key without the MCP header are human") {
+        assert(!PolicyActor.isAgent(req(Some(key(AuditActor.UiKeyLabel)))))
+        assert(!PolicyActor.isAgent(req(Some(key(AuditActor.Anonymous)))))
+        assert(!PolicyActor.isAgent(req(Some(key("session:todd")))))
+        assert(!PolicyActor.isAgent(req(None)))
+    }
+
+    test("a tap's per-run callback token is never an agent") {
+        assert(!PolicyActor.isAgent(req(Some(key("tap:prices")))))
+        assert(!PolicyActor.isAgent(req(Some(key("tap:prices")), agentSession = true)))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/policy/PolicyRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/PolicyRoutesSpec.scala
@@ -1,0 +1,65 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.auth.{CapabilityRoutes, RouteCheck}
+import org.scalatest.funsuite.AnyFunSuite
+
+class PolicyRoutesSpec extends AnyFunSuite {
+
+    test("action key is the capability resource:action for a mapped route") {
+        assert(PolicyRoutes.actionKey("DELETE", "/api/v1/tap").contains("tap:delete"))
+        assert(PolicyRoutes.actionKey("POST", "/api/v1/tap/run").contains("tap:run"))
+        assert(PolicyRoutes.actionKey("POST", "/api/v1/pipeline").contains("pipeline:create"))
+    }
+
+    test("dest-types apply is refined to a sub-action whose parent matches the capability route") {
+        assert(PolicyRoutes.actionKey("POST", "/api/v1/pipeline/dest-types").contains("pipeline:update:dest-types"))
+        assert(CapabilityRoutes.lookup("POST", "/api/v1/pipeline/dest-types") == RouteCheck.Require("pipeline", "update"))
+        assert(PolicyRoutes.actionKey("GET", "/api/v1/pipeline/dest-types").contains("pipeline:read"))
+    }
+
+    test("skip-class and unmapped routes have no action key") {
+        assert(PolicyRoutes.actionKey("POST", "/api/v1/auth/login").isEmpty)
+        assert(PolicyRoutes.actionKey("GET", "/api/v1/version").isEmpty)
+        assert(PolicyRoutes.actionKey("POST", "/api/v1/does-not-exist").isEmpty)
+    }
+
+    test("reads, queries, searches and metadata are never gateable") {
+        assert(!PolicyRoutes.isGateable("tap:read"))
+        assert(!PolicyRoutes.isGateable("query:postgres"))
+        assert(!PolicyRoutes.isGateable("search:vector"))
+        assert(!PolicyRoutes.isGateable("metadata:read"))
+        assert(!PolicyRoutes.isGateable("policy:read"))
+        assert(!PolicyRoutes.isGateable("approval:read"))
+        assert(PolicyRoutes.isGateable("tap:delete"))
+        assert(PolicyRoutes.isGateable("pipeline:update:dest-types"))
+        assert(PolicyRoutes.isGateable("document:upload"))
+    }
+
+    test("policy management and approval decisions are governed by hard rules, not the policy") {
+        assert(!PolicyRoutes.isGateable("policy:update"))
+        assert(!PolicyRoutes.isGateable("approval:decide"))
+    }
+
+    test("every catalog entry is a known, gateable key") {
+        assert(PolicyRoutes.catalog.nonEmpty)
+        PolicyRoutes.catalog.foreach { k =>
+            assert(PolicyRoutes.isKnownActionKey(k), k)
+            assert(PolicyRoutes.isGateable(k), k)
+        }
+        assert(PolicyRoutes.catalog == PolicyRoutes.catalog.sorted)
+    }
+
+    test("new policy and approval routes are capability-mapped") {
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/policy") == RouteCheck.Require("policy", "read"))
+        assert(CapabilityRoutes.lookup("PUT", "/api/v1/policy") == RouteCheck.Require("policy", "update"))
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/approvals") == RouteCheck.Require("approval", "read"))
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/approvals/pa_1") == RouteCheck.Require("approval", "read"))
+        assert(CapabilityRoutes.lookup("POST", "/api/v1/approvals/pa_1/approve") == RouteCheck.Require("approval", "decide"))
+        assert(CapabilityRoutes.lookup("POST", "/api/v1/approvals/pa_1/reject") == RouteCheck.Require("approval", "decide"))
+    }
+}

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -309,6 +309,10 @@ services:
       USEAUDITLOG: "${USE_AUDIT_LOG:-false}"
       AUDITLOG_RETENTIONDAYS: "${AUDIT_LOG_RETENTION_DAYS:-90}"
       AUDITLOG_LOGREADS: "${AUDIT_LOG_READS:-false}"
+      # Agent policy: lets an admin mark agent actions auto / approve / deny and
+      # approve queued ones under Activity → Approvals. Off by default; when on
+      # with no policy saved, behavior is unchanged until a rule is set.
+      USEAGENTPOLICY: "${USE_AGENT_POLICY:-false}"
       # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
       # the server requires MinIO to present it as a bearer token (see
       # minio-init.sh auth_token). Empty by default so existing deployments keep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,6 +288,10 @@ services:
       USEAUDITLOG: "${USE_AUDIT_LOG:-false}"
       AUDITLOG_RETENTIONDAYS: "${AUDIT_LOG_RETENTION_DAYS:-90}"
       AUDITLOG_LOGREADS: "${AUDIT_LOG_READS:-false}"
+      # Agent policy: lets an admin mark agent actions auto / approve / deny and
+      # approve queued ones under Activity → Approvals. Off by default; when on
+      # with no policy saved, behavior is unchanged until a rule is set.
+      USEAGENTPOLICY: "${USE_AGENT_POLICY:-false}"
       # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
       # the server requires MinIO to present it as a bearer token (see
       # minio-init.sh auth_token). Empty by default so existing deployments keep

--- a/docs/agent-policy.mdx
+++ b/docs/agent-policy.mdx
@@ -1,0 +1,92 @@
+---
+title: "Agent Policy"
+description: "Decide, per action, whether agents run it on their own, wait for a person to approve it, or are refused — enforced by the platform, not by a prompt."
+---
+
+The agent policy is the boundary between agents being useful and agents being safe. For every kind of change an agent can make through Datris — create a tap, run it, delete a pipeline, migrate a destination table's column types — an administrator decides one of three things:
+
+| Mode | What happens when an agent tries it |
+|------|-------------------------------------|
+| **Auto** | It runs, exactly as today. |
+| **Approve** | It does **not** run. The request is parked, the agent is told it is waiting for approval, and a person approves or rejects it under **Activity → Approvals**. On approval the platform performs the original request on the approver's behalf. |
+| **Deny** | It is refused with a clear error the agent can read. |
+
+Anything you have not set is **Auto**, so turning the feature on changes nothing until you set a rule. People using the Datris UI are never gated — they are the approvers.
+
+This is infrastructure, not a system prompt. An agent cannot talk its way past it, and it applies to every client — the in-platform Assistant, Claude Desktop, Cursor, the CLI, or any script holding an API key.
+
+## Enabling it
+
+Off by default — existing installs are unchanged until you opt in.
+
+1. Add the flag to your `.env`:
+
+   ```bash
+   USE_AGENT_POLICY=true
+   ```
+
+2. Recreate the Datris container:
+
+   ```bash
+   docker compose up -d --force-recreate datris
+   ```
+
+3. Open **Configuration → Agent Policy** (admins only when user authentication is on). Set the actions you care about, or click **Use recommended** for a starting point that pauses deletes, job kills and destination-type migrations and refuses secret and connection changes.
+
+The policy applies within a few seconds of saving; no restart.
+
+## What counts as an agent
+
+| Caller | Gated? |
+|--------|--------|
+| A person clicking in the Datris UI | No |
+| The in-platform Assistant, Ops or Catalog chat acting for a logged-in user | **Yes** — attributed to the user, but it is still the agent proposing |
+| An external MCP client (Claude Desktop, Cursor, Claude Code, …) or a script with an API key | **Yes** |
+| A scheduled tap run, Kafka or object-store trigger | No — these are the platform's own work |
+| A tap script reading platform data during a run | No |
+
+## Actions
+
+The actions you can set are exactly the ones the [capability model](/api-keys) already recognizes — `pipeline:create`, `tap:delete`, `job:kill`, `secret:write`, and so on — plus one refinement: `pipeline:update:dest-types`, the destination column-type migration, which shares a capability with an ordinary pipeline save but rewrites a landed table. A sub-action inherits its parent's mode unless set; `resource:*` sets every action on a resource.
+
+Reads, queries, searches and metadata lookups are never gated. What a key may read is governed by its [capabilities](/api-keys).
+
+Two rules are not part of the policy and cannot be changed by it: an agent can never edit the policy, and an agent can never approve or reject an approval — whatever capabilities its key holds.
+
+### Per-resource overrides
+
+An override tightens the policy for one pipeline or tap: `tap:prices → tap:run = approve` pauses runs of that one tap while every other tap runs freely. Overrides can only make an action stricter, never looser.
+
+## Approvals
+
+When an agent's request hits an **Approve** rule, the agent receives a `pending_approval` response with an approval id instead of a result. The Assistant will tell you plainly that the action is waiting, and it can poll for the decision. The request itself — method, path and body, with secret-looking values masked — is shown on the approval card so you see exactly what will run.
+
+Approve, and the platform performs the original request, attributed to you. The audit log then holds two linked entries: the agent's queued request (with the reason it gave, if any) and your approval executing it. Reject, and the agent is told so on its next poll. Approvals not decided within the configured time (24 hours by default) expire on their own.
+
+An approval executes what was proposed, not what the agent would propose now: if the pipeline or tap changed in the meantime, the approval is refused as stale and the agent has to propose again.
+
+Some requests cannot be parked — file uploads, and bodies over 256 KB. If such an action is set to **Approve**, the agent is told to ask you to do it in the UI instead.
+
+## For agents
+
+Three MCP tools support the flow:
+
+| Tool | Purpose |
+|------|---------|
+| `get_agent_policy` | Read the policy before acting, to know whether a delete or migration will run or queue |
+| `list_pending_approvals` | The actions this agent has queued, with their state |
+| `get_approval` | Poll one approval by id until it is executed, rejected or expired |
+
+Every mutating tool also accepts an optional `reason` — one line stating why the agent wants the change. It is stored in the [audit log](/audit-log) and shown on the approval card.
+
+## Limits
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| Pending approval TTL | 24 hours | Undecided approvals expire after this |
+| Max pending per agent | 50 | An agent with this many undecided approvals is told to wait |
+
+## Related
+
+- [API Keys](/api-keys) — what a key *may* do; the policy decides what it may do *unattended*
+- [Audit Log](/audit-log) — where queued requests, decisions and executions are recorded

--- a/docs/api-keys.mdx
+++ b/docs/api-keys.mdx
@@ -149,3 +149,7 @@ When user-auth is on, logged-in browser sessions are first-class identities too:
 - [User Authentication](/user-auth) — login + roles for the UI
 - [Configuration Reference](/configuration-reference) — full env var list
 - [MCP Server](/mcp-server) — how external agents connect
+
+## Capabilities vs. the agent policy
+
+A capability says what a key *may* do. The [agent policy](/agent-policy) says what an agent may do *unattended*: for each action, whether it runs on its own, waits for a person to approve it, or is refused. The policy runs after the capability check and can only pause or refuse what the key already holds — it never grants anything. Two capabilities support it: `policy:read` (read the policy; any key) and `approval:read` (list and poll the approvals the key queued; use `approval:read:owner=self`). Deciding approvals is a person's job — an agent-initiated request is refused even with `approval:decide`.

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -86,6 +86,7 @@ Two independent flags control access. Set them together — see [the supported m
 | `USE_AUDIT_LOG` | `false` | Record who created, changed, ran, or deleted what — readable by admins under Configuration → Audit Log and mirrored to the server log. Restart to change. See [Audit Log](/audit-log) |
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries in the config store; `0` keeps them forever. Maps to `auditLog.retentionDays` |
 | `AUDIT_LOG_READS` | `false` | Also record reads — queries, searches, listings, metadata. Off by default because they dwarf the write trail. Maps to `auditLog.logReads` |
+| `USE_AGENT_POLICY` | `false` | Per-action auto / approve / deny for agent-initiated changes, with a human approval queue under Activity → Approvals. With it on and no rules set, nothing changes. Restart to change. See [Agent Policy](/agent-policy) |
 
 One further audit setting lives only in `application.yaml`: `auditLog.emitLogLine` (default `true`; mirror each entry to the `ai.datris.audit` logger for SIEM pickup).
 
@@ -348,6 +349,8 @@ The following buckets are created automatically by the `minio-init` container:
 | `{environment}-file-notifier-message` | Processed message deduplication |
 | `{environment}-data-pull` | Database pull scheduling state |
 | `{environment}-audit-log` | Audit entries (when `USE_AUDIT_LOG=true`); TTL-expired per `AUDIT_LOG_RETENTION_DAYS` |
+| `{environment}-agent-policy` | The [agent policy](/agent-policy) document (when `USE_AGENT_POLICY=true`) |
+| `{environment}-pending-action` | Agent actions queued for approval; TTL-expired at their own expiry |
 
 ## Container Environment Variables
 
@@ -365,3 +368,4 @@ These environment variables are read by `docker-compose.yml` and passed into the
 | `USE_AUDIT_LOG` | `false` | Enable the [Audit Log](/audit-log) — who did what, by login or API key. |
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries; `0` = forever. |
 | `AUDIT_LOG_READS` | `false` | Also record reads (queries, searches, listings). |
+| `USE_AGENT_POLICY` | `false` | Enable the [Agent Policy](/agent-policy) — auto / approve / deny per agent action, with a human approval queue. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,7 @@
               "user-auth",
               "api-keys",
               "audit-log",
+              "agent-policy",
               "monitoring",
               "notifications"
             ]

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -124,6 +124,16 @@ For a document tap, `create_tap` **requires** the `target_pipeline` to have an `
 | `list_platform_secrets` | List the names of human-owned platform secrets (the Platform tab in Configuration → Secrets). These hold destination credentials and infrastructure connections. Read-only — agents cannot create, modify, or delete them. |
 | `get_platform_secret_fields` | Return the field NAMES (no values) of a platform secret. Use after `list_platform_secrets` to verify a candidate has the required keys for a destination — e.g. an S3 `credentialsSecret` must contain `accessKey`, `secretKey`, `region`. |
 
+### Agent policy and approvals
+
+| Tool | Description |
+|------|-------------|
+| `get_agent_policy` | Read this instance's [agent policy](/agent-policy): for each action whether an agent may do it on its own, must wait for a person to approve it, or is refused. Call before a delete or destination-type migration to know whether it will run or queue |
+| `list_pending_approvals` | The actions this agent queued for approval, with their state |
+| `get_approval` | Poll one queued approval by id until it is executed, rejected or expired |
+
+Every tool that changes platform state also accepts an optional `reason` — one line the agent gives for the change. It is recorded in the [audit log](/audit-log) and shown on the approval card. When the policy requires approval, the mutating tool returns `status: pending_approval` with an `approvalId` instead of performing the action.
+
 ## Monitoring Active Agents
 
 The [Datris UI](http://localhost:4200) includes an **Agent Monitor** tab that shows a live view of every agent currently connected to the MCP server and a streaming log of the tool calls each one is making. Agents are labeled using their MCP `clientInfo.name` — so Claude Desktop appears as `claude-ai`, Claude Code as `claude-code`, Cursor as `cursor`, and so on — with graceful fallbacks to tenant name, API-key name, or session id for clients that don't supply one. See [Monitoring → Agent Monitor](/monitoring#agent-monitor) for details.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28,6 +28,82 @@ components:
       description: Optional API key for authentication (enabled via application.yaml)
 
   schemas:
+    AgentPolicy:
+      type: object
+      properties:
+        version:
+          type: integer
+          readOnly: true
+        actions:
+          type: object
+          description: action key (resource:action[:sub] or resource:*) → auto | approve | deny; unset is auto
+          additionalProperties:
+            type: string
+            enum: [auto, approve, deny]
+        overrides:
+          type: object
+          description: pipeline:<name> or tap:<name> → action map that may only tighten the default
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+              enum: [auto, approve, deny]
+        limits:
+          type: object
+          properties:
+            pendingTtlHours:
+              type: integer
+              default: 24
+            maxPendingPerActor:
+              type: integer
+              default: 50
+        updatedAt:
+          type: string
+          readOnly: true
+        updatedBy:
+          type: string
+          readOnly: true
+    PendingAction:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+        resourceType:
+          type: string
+        resource:
+          type: string
+        resourceVersion:
+          type: integer
+        actor:
+          type: object
+        reason:
+          type: string
+        agentSession:
+          type: string
+        request:
+          type: object
+          description: The parked request (body already redacted)
+        createdAt:
+          type: string
+        expiresAt:
+          type: string
+        state:
+          type: string
+          enum: [pending, approved, rejected, expired, executed, failed]
+        decidedBy:
+          type: string
+        decidedAt:
+          type: string
+        decisionNote:
+          type: string
+        executedAt:
+          type: string
+        resultStatus:
+          type: integer
+        resultBody:
+          type: string
     QueryResponse:
       type: object
       properties:
@@ -3127,6 +3203,171 @@ paths:
 
   # ── API Keys ───────────────────────────────────────────────
 
+  /api/v1/policy:
+    get:
+      tags: [Agent Policy]
+      summary: Read the agent policy
+      description: >-
+        Per-action auto / approve / deny for agent-initiated changes. Anyone
+        may read it (agents consult it before acting). `enabled` is false
+        when USE_AGENT_POLICY is off, in which case every action is auto.
+      responses:
+        '200':
+          description: The policy, the recommended template and the action vocabulary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  policy:
+                    $ref: '#/components/schemas/AgentPolicy'
+                  recommended:
+                    $ref: '#/components/schemas/AgentPolicy'
+                  actions:
+                    type: array
+                    description: Every action key a policy may name (sorted)
+                    items:
+                      type: string
+                  pendingCount:
+                    type: integer
+    put:
+      tags: [Agent Policy]
+      summary: Replace the agent policy (admin)
+      description: >-
+        Admin-only, and never permitted from an agent-initiated request
+        regardless of key capabilities. Unknown action keys, bad modes or
+        malformed overrides are rejected with 400 naming the problem.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentPolicy'
+      responses:
+        '200':
+          description: The saved policy (version incremented)
+        '400':
+          description: Validation error
+        '403':
+          description: Not an admin, or an agent-initiated request
+        '404':
+          description: USE_AGENT_POLICY is off
+  /api/v1/approvals:
+    get:
+      tags: [Agent Policy]
+      summary: List queued agent actions
+      description: >-
+        Newest first. An agent-initiated caller sees only the actions it
+        queued; a person sees everything.
+      parameters:
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [pending, approved, rejected, expired, executed, failed]
+        - in: query
+          name: actor
+          schema:
+            type: string
+          description: Filter by actor label (people only)
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            maximum: 500
+      responses:
+        '200':
+          description: Approvals
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  approvals:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PendingAction'
+  /api/v1/approvals/{id}:
+    get:
+      tags: [Agent Policy]
+      summary: Read one queued action
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The approval
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingAction'
+        '404':
+          description: Unknown id, or not visible to this caller
+  /api/v1/approvals/{id}/approve:
+    post:
+      tags: [Agent Policy]
+      summary: Approve a queued action (admin / editor)
+      description: >-
+        Performs the original request on the approver's behalf by replaying
+        it through the normal request chain. Never permitted from an
+        agent-initiated request. Refused as stale (409) if the target
+        pipeline or tap changed since the action was queued.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Executed — `resultStatus` / `resultBody` carry the original call's outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingAction'
+        '409':
+          description: Stale (resource version moved) or already decided
+        '410':
+          description: Expired before a decision
+        '502':
+          description: Approved but the replay failed (state `failed`)
+  /api/v1/approvals/{id}/reject:
+    post:
+      tags: [Agent Policy]
+      summary: Reject a queued action (admin / editor)
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  description: Optional note shown to the agent on its next poll
+      responses:
+        '200':
+          description: Rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingAction'
+        '409':
+          description: No longer pending
   /api/v1/keys:
     get:
       tags: [API Keys]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -58,6 +58,10 @@ _session_on_behalf_of: contextvars.ContextVar[str] = contextvars.ContextVar("_se
 # Per-session id used for agent-monitor attribution
 _session_id: contextvars.ContextVar[str] = contextvars.ContextVar("_session_id", default="")
 
+# The optional `reason` argument of the current mutating tool call, forwarded
+# to the platform as X-Datris-Reason (audit metadata + approval cards).
+_call_reason: contextvars.ContextVar[str] = contextvars.ContextVar("_call_reason", default="")
+
 # Agent-monitor: in-process activity buffer + session tracker.
 # Ephemeral; cleared on restart. Safe to read via a plain lock.
 _activity_buffer: deque = deque(maxlen=200)
@@ -392,6 +396,9 @@ NEVER narrate a create / update / delete / run operation as completed unless the
   - When the verification call FINDS the resource (the pipeline / tap / collection / table is present in the list response), it exists — full stop. Do NOT retract a previous-turn claim that it was created, do NOT apologize for confabulating, and do NOT re-create it. Skim the response for the name you're looking for; if it's there, treat it as real and move on to the user's current ask. The EVIDENCE RULE prevents fake claims of success — it does NOT require retracting true claims just because they happened in a previous turn.
 The user trusts your narrative as a proxy for the platform state. Confabulating "done" when only some of it is done corrupts that trust and creates failure modes (a cron set on a tap whose pipeline doesn't exist; a "run now" call against a pipeline that was never created). Be honest about what happened in THIS turn, even if it's less than the user asked for — they can redirect, but only if your report is true.
 
+APPROVAL RULE (agent policy):
+Some actions on this instance may be gated by the platform's agent policy. When a mutating tool returns `status: pending_approval`, the action was NOT performed — it is queued for a person to approve. Tell the user plainly that it is waiting for approval in Datris (Activity → Approvals), quote the `approvalId`, and either poll `get_approval` (with `wait_seconds` between polls) or offer to check back later. Never re-issue the action to "retry" it (you get the same id back), never describe it as done, and never ask the user for an API key or credential to get around the gate. `status: 403` with `errorKind: policy_denied` means the action is refused for agents on this instance — report that and stop. Call `get_agent_policy` before a delete or destination-schema change if you want to know in advance whether it will queue.
+
 DESTINATION OFFERING RULE (structured data):
 The structured destinations available in this deployment are: {{STRUCTURED_OFFER_DESTINATIONS}}. When the user wants to ingest structured/tabular data and has not named a destination, offer exactly this set — name every one of them in your question, with no silent defaults and no destinations outside this list. This list was resolved by the platform and baked into this text at session start — do NOT probe or re-check availability before offering, and do NOT drop an option just because you haven't seen it used yet. (If the user explicitly asks about a destination that is not in the list, you may still explain how it works and what configuring it requires.)
 
@@ -483,6 +490,9 @@ def _identity_headers():
     obo = _session_on_behalf_of.get()
     if obo:
         h["X-Datris-On-Behalf-Of"] = obo
+    reason = _call_reason.get()
+    if reason:
+        h["X-Datris-Reason"] = reason[:500]
     return h
 
 
@@ -1420,7 +1430,41 @@ async def list_tools():
     return [t for t in tools if t.name in allowed]
 
 
+# Tools that change platform state. Each gets an optional `reason` argument
+# (recorded in the audit log and shown on approval cards) and a note on the
+# agent-policy approval flow. Kept as a name list so the schema decoration
+# never drifts from the catalog by accident: a new mutating tool that is not
+# listed here simply lacks the optional argument.
+_MUTATING_TOOLS = {
+    "create_pipeline", "set_catalog", "delete_pipeline", "upload_data", "kill_job",
+    "apply_dest_types", "upload_config", "update_secret", "create_tap_secret",
+    "delete_tap_secret", "create_tap", "run_tap", "delete_tap", "set_tap_state",
+    "test_tap", "update_tap", "restore_tap_version", "restore_pipeline_version",
+}
+
+_APPROVAL_NOTE = (
+    " If this Datris instance's agent policy requires a person to approve this action, the call does NOT perform it: "
+    "it returns status `pending_approval` with an `approvalId`. Tell the user it is waiting for approval in Datris, "
+    "then poll `get_approval` with that id (pause with `wait_seconds` between polls) — do not re-issue the action."
+)
+
+
 def _all_tools():
+    tools = _base_tools()
+    for t in tools:
+        if t.name in _MUTATING_TOOLS:
+            props = t.inputSchema.setdefault("properties", {})
+            if "reason" not in props:
+                props["reason"] = {
+                    "type": "string",
+                    "description": "Optional one-line reason for this change, recorded in the platform's audit log and shown to anyone asked to approve it.",
+                }
+            if "pending_approval" not in (t.description or ""):
+                t.description = (t.description or "") + _APPROVAL_NOTE
+    return tools
+
+
+def _base_tools():
     return [
         # --- Pipeline Management ---
         Tool(
@@ -2719,6 +2763,46 @@ def _all_tools():
                 "required": ["seconds"]
             }
         ),
+        # --- Agent policy / approvals ---
+        Tool(
+            name="get_agent_policy",
+            description="Read this Datris instance's agent policy: for each action (e.g. tap:delete, pipeline:update:dest-types) whether an agent may do it on its own (auto), must wait for a person to approve it (approve), or is refused (deny). Call this before a delete, schema migration, or other consequential change to know whether it will run immediately or queue for approval, and tell the user accordingly. Returns {enabled, policy:{actions, overrides, limits}, actions:[all policy-able action keys], pendingCount}. When enabled is false, every action is auto.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            }
+        ),
+        Tool(
+            name="list_pending_approvals",
+            description="List the actions this agent queued for human approval under the agent policy, newest first. Each entry has id, action, resource, state (pending | approved | rejected | expired | executed | failed), createdAt, expiresAt and — once decided — decidedBy and the result. Use `state` to filter (default: all).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "type": "string",
+                        "description": "Filter by state: pending, approved, rejected, expired, executed, failed. Omit for all.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum entries to return (default 100).",
+                    },
+                },
+            }
+        ),
+        Tool(
+            name="get_approval",
+            description="Poll one queued approval by the `approvalId` a mutating tool returned with status pending_approval. Returns its current state: pending (still waiting for a person), executed (approved and performed — `resultStatus` / `resultBody` carry the outcome of the original call), failed (approved but the replay failed), rejected, or expired. Poll with `wait_seconds` between calls, backing off to 30-60s; a decision can take minutes or hours, so after a few polls tell the user you will check back and stop polling unless they ask you to wait.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "approval_id": {
+                        "type": "string",
+                        "description": "The approvalId returned with pending_approval.",
+                    },
+                },
+                "required": ["approval_id"],
+            }
+        ),
     ]
 
 
@@ -2739,7 +2823,13 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         # worker thread so the event loop stays responsive. Contextvars
         # (_session_api_key, _session_id) are copied automatically — see
         # asyncio.to_thread docs.
-        result_text = await asyncio.to_thread(_dispatch, name, arguments)
+        dispatch_args = dict(arguments or {})
+        reason = dispatch_args.pop("reason", None)
+        reason_token = _call_reason.set(str(reason).strip() if reason else "")
+        try:
+            result_text = await asyncio.to_thread(_dispatch, name, dispatch_args)
+        finally:
+            _call_reason.reset(reason_token)
         return [TextContent(type="text", text=result_text)]
     except Exception as e:
         status = "error"
@@ -3692,6 +3782,24 @@ def _dispatch(name: str, args: dict) -> str:
         seconds = max(1, min(120, requested))
         time.sleep(seconds)
         return json.dumps({"slept": seconds, "requested": requested})
+
+    # --- Agent policy / approvals ---
+    elif name == "get_agent_policy":
+        return _call("get", "/api/v1/policy")
+
+    elif name == "list_pending_approvals":
+        params = {}
+        if args.get("state"):
+            params["state"] = args["state"]
+        if args.get("limit"):
+            params["limit"] = args["limit"]
+        return _call("get", "/api/v1/approvals", params=params)
+
+    elif name == "get_approval":
+        approval_id = str(args.get("approval_id", "")).strip()
+        if not approval_id:
+            return json.dumps({"error": "approval_id is required"})
+        return _call("get", f"/api/v1/approvals/{approval_id}")
 
     else:
         return json.dumps({"error": f"Unknown tool: {name}"})

--- a/ui/src/app/activity/activity.component.css
+++ b/ui/src/app/activity/activity.component.css
@@ -641,3 +641,211 @@
   color: #f87171;
   font-weight: 500;
 }
+
+/* ─── Approvals (agent policy) ───────────────────────────────────── */
+.approvals-panel .panel-header { border-bottom: none; padding-bottom: 8px; }
+.approvals-spacer { flex: 1; }
+
+.approvals-error { margin: 0 18px 10px; }
+
+.approval-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.approval-card {
+  background: rgba(251, 191, 36, 0.04);
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.approval-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary, #f0f4ff);
+}
+
+.approval-actor-type {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  background: rgba(99, 179, 237, 0.12);
+  color: var(--text-secondary, #94a3b8);
+  border: 1px solid rgba(99, 179, 237, 0.2);
+}
+
+.approval-actor-type.type-api-key { color: var(--accent-cyan, #00b4ff); border-color: rgba(0, 180, 255, 0.3); background: rgba(0, 180, 255, 0.1); }
+.approval-actor-type.type-assistant { color: #c084fc; border-color: rgba(192, 132, 252, 0.3); background: rgba(192, 132, 252, 0.1); }
+.approval-actor-type.type-tap { color: #fbbf24; border-color: rgba(251, 191, 36, 0.3); background: rgba(251, 191, 36, 0.1); }
+.approval-actor-type.type-user { color: #4ade80; border-color: rgba(74, 222, 128, 0.3); background: rgba(74, 222, 128, 0.1); }
+
+.approval-actor { font-weight: 600; }
+.approval-arrow { color: var(--text-secondary, #94a3b8); font-size: 12px; }
+
+.approval-action {
+  font-size: 12px;
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.approval-resource { font-size: 12px; color: var(--text-secondary, #94a3b8); }
+.approval-resource strong { color: var(--text-primary, #f0f4ff); font-weight: 600; }
+
+.approval-reason {
+  margin-top: 6px;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.approval-times {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}
+
+.approval-req-toggle {
+  margin-top: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 12px;
+  color: var(--text-secondary, #94a3b8);
+  cursor: pointer;
+}
+
+.approval-req-toggle:hover { color: var(--text-primary, #f0f4ff); }
+
+.approval-request { margin-top: 6px; }
+
+.approval-req-line code {
+  font-size: 11px;
+  color: var(--text-secondary, #94a3b8);
+  word-break: break-all;
+}
+
+.approval-req-body {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  background: var(--bg-primary, #0a0e1a);
+  border: 1px solid var(--border-color, rgba(99, 179, 237, 0.15));
+  border-radius: 4px;
+  font-size: 11px;
+  line-height: 1.4;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.approval-outcome {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.approval-outcome-ok { background: rgba(74, 222, 128, 0.10); color: #4ade80; }
+.approval-outcome-err { background: rgba(248, 113, 113, 0.10); color: #f87171; }
+.approval-outcome-warn { background: rgba(251, 191, 36, 0.10); color: #fbbf24; }
+
+.approval-outcome-detail {
+  margin: 6px 0 0;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: inherit;
+  opacity: 0.85;
+  max-height: 140px;
+  overflow: auto;
+}
+
+.approval-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.approval-approve {
+  background: rgba(74, 222, 128, 0.12);
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.28);
+}
+
+.approval-approve:hover:not(:disabled) { background: rgba(74, 222, 128, 0.22); }
+
+.approval-reject-note {
+  flex: 1;
+  min-width: 160px;
+  padding: 5px 10px;
+  background: var(--bg-primary, #0a0e1a);
+  border: 1px solid var(--border-color, rgba(99, 179, 237, 0.15));
+  border-radius: 4px;
+  color: var(--text-primary, #f0f4ff);
+  font-size: 12px;
+}
+
+.approval-reject-confirm {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.28);
+}
+
+.approval-reject-confirm:hover:not(:disabled) { background: rgba(248, 113, 113, 0.22); }
+
+/* Decided approvals — compact table behind the toggle. */
+.approval-decided { padding: 4px 18px 0; }
+
+.approval-decided-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.approval-decided-table th,
+.approval-decided-table td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-color, rgba(99, 179, 237, 0.1));
+  font-size: 12px;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.approval-decided-table th {
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.approval-decided-table code { font-size: 11px; color: var(--text-primary, #f0f4ff); }
+
+.approval-state {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.approval-state.state-executed { background: rgba(74, 222, 128, 0.14); color: #4ade80; }
+.approval-state.state-approved { background: rgba(74, 222, 128, 0.14); color: #4ade80; }
+.approval-state.state-failed { background: rgba(248, 113, 113, 0.14); color: #f87171; }
+.approval-state.state-rejected { background: rgba(248, 113, 113, 0.14); color: #f87171; }
+.approval-state.state-expired { background: rgba(148, 163, 184, 0.14); color: #94a3b8; }

--- a/ui/src/app/activity/activity.component.html
+++ b/ui/src/app/activity/activity.component.html
@@ -50,6 +50,106 @@
     </div>
   </section>
 
+  <!-- Approvals: agent actions waiting on a person (agent policy). Only
+       rendered when USE_AGENT_POLICY is on. -->
+  <section class="panel approvals-panel" id="approvals" *ngIf="policyEnabled">
+    <div class="panel-header">
+      <h3 class="panel-title">Approvals</h3>
+      <span class="panel-count" [class.panel-count-ok]="pendingApprovals.length === 0">{{ pendingApprovals.length }}</span>
+      <span class="panel-sub">agent actions waiting on a person</span>
+      <span class="approvals-spacer"></span>
+      <button class="action-btn action-btn-ghost" (click)="toggleDecided()">
+        {{ showDecided ? 'Hide decided' : 'Show decided' }}
+      </button>
+    </div>
+
+    <div class="error-banner approvals-error" *ngIf="approvalsError">{{ approvalsError }}</div>
+
+    <div class="panel-empty" *ngIf="approvalsLoaded && pendingApprovals.length === 0 && !approvalsError">
+      <span class="panel-empty-check">✓</span> Nothing waiting for approval.
+    </div>
+
+    <ul class="approval-list" *ngIf="pendingApprovals.length > 0">
+      <li class="approval-card" *ngFor="let a of pendingApprovals; trackBy: trackByApproval">
+        <div class="approval-head">
+          <span class="approval-actor-type" [class]="'approval-actor-type type-' + a.actor.type">{{ a.actor.type }}</span>
+          <span class="approval-actor">{{ approvalActor(a) }}</span>
+          <span class="approval-arrow">wants to</span>
+          <code class="approval-action">{{ a.action }}</code>
+          <span class="approval-resource" *ngIf="approvalResource(a)">on <strong>{{ approvalResource(a) }}</strong></span>
+        </div>
+        <div class="approval-reason" *ngIf="a.reason">&ldquo;{{ a.reason }}&rdquo;</div>
+        <div class="approval-times">
+          queued {{ formatRelative(a.createdAt) }} · expires {{ formatUntil(a.expiresAt) }}
+        </div>
+
+        <button class="approval-req-toggle" (click)="toggleRequest(a)">
+          {{ requestOpen.has(a.id) ? '▾' : '▸' }} Request
+        </button>
+        <div class="approval-request" *ngIf="requestOpen.has(a.id)">
+          <div class="approval-req-line">
+            <code>{{ a.request.method }} {{ a.request.path }}<ng-container *ngIf="a.request.query">?{{ a.request.query }}</ng-container></code>
+          </div>
+          <pre class="approval-req-body" *ngIf="requestBody(a)">{{ requestBody(a) }}</pre>
+        </div>
+
+        <div class="approval-outcome" *ngIf="outcomeFor(a) as o"
+             [class.approval-outcome-ok]="o.tone === 'ok'"
+             [class.approval-outcome-err]="o.tone === 'err'"
+             [class.approval-outcome-warn]="o.tone === 'warn'">
+          {{ o.text }}
+          <pre class="approval-outcome-detail" *ngIf="o.detail">{{ o.detail }}</pre>
+        </div>
+
+        <div class="approval-actions" *ngIf="auth.canWrite()">
+          <button class="action-btn approval-approve"
+                  [disabled]="isDeciding(a)"
+                  (click)="approve(a)"
+                  title="Approve — the queued request executes now">
+            <span class="action-spinner" *ngIf="isDeciding(a)"></span>
+            {{ isDeciding(a) ? 'Working…' : 'Approve' }}
+          </button>
+          <button class="action-btn action-btn-ghost"
+                  [disabled]="isDeciding(a)"
+                  (click)="openReject(a)">
+            Reject
+          </button>
+          <ng-container *ngIf="rejectOpen.has(a.id)">
+            <input type="text" class="approval-reject-note"
+                   placeholder="Note (optional)"
+                   [ngModel]="rejectNote(a)"
+                   (ngModelChange)="setRejectNote(a, $event)"
+                   name="reject-note-{{ a.id }}" />
+            <button class="action-btn approval-reject-confirm"
+                    [disabled]="isDeciding(a)"
+                    (click)="reject(a)">
+              Confirm reject
+            </button>
+          </ng-container>
+        </div>
+      </li>
+    </ul>
+
+    <div class="approval-decided" *ngIf="showDecided">
+      <div class="panel-empty" *ngIf="decidedApprovals.length === 0">No decided approvals yet.</div>
+      <table class="approval-decided-table" *ngIf="decidedApprovals.length > 0">
+        <thead>
+          <tr><th>State</th><th>Action</th><th>Resource</th><th>Actor</th><th>Decided by</th><th>Decided at</th></tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let a of decidedApprovals; trackBy: trackByApproval">
+            <td><span class="approval-state" [class]="'approval-state state-' + a.state">{{ a.state }}</span></td>
+            <td><code>{{ a.action }}</code></td>
+            <td>{{ approvalResource(a) || '—' }}</td>
+            <td>{{ approvalActor(a) }}</td>
+            <td>{{ a.decidedBy || '—' }}</td>
+            <td>{{ formatTs(a.decidedAt) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
   <!-- Region 2: timeline charts -->
   <section class="timeline-row">
     <div class="chart-card">

--- a/ui/src/app/activity/activity.component.ts
+++ b/ui/src/app/activity/activity.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, forkJoin, of, Subscription } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import type { EChartsOption } from 'echarts';
@@ -10,6 +10,7 @@ import { AuthService } from '../auth.service';
 import { OpsChatContextService } from '../ops-chat/ops-chat-context.service';
 import { OpsActionBus } from '../ops-chat/ops-action-bus.service';
 import { OpsAssistantStateService } from '../ops-chat/ops-assistant-state.service';
+import { Approval, ApprovalsService } from '../approvals.service';
 
 type Window = '24h' | '7d' | '30d';
 
@@ -107,6 +108,28 @@ export class ActivityComponent implements OnInit, OnDestroy {
   private refreshTimer: any;
   private readonly REFRESH_MS = 30_000;
 
+  // ── Approvals (agent policy) ──────────────────────────────────────────────
+  // Only rendered when USE_AGENT_POLICY is on. Pending approvals are actions
+  // an agent asked for that wait on a person; decided ones are shown behind a
+  // toggle. Refreshed on the same 30s cycle as the rest of the dashboard and
+  // immediately after any decision made here.
+  policyEnabled = false;
+  pendingApprovals: Approval[] = [];
+  decidedApprovals: Approval[] = [];
+  showDecided = false;
+  approvalsError = '';
+  approvalsLoaded = false;
+  /** Approval ids with an approve/reject call in flight. */
+  deciding = new Set<string>();
+  /** Approval ids whose "Request" block is expanded. */
+  requestOpen = new Set<string>();
+  /** Approval ids with the inline reject-note input open, and its draft. */
+  rejectOpen = new Set<string>();
+  rejectNotes = new Map<string, string>();
+  /** Per-approval outcome banner after a decision made from this page. */
+  decisionOutcome = new Map<string, { tone: 'ok' | 'err' | 'warn'; text: string; detail?: string }>();
+  private approvalsScrollPending = false;
+
   constructor(
     private tapService: TapService,
     private pipelineService: PipelineService,
@@ -115,10 +138,20 @@ export class ActivityComponent implements OnInit, OnDestroy {
     public auth: AuthService,
     private opsContext: OpsChatContextService,
     private opsActionBus: OpsActionBus,
-    private opsState: OpsAssistantStateService
+    private opsState: OpsAssistantStateService,
+    private approvalsService: ApprovalsService,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
+    // Deep-link from Configuration → Agent Policy and the chat tool cards:
+    // /ops/activity#approvals scrolls the Approvals section into view once
+    // it has rendered.
+    this.approvalsScrollPending = this.route.snapshot.fragment === 'approvals';
+    this.approvalsService.policyEnabled().subscribe(on => {
+      this.policyEnabled = on;
+      if (on) this.loadApprovals();
+    });
     this.loadData();
     this.refreshTimer = setInterval(() => this.loadData(true), this.REFRESH_MS);
     // Chat-triggered tap runs flow through the action bus so the row's
@@ -163,6 +196,7 @@ export class ActivityComponent implements OnInit, OnDestroy {
       this.loading = true;
       this.loadError = '';
     }
+    if (this.policyEnabled) this.loadApprovals();
 
     try {
       // Pull tap logs covering both the current window and the prior window so the
@@ -205,6 +239,195 @@ export class ActivityComponent implements OnInit, OnDestroy {
     } finally {
       this.loading = false;
     }
+  }
+
+  // ── Approvals ─────────────────────────────────────────────────────────────
+
+  loadApprovals(): void {
+    this.approvalsService.list('pending', 100).subscribe({
+      next: (page) => {
+        this.policyEnabled = page.enabled !== false;
+        this.pendingApprovals = page.approvals || [];
+        this.approvalsLoaded = true;
+        this.approvalsError = '';
+        // Drop stale per-card state for approvals that left the pending list.
+        const ids = new Set(this.pendingApprovals.map(a => a.id));
+        for (const id of Array.from(this.rejectOpen)) if (!ids.has(id)) this.rejectOpen.delete(id);
+        for (const id of Array.from(this.requestOpen)) if (!ids.has(id)) this.requestOpen.delete(id);
+        if (this.approvalsScrollPending) {
+          this.approvalsScrollPending = false;
+          setTimeout(() => document.getElementById('approvals')?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+        }
+      },
+      error: (err) => {
+        this.approvalsLoaded = true;
+        this.approvalsError = err?.error?.error || 'Failed to load approvals';
+      }
+    });
+    if (this.showDecided) this.loadDecided();
+  }
+
+  private loadDecided(): void {
+    // The server lists newest first; ask for enough to fill 20 after
+    // filtering out whatever is still pending.
+    this.approvalsService.list(undefined, 60).subscribe({
+      next: (page) => {
+        this.decidedApprovals = (page.approvals || []).filter(a => a.state !== 'pending').slice(0, 20);
+      },
+      error: () => { /* keep the last list; the pending fetch reports errors */ }
+    });
+  }
+
+  toggleDecided(): void {
+    this.showDecided = !this.showDecided;
+    if (this.showDecided) this.loadDecided();
+  }
+
+  toggleRequest(a: Approval): void {
+    if (this.requestOpen.has(a.id)) this.requestOpen.delete(a.id);
+    else this.requestOpen.add(a.id);
+  }
+
+  openReject(a: Approval): void {
+    if (this.rejectOpen.has(a.id)) {
+      this.rejectOpen.delete(a.id);
+    } else {
+      this.rejectOpen.add(a.id);
+      if (!this.rejectNotes.has(a.id)) this.rejectNotes.set(a.id, '');
+    }
+  }
+
+  rejectNote(a: Approval): string {
+    return this.rejectNotes.get(a.id) || '';
+  }
+
+  setRejectNote(a: Approval, v: string): void {
+    this.rejectNotes.set(a.id, v);
+  }
+
+  isDeciding(a: Approval): boolean {
+    return this.deciding.has(a.id);
+  }
+
+  outcomeFor(a: Approval) {
+    return this.decisionOutcome.get(a.id) || null;
+  }
+
+  approve(a: Approval): void {
+    if (this.deciding.has(a.id)) return;
+    this.deciding.add(a.id);
+    this.decisionOutcome.delete(a.id);
+    this.approvalsService.approve(a.id).subscribe({
+      next: (res) => {
+        this.deciding.delete(a.id);
+        this.decisionOutcome.set(a.id, {
+          tone: 'ok',
+          text: `Approved and executed (HTTP ${res.resultStatus ?? 200}).`
+        });
+        this.loadApprovals();
+        this.loadData(true);
+      },
+      error: (err) => {
+        this.deciding.delete(a.id);
+        const body = err?.error || {};
+        if (err?.status === 502) {
+          this.decisionOutcome.set(a.id, {
+            tone: 'err',
+            text: `Approved, but the action failed (HTTP ${body.resultStatus ?? '?'}).`,
+            detail: body.resultBody || body.error || ''
+          });
+          this.loadApprovals();
+        } else if (err?.status === 409 && body.errorKind === 'approval_stale') {
+          // The resource changed since the agent asked — leave the card
+          // pending so the person can re-read the request before deciding.
+          this.decisionOutcome.set(a.id, {
+            tone: 'warn',
+            text: body.message || `The ${a.resourceType || 'resource'} changed since this was requested (now version ${body.liveVersion}). Review and try again.`
+          });
+        } else if (err?.status === 409) {
+          this.decisionOutcome.set(a.id, { tone: 'warn', text: body.message || body.error || 'Already decided.' });
+          this.loadApprovals();
+        } else if (err?.status === 410) {
+          this.decisionOutcome.set(a.id, { tone: 'warn', text: 'This request has expired.' });
+          this.loadApprovals();
+        } else {
+          this.decisionOutcome.set(a.id, { tone: 'err', text: body.error || body.message || 'Approve failed.' });
+        }
+      }
+    });
+  }
+
+  reject(a: Approval): void {
+    if (this.deciding.has(a.id)) return;
+    this.deciding.add(a.id);
+    this.decisionOutcome.delete(a.id);
+    this.approvalsService.reject(a.id, this.rejectNotes.get(a.id)).subscribe({
+      next: () => {
+        this.deciding.delete(a.id);
+        this.rejectOpen.delete(a.id);
+        this.rejectNotes.delete(a.id);
+        this.decisionOutcome.set(a.id, { tone: 'ok', text: 'Rejected.' });
+        this.loadApprovals();
+      },
+      error: (err) => {
+        this.deciding.delete(a.id);
+        const body = err?.error || {};
+        if (err?.status === 409 || err?.status === 410) {
+          this.decisionOutcome.set(a.id, { tone: 'warn', text: body.message || body.error || 'Already decided.' });
+          this.loadApprovals();
+        } else {
+          this.decisionOutcome.set(a.id, { tone: 'err', text: body.error || body.message || 'Reject failed.' });
+        }
+      }
+    });
+  }
+
+  approvalActor(a: Approval): string {
+    const x = a.actor;
+    switch (x.type) {
+      case 'user': return x.username || x.label;
+      case 'assistant': return `${x.username || x.label} via Assistant`;
+      case 'tap': return `tap ${x.label}`;
+      default: return x.label;
+    }
+  }
+
+  approvalResource(a: Approval): string {
+    if (!a.resource) return '';
+    return a.resourceType ? `${a.resourceType} ${a.resource}` : a.resource;
+  }
+
+  /** "in 3h" / "2m ago" for expiry — the failures pane's formatRelative only
+   *  looks backwards. */
+  formatUntil(iso: string | null | undefined): string {
+    const t = this.parseTime(iso || null);
+    if (t == null) return '—';
+    const diff = t - Date.now();
+    if (diff <= 0) return 'now';
+    if (diff < 60_000) return 'in <1m';
+    if (diff < 3600_000) return `in ${Math.floor(diff / 60_000)}m`;
+    if (diff < 86400_000) return `in ${Math.floor(diff / 3600_000)}h`;
+    return `in ${Math.floor(diff / 86400_000)}d`;
+  }
+
+  requestBody(a: Approval): string {
+    const b = a.request?.body;
+    if (b === undefined || b === null || b === '') return '';
+    try {
+      return typeof b === 'string' ? b : JSON.stringify(b, null, 2);
+    } catch {
+      return String(b);
+    }
+  }
+
+  formatTs(iso: string | undefined): string {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? iso : d.toLocaleString();
+  }
+
+  trackByApproval(_i: number, a: Approval): string {
+    return a.id;
   }
 
   /** Push a compact dashboard snapshot to the chat panel's context service.

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { ChangePasswordModalComponent } from './change-password-modal/change-pas
 import { UsersComponent } from './configuration/users/users.component';
 import { KeysComponent } from './configuration/keys/keys.component';
 import { AuditLogComponent } from './configuration/audit-log/audit-log.component';
+import { AgentPolicyComponent } from './configuration/agent-policy/agent-policy.component';
 import { VersionHistoryComponent } from './version-history/version-history.component';
 import { AppRoutingModule } from './app-routing.module';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -81,6 +82,7 @@ import { NgxEchartsModule } from 'ngx-echarts';
     UsersComponent,
     KeysComponent,
     AuditLogComponent,
+    AgentPolicyComponent,
     VersionHistoryComponent
   ],
   imports: [

--- a/ui/src/app/approvals.service.ts
+++ b/ui/src/app/approvals.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+
+/** Actor that made the gated request — same shape the audit log uses. */
+export interface ApprovalActor {
+  type: 'user' | 'api-key' | 'assistant' | 'tap' | 'system';
+  label: string;
+  keyLabel?: string;
+  keyId?: string | null;
+  username?: string;
+  role?: string;
+}
+
+export type ApprovalState = 'pending' | 'approved' | 'rejected' | 'expired' | 'executed' | 'failed';
+
+/** One queued (or decided) agent action as returned by GET /api/v1/approvals. */
+export interface Approval {
+  id: string;
+  action: string;
+  resourceType?: string;
+  resource?: string;
+  resourceVersion?: number;
+  actor: ApprovalActor;
+  reason?: string;
+  agentSession?: string;
+  request: { method: string; path: string; query?: string; contentType?: string; body?: any };
+  createdAt: string;
+  expiresAt: string;
+  state: ApprovalState;
+  decidedBy?: string;
+  decidedAt?: string;
+  decisionNote?: string;
+  executedAt?: string;
+  resultStatus?: number;
+  resultBody?: string;
+  /** Present on 409 conflict responses (stale resource / already decided). */
+  error?: string;
+  errorKind?: string;
+  liveVersion?: number;
+  message?: string;
+}
+
+export interface ApprovalsPage {
+  enabled: boolean;
+  approvals: Approval[];
+}
+
+/** Shape of a tool result the chats receive when the agent's call was gated
+ *  by policy. `status: "pending_approval"` means the action is queued for a
+ *  person; `errorKind: "policy_denied"` means it was refused outright. */
+export interface PolicyToolOutcome {
+  kind: 'pending' | 'denied';
+  approvalId?: string;
+  action?: string;
+  resource?: string;
+  resourceType?: string;
+  message?: string;
+}
+
+/** Shared by the Activity → Approvals section and both chats. */
+@Injectable({ providedIn: 'root' })
+export class ApprovalsService {
+  private enabled$?: Observable<boolean>;
+
+  constructor(private http: HttpClient) {}
+
+  /** USE_AGENT_POLICY flag from /api/v1/version, fetched once per app life. */
+  policyEnabled(): Observable<boolean> {
+    if (!this.enabled$) {
+      this.enabled$ = this.http.get<any>('/api/v1/version').pipe(
+        map(v => String(v?.useAgentPolicy) === 'true'),
+        catchError(() => of(false)),
+        shareReplay(1)
+      );
+    }
+    return this.enabled$;
+  }
+
+  list(state?: string, limit?: number): Observable<ApprovalsPage> {
+    let p = new HttpParams();
+    if (state) p = p.set('state', state);
+    if (limit) p = p.set('limit', String(limit));
+    return this.http.get<ApprovalsPage>('/api/v1/approvals', { params: p });
+  }
+
+  get(id: string): Observable<Approval> {
+    return this.http.get<Approval>('/api/v1/approvals/' + encodeURIComponent(id));
+  }
+
+  approve(id: string): Observable<Approval> {
+    return this.http.post<Approval>('/api/v1/approvals/' + encodeURIComponent(id) + '/approve', {});
+  }
+
+  reject(id: string, note?: string): Observable<Approval> {
+    const body = note && note.trim() ? { note: note.trim() } : {};
+    return this.http.post<Approval>('/api/v1/approvals/' + encodeURIComponent(id) + '/reject', body);
+  }
+
+  /** Parse a chat tool-result string for a policy outcome. Returns null for
+   *  anything that isn't a pending-approval or policy-denied envelope. */
+  static parseToolOutcome(result: string): PolicyToolOutcome | null {
+    if (!result || typeof result !== 'string') return null;
+    const trimmed = result.trim();
+    if (!trimmed.startsWith('{')) return null;
+    let obj: any;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+    if (!obj || typeof obj !== 'object') return null;
+    // MCP-style envelopes wrap the payload in content[0].text — unwrap once.
+    if (Array.isArray(obj.content) && obj.content.length && typeof obj.content[0]?.text === 'string') {
+      try {
+        const inner = JSON.parse(obj.content[0].text);
+        if (inner && typeof inner === 'object') obj = inner;
+      } catch { /* keep outer */ }
+    }
+    const pick = (o: any, k: string): string | undefined =>
+      typeof o?.[k] === 'string' && o[k] ? o[k] : undefined;
+    if (obj.status === 'pending_approval') {
+      return {
+        kind: 'pending',
+        approvalId: pick(obj, 'approvalId') || pick(obj, 'id'),
+        action: pick(obj, 'action'),
+        resource: pick(obj, 'resource'),
+        resourceType: pick(obj, 'resourceType'),
+        message: pick(obj, 'message')
+      };
+    }
+    if (obj.errorKind === 'policy_denied') {
+      return {
+        kind: 'denied',
+        action: pick(obj, 'action'),
+        resource: pick(obj, 'resource'),
+        resourceType: pick(obj, 'resourceType'),
+        message: pick(obj, 'message') || pick(obj, 'error')
+      };
+    }
+    return null;
+  }
+}

--- a/ui/src/app/assistant/assistant.component.css
+++ b/ui/src/app/assistant/assistant.component.css
@@ -716,3 +716,63 @@
   color: #e25c5c;
   font-size: 13px;
 }
+
+/* Agent-policy outcomes on tool cards */
+.policy-note {
+  margin: 0;
+  padding: 8px 12px;
+  border-top: 1px solid #3a3f4a;
+  font-size: 12.5px;
+  color: #d0d2d8;
+}
+
+.policy-pending { background: rgba(251, 191, 36, 0.06); }
+.policy-denied { background: rgba(255, 115, 115, 0.06); }
+
+.policy-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.policy-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.policy-badge-pending {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.policy-badge-denied {
+  background: rgba(255, 115, 115, 0.15);
+  color: #ff7373;
+  border: 1px solid rgba(255, 115, 115, 0.3);
+}
+
+.policy-open {
+  background: transparent;
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: #fbbf24;
+  cursor: pointer;
+}
+
+.policy-open:hover { background: rgba(251, 191, 36, 0.12); }
+
+.policy-line { margin-top: 4px; }
+.policy-line code { color: #fbbf24; }
+.policy-denied .policy-line { color: #ffb3b3; margin-top: 6px; }
+.policy-id {
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  color: #8a8e96;
+}

--- a/ui/src/app/assistant/assistant.component.html
+++ b/ui/src/app/assistant/assistant.component.html
@@ -191,6 +191,25 @@
                   </div>
                 </ng-container>
 
+                <!-- Agent-policy outcomes: the call is queued for a person, or
+                     was refused by policy. Rendered from the tool result JSON. -->
+                <ng-container *ngIf="policyOutcome(seg) as po">
+                  <div class="policy-note policy-pending" *ngIf="po.kind === 'pending'">
+                    <div class="policy-head">
+                      <span class="policy-badge policy-badge-pending">Waiting for approval</span>
+                      <button class="policy-open" (click)="openApprovals()">Open Approvals</button>
+                    </div>
+                    <div class="policy-line" *ngIf="po.action">
+                      <code>{{ po.action }}</code><ng-container *ngIf="po.resource"> on <strong>{{ (po.resourceType ? po.resourceType + ' ' : '') + po.resource }}</strong></ng-container>
+                    </div>
+                    <div class="policy-line policy-id" *ngIf="po.approvalId">{{ po.approvalId }}</div>
+                  </div>
+                  <div class="policy-note policy-denied" *ngIf="po.kind === 'denied'">
+                    <span class="policy-badge policy-badge-denied">Refused by agent policy</span>
+                    <div class="policy-line" *ngIf="po.message">{{ po.message }}</div>
+                  </div>
+                </ng-container>
+
                 <!-- Generic tool body (input + result JSON). Suppressed for
                      active secret-request cards since the form replaces it. -->
                 <div class="tool-body" *ngIf="seg.expanded && !seg.secretRequest">

--- a/ui/src/app/assistant/assistant.component.ts
+++ b/ui/src/app/assistant/assistant.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewInit, AfterViewChecked, NgZone } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AssistantStateService, AssistantTurn, ToolCard, TextSegment } from './assistant-state.service';
 import { SecretsService } from '../secrets.service';
 import { TapService } from '../tap.service';
+import { ApprovalsService, PolicyToolOutcome } from '../approvals.service';
 
 interface StarterPrompt {
   label: string;
@@ -48,6 +49,7 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
     private secretsService: SecretsService,
     private tapService: TapService,
     private route: ActivatedRoute,
+    private router: Router,
     private zone: NgZone
   ) { }
 
@@ -364,6 +366,24 @@ export class AssistantComponent implements OnInit, OnDestroy, AfterViewInit, Aft
       return { icon: '🗑',  label: 'Deleting ' + (arg('name') || name.substring('delete_'.length)) };
     }
     return { icon: '▸', label: 'Called ' + name };
+  }
+
+  /** Agent-policy outcome carried in a tool result: the call is queued for a
+   *  person ("pending_approval") or was refused ("policy_denied"). Parsed
+   *  once per result string and memoized — this runs from the template. */
+  private policyOutcomes = new Map<string, PolicyToolOutcome | null>();
+
+  policyOutcome(card: ToolCard): PolicyToolOutcome | null {
+    if (card.status === 'running' || !card.result) return null;
+    const key = card.id + '\u0000' + card.result;
+    if (!this.policyOutcomes.has(key)) {
+      this.policyOutcomes.set(key, ApprovalsService.parseToolOutcome(card.result));
+    }
+    return this.policyOutcomes.get(key) || null;
+  }
+
+  openApprovals(): void {
+    this.router.navigate(['/ops', 'activity'], { fragment: 'approvals' });
   }
 
   toolStatusIcon(card: ToolCard): string {

--- a/ui/src/app/configuration/agent-policy/agent-policy.component.css
+++ b/ui/src/app/configuration/agent-policy/agent-policy.component.css
@@ -1,0 +1,379 @@
+.policy-pane {
+  padding: 24px;
+  color: #f0f4ff;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.hint {
+  margin: 4px 0 0;
+  color: #8b9dc3;
+  font-size: 0.8rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.error {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+.success {
+  color: #00e5a0;
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+.disabled-card {
+  padding: 14px 16px;
+  background: #0a0e1a;
+  border: 1px solid rgba(255, 191, 0, 0.3);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: #d5deef;
+}
+
+.disabled-card .note-title {
+  margin: 0 0 6px;
+  font-weight: 600;
+  color: #ffbf00;
+}
+
+.disabled-card p { margin: 6px 0; }
+.disabled-card code { color: #00e5a0; }
+.disabled-card pre {
+  margin: 8px 0;
+  padding: 8px 10px;
+  background: #141a2e;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+}
+
+/* ---- meta strip ---- */
+
+.meta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: #0a0e1a;
+  border: 1px solid rgba(99, 179, 237, 0.15);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  color: #8b9dc3;
+}
+
+.meta-item strong { color: #f0f4ff; font-weight: 600; }
+.meta-spacer { flex: 1; }
+
+.pending-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid rgba(255, 191, 0, 0.3);
+  border-radius: 12px;
+  padding: 3px 10px;
+  color: #ffbf00;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.pending-link:hover { background: rgba(255, 191, 0, 0.1); }
+
+.pending-count {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 6px;
+  border-radius: 9px;
+  background: rgba(255, 191, 0, 0.2);
+  text-align: center;
+  font-weight: 600;
+}
+
+.pending-count-zero {
+  background: rgba(139, 157, 195, 0.15);
+  color: #8b9dc3;
+}
+
+/* ---- cards ---- */
+
+.card {
+  margin-bottom: 14px;
+  padding: 14px 16px;
+  background: #0a0e1a;
+  border: 1px solid rgba(99, 179, 237, 0.15);
+  border-radius: 8px;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.card-header h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 10px;
+  font-size: 0.75rem;
+  color: #8b9dc3;
+}
+
+.legend-item { display: inline-flex; align-items: center; gap: 6px; }
+
+.mode-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.mode-auto { background: #00e5a0; }
+.mode-approve { background: #ffbf00; }
+.mode-deny { background: #f87171; }
+
+/* ---- matrix ---- */
+
+.matrix { display: flex; flex-direction: column; }
+
+.matrix-group {
+  margin: 10px 0 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #00b4ff;
+}
+
+.matrix-group:first-child { margin-top: 0; }
+
+.matrix-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  border-bottom: 1px solid rgba(99, 179, 237, 0.08);
+}
+
+.matrix-row:hover { background: rgba(99, 179, 237, 0.05); }
+.matrix-row-sub { padding-left: 28px; }
+
+.matrix-key {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.matrix-key code {
+  font-size: 0.8rem;
+  color: #f0f4ff;
+}
+
+.inherit-hint {
+  font-size: 0.7rem;
+  color: #5a6b8a;
+}
+
+.segmented {
+  display: inline-flex;
+  flex-shrink: 0;
+  border: 1px solid rgba(139, 157, 195, 0.2);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  padding: 4px 12px;
+  background: transparent;
+  color: #8b9dc3;
+  border: none;
+  border-right: 1px solid rgba(139, 157, 195, 0.2);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.seg-btn:last-child { border-right: none; }
+.seg-btn:hover { color: #f0f4ff; background: rgba(99, 179, 237, 0.08); }
+
+.seg-active.seg-auto { background: rgba(0, 229, 160, 0.15); color: #00e5a0; }
+.seg-active.seg-approve { background: rgba(255, 191, 0, 0.15); color: #ffbf00; }
+.seg-active.seg-deny { background: rgba(248, 113, 113, 0.15); color: #f87171; }
+/* Sub-action left unset: dim the Auto pill so it reads as "following parent". */
+.seg-active.seg-inherited { background: rgba(139, 157, 195, 0.12); color: #8b9dc3; font-style: italic; }
+
+.empty {
+  padding: 12px;
+  text-align: center;
+  color: #5a6b8a;
+  font-style: italic;
+  font-size: 0.8rem;
+}
+
+/* ---- overrides ---- */
+
+.override {
+  margin-bottom: 10px;
+  padding: 10px;
+  background: #141a2e;
+  border: 1px solid rgba(99, 179, 237, 0.1);
+  border-radius: 6px;
+}
+
+.override-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.override-resource { flex: 1; }
+
+.override-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding-left: 12px;
+}
+
+.override input,
+.override select,
+.limits input {
+  padding: 7px 10px;
+  background: #0a0e1a;
+  border: 1px solid rgba(99, 179, 237, 0.15);
+  border-radius: 4px;
+  color: #f0f4ff;
+  font-size: 0.8rem;
+}
+
+.override-entry select:first-child { flex: 1; min-width: 0; }
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  color: #8b9dc3;
+  cursor: pointer;
+  line-height: 0;
+  padding: 2px;
+}
+
+.icon-btn:hover:not(:disabled) { color: #f87171; }
+.icon-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+.icon-btn mat-icon { font-size: 18px; width: 18px; height: 18px; }
+
+.link-btn {
+  background: transparent;
+  border: none;
+  color: #00b4ff;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 2px 0 0 12px;
+}
+
+.link-btn:hover { text-decoration: underline; }
+
+/* ---- limits ---- */
+
+.limits {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+}
+
+.limit {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+}
+
+.limit input { width: 120px; }
+
+.limit-hint {
+  font-size: 0.7rem;
+  color: #5a6b8a;
+}
+
+/* ---- rules + footer ---- */
+
+.rules {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 4px 0 14px;
+  font-size: 0.75rem;
+  color: #5a6b8a;
+}
+
+.rules span::before {
+  content: '•';
+  margin-right: 6px;
+}
+
+.footer-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #00b4ff, #00e5a0);
+  color: #000;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: #8b9dc3;
+  border: 1px solid rgba(139, 157, 195, 0.2);
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (max-width: 700px) {
+  .matrix-row { flex-direction: column; align-items: flex-start; }
+}

--- a/ui/src/app/configuration/agent-policy/agent-policy.component.html
+++ b/ui/src/app/configuration/agent-policy/agent-policy.component.html
@@ -1,0 +1,156 @@
+<div class="policy-pane">
+  <div class="header">
+    <div>
+      <h3>Agent Policy</h3>
+      <p class="hint">Decide what agents may do on their own, what waits for a person, and what is refused. Humans are never gated.</p>
+    </div>
+    <div class="header-actions" *ngIf="enabled">
+      <button class="btn-secondary" (click)="reload()" [disabled]="loading || saving" title="Discard unsaved edits and reload">Reload</button>
+      <button class="btn-primary" (click)="save()" [disabled]="saving || loading" title="Save the policy">
+        {{ saving ? 'Saving…' : 'Save' }}
+      </button>
+    </div>
+  </div>
+
+  <p class="error" *ngIf="error">{{ error }}</p>
+  <p class="success" *ngIf="success">{{ success }}</p>
+
+  <!-- Disabled state -->
+  <div class="disabled-card" *ngIf="status && !enabled">
+    <p class="note-title">Agent policy is off on this server.</p>
+    <p>Agents currently act with the full permissions of the key they hold. To gate agent actions, set <code>USE_AGENT_POLICY=true</code> in your <code>.env</code> and recreate the container:</p>
+    <pre>docker compose up -d --force-recreate datris</pre>
+    <p>Once on, every agent write goes through this policy: run on its own, wait for a person to approve, or be refused. Humans and reads are never affected.</p>
+  </div>
+
+  <ng-container *ngIf="enabled">
+    <!-- Meta strip -->
+    <div class="meta-strip">
+      <span class="meta-item">Version <strong>{{ version }}</strong></span>
+      <span class="meta-item" *ngIf="updatedBy">Updated by <strong>{{ updatedBy }}</strong></span>
+      <span class="meta-item" *ngIf="updatedAt">on {{ formatTs(updatedAt) }}</span>
+      <span class="meta-spacer"></span>
+      <button class="pending-link" (click)="openApprovals()" [title]="'Open the Approvals section of the Activity page'">
+        <span class="pending-count" [class.pending-count-zero]="pendingCount === 0">{{ pendingCount }}</span>
+        pending approval{{ pendingCount === 1 ? '' : 's' }} →
+      </button>
+    </div>
+
+    <!-- Action matrix -->
+    <section class="card">
+      <div class="card-header">
+        <div>
+          <h4>Actions</h4>
+          <p class="hint">Anything not set is <strong>Auto</strong>. Sub-actions follow their parent unless set here.</p>
+        </div>
+        <button class="btn-secondary" (click)="useRecommended()" [disabled]="!status?.recommended" title="Load the recommended settings into the matrix — nothing is saved until you click Save">Use recommended</button>
+      </div>
+
+      <div class="legend">
+        <span class="legend-item"><span class="mode-dot mode-auto"></span>Auto — runs immediately</span>
+        <span class="legend-item"><span class="mode-dot mode-approve"></span>Approve — waits for a person</span>
+        <span class="legend-item"><span class="mode-dot mode-deny"></span>Deny — refused</span>
+      </div>
+
+      <div class="matrix">
+        <ng-container *ngFor="let g of groups; trackBy: trackByResource">
+          <div class="matrix-group">{{ g.resource }}</div>
+          <div class="matrix-row" *ngFor="let r of g.rows; trackBy: trackByKey" [class.matrix-row-sub]="r.sub">
+            <div class="matrix-key">
+              <code>{{ r.key }}</code>
+              <span class="inherit-hint" *ngIf="r.sub">
+                inherits {{ r.parentKey }} unless set<ng-container *ngIf="inherits(r)"> · currently {{ inheritedMode(r) }}</ng-container>
+              </span>
+            </div>
+            <div class="segmented" role="radiogroup" [attr.aria-label]="'Mode for ' + r.key">
+              <button *ngFor="let m of modes"
+                      type="button"
+                      class="seg-btn"
+                      [class.seg-active]="modeOf(r.key) === m"
+                      [class.seg-auto]="modeOf(r.key) === m && m === 'auto'"
+                      [class.seg-approve]="modeOf(r.key) === m && m === 'approve'"
+                      [class.seg-deny]="modeOf(r.key) === m && m === 'deny'"
+                      [class.seg-inherited]="r.sub && inherits(r) && m === 'auto'"
+                      role="radio"
+                      [attr.aria-checked]="modeOf(r.key) === m"
+                      (click)="setMode(r.key, m)">
+                {{ m === 'auto' ? 'Auto' : m === 'approve' ? 'Approve' : 'Deny' }}
+              </button>
+            </div>
+          </div>
+        </ng-container>
+        <div class="empty" *ngIf="groups.length === 0 && !loading">No gateable actions reported by the server.</div>
+        <div class="empty" *ngIf="loading">Loading…</div>
+      </div>
+    </section>
+
+    <!-- Overrides -->
+    <section class="card">
+      <div class="card-header">
+        <div>
+          <h4>Per-resource overrides</h4>
+          <p class="hint">Tighten the rule for a single pipeline or tap. An override can only make an action stricter for that resource.</p>
+        </div>
+        <button class="btn-secondary" (click)="addOverride()">Add override</button>
+      </div>
+
+      <div class="empty" *ngIf="overrides.length === 0">No overrides.</div>
+
+      <div class="override" *ngFor="let o of overrides; let i = index; trackBy: trackByIndex">
+        <div class="override-head">
+          <input type="text" class="override-resource" [(ngModel)]="o.resource" name="override-resource-{{ i }}"
+                 placeholder="pipeline:<name> or tap:<name>" spellcheck="false" />
+          <button class="icon-btn" (click)="removeOverride(i)" title="Remove override" aria-label="Remove override">
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+        <div class="override-entry" *ngFor="let e of o.entries; let j = index; trackBy: trackByIndex">
+          <select [(ngModel)]="e.action" name="override-action-{{ i }}-{{ j }}" title="Action">
+            <option value="">— action —</option>
+            <option *ngFor="let k of actionKeys" [value]="k">{{ k }}</option>
+          </select>
+          <select [(ngModel)]="e.mode" name="override-mode-{{ i }}-{{ j }}" title="Mode">
+            <option value="approve">Approve</option>
+            <option value="deny">Deny</option>
+            <option value="auto">Auto</option>
+          </select>
+          <button class="icon-btn" (click)="removeOverrideEntry(o, j)" title="Remove action" aria-label="Remove action" [disabled]="o.entries.length === 1">
+            <mat-icon>remove</mat-icon>
+          </button>
+        </div>
+        <button class="link-btn" (click)="addOverrideEntry(o)">+ add action</button>
+      </div>
+    </section>
+
+    <!-- Limits -->
+    <section class="card">
+      <div class="card-header">
+        <div>
+          <h4>Limits</h4>
+          <p class="hint">Keep the approval queue bounded.</p>
+        </div>
+      </div>
+      <div class="limits">
+        <label class="limit">
+          <span>Pending approval TTL (hours)</span>
+          <input type="number" min="1" [(ngModel)]="pendingTtlHours" name="pendingTtlHours" />
+          <span class="limit-hint">Undecided requests expire after this long.</span>
+        </label>
+        <label class="limit">
+          <span>Max pending per agent</span>
+          <input type="number" min="1" [(ngModel)]="maxPendingPerActor" name="maxPendingPerActor" />
+          <span class="limit-hint">Further gated calls from that agent are refused until some are decided.</span>
+        </label>
+      </div>
+    </section>
+
+    <p class="rules">
+      <span>Agents can never change this policy or decide approvals, whatever key they hold.</span>
+      <span>Reads, queries and searches are never gated.</span>
+    </p>
+
+    <div class="footer-actions">
+      <button class="btn-primary" (click)="save()" [disabled]="saving || loading">{{ saving ? 'Saving…' : 'Save' }}</button>
+    </div>
+  </ng-container>
+</div>

--- a/ui/src/app/configuration/agent-policy/agent-policy.component.ts
+++ b/ui/src/app/configuration/agent-policy/agent-policy.component.ts
@@ -1,0 +1,256 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { AgentPolicy, AgentPolicyService, PolicyMode, PolicyResponse } from './agent-policy.service';
+
+/** One row of the action matrix. Sub-actions ("pipeline:update:dest-types")
+ *  are indented under their two-part parent and inherit its mode unless set. */
+interface ActionRow {
+  key: string;
+  action: string;      // the part after the resource prefix, e.g. "update:dest-types"
+  sub: boolean;        // 3-part key
+  parentKey?: string;  // for sub-actions: the 2-part key it inherits from
+}
+
+interface ResourceGroup {
+  resource: string;
+  rows: ActionRow[];
+}
+
+/** Editable override row. Each holds a resource key plus its own action→mode
+ *  pairs; the form works on this flat shape and folds it back into the
+ *  server's map-of-maps on save. */
+interface OverrideRow {
+  resource: string;
+  entries: { action: string; mode: PolicyMode }[];
+}
+
+/** Admin-only Agent Policy sub-tab inside Configuration.
+ *
+ *  Decides what agents may do on their own, what waits for a person, and what
+ *  is refused. Humans are never gated; reads are never gated; agents can never
+ *  change the policy or decide approvals. */
+@Component({
+    selector: 'app-agent-policy',
+    templateUrl: './agent-policy.component.html',
+    styleUrl: './agent-policy.component.css',
+    standalone: false
+})
+export class AgentPolicyComponent implements OnInit {
+  status: PolicyResponse | null = null;
+  loading = false;
+  saving = false;
+  error = '';
+  success = '';
+
+  readonly modes: PolicyMode[] = ['auto', 'approve', 'deny'];
+
+  groups: ResourceGroup[] = [];
+  /** Working copy of the matrix — only keys set to approve/deny are kept. */
+  actions: Record<string, PolicyMode> = {};
+  overrides: OverrideRow[] = [];
+  pendingTtlHours = 24;
+  maxPendingPerActor = 10;
+
+  /** Saved document metadata, shown after load/save. */
+  version = 0;
+  updatedAt?: string;
+  updatedBy?: string;
+  pendingCount = 0;
+
+  constructor(private svc: AgentPolicyService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  get enabled(): boolean {
+    return !!this.status?.enabled;
+  }
+
+  reload(): void {
+    this.loading = true;
+    this.error = '';
+    this.svc.get().subscribe({
+      next: (s) => {
+        this.status = s;
+        this.loading = false;
+        if (s.enabled) {
+          this.groups = this.buildGroups(s.actions || []);
+          this.applyPolicy(s.policy);
+          this.pendingCount = s.pendingCount || 0;
+        }
+      },
+      error: (err) => {
+        // 404 = feature off on a server that predates the endpoint being
+        // always-on; render the enable-it card instead of an error.
+        if (err?.status === 404) {
+          this.status = { enabled: false } as PolicyResponse;
+        } else {
+          this.error = err?.error?.error || 'Failed to read agent policy';
+        }
+        this.loading = false;
+      }
+    });
+  }
+
+  // ------- matrix -------
+
+  private buildGroups(keys: string[]): ResourceGroup[] {
+    const byResource = new Map<string, ActionRow[]>();
+    const sorted = keys.slice().sort();
+    for (const key of sorted) {
+      const parts = key.split(':');
+      const resource = parts[0] || key;
+      const action = parts.slice(1).join(':');
+      const sub = parts.length >= 3;
+      const row: ActionRow = { key, action, sub };
+      if (sub) row.parentKey = parts.slice(0, 2).join(':');
+      if (!byResource.has(resource)) byResource.set(resource, []);
+      byResource.get(resource)!.push(row);
+    }
+    // Keep sub-actions directly under their parent regardless of sort order.
+    const groups: ResourceGroup[] = [];
+    for (const [resource, rows] of byResource) {
+      const ordered: ActionRow[] = [];
+      const parents = rows.filter(r => !r.sub);
+      const subs = rows.filter(r => r.sub);
+      for (const p of parents) {
+        ordered.push(p);
+        for (const s of subs) if (s.parentKey === p.key) ordered.push(s);
+      }
+      // Orphan sub-actions (no listed parent) go at the end.
+      for (const s of subs) if (!ordered.includes(s)) ordered.push(s);
+      groups.push({ resource, rows: ordered });
+    }
+    return groups;
+  }
+
+  private applyPolicy(p: AgentPolicy | undefined): void {
+    this.actions = { ...(p?.actions || {}) };
+    this.overrides = Object.entries(p?.overrides || {}).map(([resource, m]) => ({
+      resource,
+      entries: Object.entries(m || {}).map(([action, mode]) => ({ action, mode }))
+    }));
+    this.pendingTtlHours = p?.limits?.pendingTtlHours ?? 24;
+    this.maxPendingPerActor = p?.limits?.maxPendingPerActor ?? 10;
+    this.version = p?.version ?? 0;
+    this.updatedAt = p?.updatedAt;
+    this.updatedBy = p?.updatedBy;
+  }
+
+  modeOf(key: string): PolicyMode {
+    return this.actions[key] || 'auto';
+  }
+
+  /** True when a sub-action has no explicit mode — it follows its parent. */
+  inherits(row: ActionRow): boolean {
+    return row.sub && !this.actions[row.key];
+  }
+
+  /** The mode a sub-action effectively runs under when unset. */
+  inheritedMode(row: ActionRow): PolicyMode {
+    return row.parentKey ? this.modeOf(row.parentKey) : 'auto';
+  }
+
+  setMode(key: string, mode: PolicyMode): void {
+    if (mode === 'auto') delete this.actions[key];
+    else this.actions[key] = mode;
+    this.success = '';
+  }
+
+  useRecommended(): void {
+    const rec = this.status?.recommended;
+    if (!rec) return;
+    this.actions = { ...(rec.actions || {}) };
+    this.success = '';
+  }
+
+  // ------- overrides -------
+
+  addOverride(): void {
+    this.overrides.push({ resource: '', entries: [{ action: '', mode: 'approve' }] });
+  }
+
+  removeOverride(i: number): void {
+    this.overrides.splice(i, 1);
+  }
+
+  addOverrideEntry(o: OverrideRow): void {
+    o.entries.push({ action: '', mode: 'approve' });
+  }
+
+  removeOverrideEntry(o: OverrideRow, j: number): void {
+    o.entries.splice(j, 1);
+  }
+
+  /** Action keys offered in the override dropdowns. */
+  get actionKeys(): string[] {
+    return this.status?.actions || [];
+  }
+
+  // ------- save -------
+
+  private collectOverrides(): Record<string, Record<string, PolicyMode>> {
+    const out: Record<string, Record<string, PolicyMode>> = {};
+    for (const o of this.overrides) {
+      const res = (o.resource || '').trim();
+      if (!res) continue;
+      const m: Record<string, PolicyMode> = {};
+      for (const e of o.entries) {
+        const a = (e.action || '').trim();
+        if (a) m[a] = e.mode;
+      }
+      if (Object.keys(m).length) out[res] = m;
+    }
+    return out;
+  }
+
+  save(): void {
+    if (!this.enabled || this.saving) return;
+    this.saving = true;
+    this.error = '';
+    this.success = '';
+    this.svc.save({
+      actions: { ...this.actions },
+      overrides: this.collectOverrides(),
+      limits: {
+        pendingTtlHours: Number(this.pendingTtlHours) || 0,
+        maxPendingPerActor: Number(this.maxPendingPerActor) || 0
+      }
+    }).subscribe({
+      next: (res) => {
+        this.applyPolicy(res.policy);
+        this.success = `Policy saved (version ${this.version}).`;
+        this.saving = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.error || err?.error?.message || 'Failed to save policy';
+        this.saving = false;
+      }
+    });
+  }
+
+  openApprovals(): void {
+    this.router.navigate(['/ops', 'activity'], { fragment: 'approvals' });
+  }
+
+  // ------- display helpers -------
+
+  formatTs(ts?: string): string {
+    if (!ts) return '—';
+    const d = new Date(ts);
+    return isNaN(d.getTime()) ? ts : d.toLocaleString();
+  }
+
+  trackByKey(_i: number, r: ActionRow): string {
+    return r.key;
+  }
+
+  trackByResource(_i: number, g: ResourceGroup): string {
+    return g.resource;
+  }
+
+  trackByIndex(i: number): number {
+    return i;
+  }
+}

--- a/ui/src/app/configuration/agent-policy/agent-policy.service.ts
+++ b/ui/src/app/configuration/agent-policy/agent-policy.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export type PolicyMode = 'auto' | 'approve' | 'deny';
+
+/** Per-resource override: `pipeline:<name>` / `tap:<name>` → action → mode. */
+export type PolicyOverrides = Record<string, Record<string, PolicyMode>>;
+
+export interface PolicyLimits {
+  pendingTtlHours: number;
+  maxPendingPerActor: number;
+}
+
+/** The policy document as stored. Unlisted actions are effectively "auto". */
+export interface AgentPolicy {
+  version: number;
+  actions: Record<string, PolicyMode>;
+  overrides: PolicyOverrides;
+  limits: PolicyLimits;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+export interface PolicyResponse {
+  enabled: boolean;
+  policy: AgentPolicy;
+  recommended: AgentPolicy;
+  /** Every gateable action key, sorted (e.g. "pipeline:create", "tap:run"). */
+  actions: string[];
+  pendingCount: number;
+}
+
+export interface PolicyUpdate {
+  actions: Record<string, PolicyMode>;
+  overrides: PolicyOverrides;
+  limits: PolicyLimits;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AgentPolicyService {
+  constructor(private http: HttpClient) {}
+
+  get(): Observable<PolicyResponse> {
+    return this.http.get<PolicyResponse>('/api/v1/policy');
+  }
+
+  save(update: PolicyUpdate): Observable<{ enabled: boolean; policy: AgentPolicy }> {
+    return this.http.put<{ enabled: boolean; policy: AgentPolicy }>('/api/v1/policy', update);
+  }
+}

--- a/ui/src/app/configuration/configuration.component.html
+++ b/ui/src/app/configuration/configuration.component.html
@@ -23,8 +23,6 @@
     <button class="sub-tab" [class.sub-tab-active]="activeTab === 'agent-policy'"
             *ngIf="canSeeAgentPolicy"
             (click)="activeTab = 'agent-policy'">Agent Policy</button>
-    <button class="sub-tab" [class.sub-tab-active]="activeTab === 'environment'"
-            (click)="activeTab = 'environment'">Environment</button>
   </div>
 
   <app-users *ngIf="activeTab === 'users' && useUserAuth"></app-users>
@@ -34,48 +32,6 @@
   <app-agent-policy *ngIf="activeTab === 'agent-policy' && canSeeAgentPolicy"></app-agent-policy>
   <app-data-sources *ngIf="activeTab === 'data-sources'"></app-data-sources>
   <app-code-repo *ngIf="activeTab === 'code-repo'"></app-code-repo>
-
-  <div class="config-card" *ngIf="!loading && activeTab === 'environment'">
-    <div class="info-grid">
-      <div class="info-row">
-        <span class="info-label">Environment</span>
-        <span class="info-value accent">{{ environment }}</span>
-      </div>
-      <div class="info-row">
-        <span class="info-label">Version</span>
-        <span class="info-value">{{ version }}</span>
-      </div>
-    </div>
-
-    <div class="note-banner" *ngIf="!useTapRunner">
-      <p class="note-title">Taps are running in-process.</p>
-      <p>This server has <code>USE_TAP_RUNNER</code> off, so tap <code>fetch()</code> shares the server network and can reach internal DB, object storage, and Vault. Docker Compose defaults to isolated taps. Keep <code>USE_TAP_RUNNER=false</code> only for sbt/IDE without the sidecar.</p>
-    </div>
-
-    <div class="status-block" *ngIf="multiTenant">
-      <div class="status-block-row">
-        <span class="status-label">AI Provider</span>
-        <span class="status-value" *ngIf="usingDefaultAiPrimary">Datris-managed (default)</span>
-        <span class="status-value accent" *ngIf="!usingDefaultAiPrimary">Your own {{ aiPrimaryProvider === 'anthropic' ? 'Anthropic' : (aiPrimaryProvider === 'ollama' ? 'Ollama' : (aiPrimaryProvider === 'grok' ? 'Grok (xAI)' : 'OpenAI')) }} key</span>
-      </div>
-      <div class="status-block-row">
-        <span class="status-label">CodeGen Provider</span>
-        <span class="status-value" *ngIf="usingDefaultCodegen">Datris-managed (default)</span>
-        <span class="status-value accent" *ngIf="!usingDefaultCodegen">Your own {{ codegenProvider === 'anthropic' ? 'Anthropic' : (codegenProvider === 'ollama' ? 'Ollama' : (codegenProvider === 'grok' ? 'Grok (xAI)' : 'OpenAI')) }} CodeGen key</span>
-      </div>
-      <div class="status-block-row">
-        <span class="status-label">Embedding Provider</span>
-        <span class="status-value" *ngIf="usingDefaultEmbedding">Datris-managed (default)</span>
-        <span class="status-value accent" *ngIf="!usingDefaultEmbedding">Your own {{ embeddingProvider === 'openai' ? 'OpenAI' : (embeddingProvider === 'tei' ? 'bundled' : (embeddingProvider === 'ollama' || embeddingProvider === 'ollama-local' ? 'Ollama' : embeddingProvider)) }} embedding</span>
-      </div>
-    </div>
-
-    <div class="note-banner" *ngIf="isTrial">
-      <p class="note-title">Trial instance — you're running with your own AI keys.</p>
-      <p>Rotate, swap providers, or change models in the AI Providers tab. Embeddings use the bundled <code>bge-m3</code> model and don't need an API key.</p>
-      <p><strong>Want more?</strong> A dedicated Datris instance adds persistent storage, no shared rate limits, a custom domain, every destination (Postgres, MySQL, MongoDB, Qdrant, Weaviate, Milvus, Chroma, pgvector, S3, MinIO), and a production SLA. Visit your <a href="https://datris.ai/dashboard" target="_blank" rel="noopener">datris.ai dashboard</a> to upgrade.</p>
-    </div>
-  </div>
 
   <div class="config-card" *ngIf="!loading && activeTab === 'ai-providers'">
     <div class="config-layout">

--- a/ui/src/app/configuration/configuration.component.html
+++ b/ui/src/app/configuration/configuration.component.html
@@ -20,6 +20,9 @@
     <button class="sub-tab" [class.sub-tab-active]="activeTab === 'audit-log'"
             *ngIf="canSeeAuditLog"
             (click)="activeTab = 'audit-log'">Audit Log</button>
+    <button class="sub-tab" [class.sub-tab-active]="activeTab === 'agent-policy'"
+            *ngIf="canSeeAgentPolicy"
+            (click)="activeTab = 'agent-policy'">Agent Policy</button>
     <button class="sub-tab" [class.sub-tab-active]="activeTab === 'environment'"
             (click)="activeTab = 'environment'">Environment</button>
   </div>
@@ -28,6 +31,7 @@
   <app-secrets *ngIf="activeTab === 'secrets' && canSeeSecrets"></app-secrets>
   <app-keys *ngIf="activeTab === 'keys' && canSeeKeys"></app-keys>
   <app-audit-log *ngIf="activeTab === 'audit-log' && canSeeAuditLog"></app-audit-log>
+  <app-agent-policy *ngIf="activeTab === 'agent-policy' && canSeeAgentPolicy"></app-agent-policy>
   <app-data-sources *ngIf="activeTab === 'data-sources'"></app-data-sources>
   <app-code-repo *ngIf="activeTab === 'code-repo'"></app-code-repo>
 

--- a/ui/src/app/configuration/configuration.component.ts
+++ b/ui/src/app/configuration/configuration.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ModelCatalogService, ModelOption } from '../model-catalog.service';
 import { AuthService } from '../auth.service';
 
-type ConfigTab = 'environment' | 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log' | 'agent-policy';
+type ConfigTab = 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log' | 'agent-policy';
 
 @Component({
     selector: 'app-configuration',
@@ -174,7 +174,7 @@ export class ConfigurationComponent implements OnInit {
     // Honor ?tab=<name> for deep-links (e.g. the redirect from /secrets).
     this.route.queryParamMap.subscribe(p => {
       const t = p.get('tab');
-      if (t === 'environment' || t === 'ai-providers' ||
+      if (t === 'ai-providers' ||
           t === 'users' || t === 'secrets' || t === 'keys' || t === 'data-sources' || t === 'audit-log' ||
           t === 'agent-policy') {
         this.activeTab = t;

--- a/ui/src/app/configuration/configuration.component.ts
+++ b/ui/src/app/configuration/configuration.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ModelCatalogService, ModelOption } from '../model-catalog.service';
 import { AuthService } from '../auth.service';
 
-type ConfigTab = 'environment' | 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log';
+type ConfigTab = 'environment' | 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log' | 'agent-policy';
 
 @Component({
     selector: 'app-configuration',
@@ -164,12 +164,19 @@ export class ConfigurationComponent implements OnInit {
     return !this.isTrial && (!this.useUserAuth || this.isAdmin());
   }
 
+  /** Admin-only like Audit Log. Shown even when USE_AGENT_POLICY is off so
+   *  the tab can explain how to turn it on. */
+  get canSeeAgentPolicy(): boolean {
+    return !this.isTrial && (!this.useUserAuth || this.isAdmin());
+  }
+
   ngOnInit(): void {
     // Honor ?tab=<name> for deep-links (e.g. the redirect from /secrets).
     this.route.queryParamMap.subscribe(p => {
       const t = p.get('tab');
       if (t === 'environment' || t === 'ai-providers' ||
-          t === 'users' || t === 'secrets' || t === 'keys' || t === 'data-sources' || t === 'audit-log') {
+          t === 'users' || t === 'secrets' || t === 'keys' || t === 'data-sources' || t === 'audit-log' ||
+          t === 'agent-policy') {
         this.activeTab = t;
       }
     });
@@ -197,6 +204,9 @@ export class ConfigurationComponent implements OnInit {
           this.activeTab = 'ai-providers';
         }
         if (this.activeTab === 'audit-log' && !this.canSeeAuditLog) {
+          this.activeTab = 'ai-providers';
+        }
+        if (this.activeTab === 'agent-policy' && !this.canSeeAgentPolicy) {
           this.activeTab = 'ai-providers';
         }
         // Load the model catalog before reading secrets so maybeAddExtraModel compares

--- a/ui/src/app/ops-chat/ops-chat-panel.component.css
+++ b/ui/src/app/ops-chat/ops-chat-panel.component.css
@@ -447,3 +447,63 @@
 }
 
 .ops-composer-stop:hover { background: #e25c5c; box-shadow: 0 0 8px rgba(211, 74, 74, 0.3); }
+
+/* Agent-policy outcomes on tool cards */
+.ops-policy-note {
+  margin: 0;
+  padding: 8px 10px;
+  border-top: 1px solid #3a3f4a;
+  font-size: 12px;
+  color: #d0d2d8;
+}
+
+.ops-policy-pending { background: rgba(251, 191, 36, 0.06); }
+.ops-policy-denied { background: rgba(255, 115, 115, 0.06); }
+
+.ops-policy-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ops-policy-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.ops-policy-badge-pending {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.ops-policy-badge-denied {
+  background: rgba(255, 115, 115, 0.15);
+  color: #ff7373;
+  border: 1px solid rgba(255, 115, 115, 0.3);
+}
+
+.ops-policy-open {
+  background: transparent;
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: #fbbf24;
+  cursor: pointer;
+}
+
+.ops-policy-open:hover { background: rgba(251, 191, 36, 0.12); }
+
+.ops-policy-line { margin-top: 4px; }
+.ops-policy-line code { color: #fbbf24; }
+.ops-policy-denied .ops-policy-line { color: #ffb3b3; margin-top: 6px; }
+.ops-policy-id {
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  color: #8a8e96;
+}

--- a/ui/src/app/ops-chat/ops-chat-panel.component.html
+++ b/ui/src/app/ops-chat/ops-chat-panel.component.html
@@ -83,6 +83,25 @@
                   <ng-container *ngIf="seg.status !== 'running'">{{ toolStatusIcon(seg) }}</ng-container>
                 </span>
               </button>
+              <!-- Agent-policy outcomes: the call is queued for a person, or
+                   was refused by policy. Rendered from the tool result JSON. -->
+              <ng-container *ngIf="policyOutcome(seg) as po">
+                <div class="ops-policy-note ops-policy-pending" *ngIf="po.kind === 'pending'">
+                  <div class="ops-policy-head">
+                    <span class="ops-policy-badge ops-policy-badge-pending">Waiting for approval</span>
+                    <button class="ops-policy-open" (click)="openApprovals()">Open Approvals</button>
+                  </div>
+                  <div class="ops-policy-line" *ngIf="po.action">
+                    <code>{{ po.action }}</code><ng-container *ngIf="po.resource"> on <strong>{{ (po.resourceType ? po.resourceType + ' ' : '') + po.resource }}</strong></ng-container>
+                  </div>
+                  <div class="ops-policy-line ops-policy-id" *ngIf="po.approvalId">{{ po.approvalId }}</div>
+                </div>
+                <div class="ops-policy-note ops-policy-denied" *ngIf="po.kind === 'denied'">
+                  <span class="ops-policy-badge ops-policy-badge-denied">Refused by agent policy</span>
+                  <div class="ops-policy-line" *ngIf="po.message">{{ po.message }}</div>
+                </div>
+              </ng-container>
+
               <div class="ops-tool-body" *ngIf="seg.expanded">
                 <div class="ops-tool-body-label">Input</div>
                 <pre class="ops-tool-body-pre">{{ formatJson(seg.input) }}</pre>

--- a/ui/src/app/ops-chat/ops-chat-panel.component.ts
+++ b/ui/src/app/ops-chat/ops-chat-panel.component.ts
@@ -1,6 +1,8 @@
 import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, AfterViewChecked } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { OpsAssistantStateService, ToolCard, AssistantTurn } from './ops-assistant-state.service';
+import { ApprovalsService, PolicyToolOutcome } from '../approvals.service';
 
 interface StarterPrompt {
   label: string;
@@ -37,7 +39,7 @@ export class OpsChatPanelComponent implements OnInit, OnDestroy, AfterViewChecke
   private scrollPending = false;
   private openSub?: Subscription;
 
-  constructor(public state: OpsAssistantStateService) {}
+  constructor(public state: OpsAssistantStateService, private router: Router) {}
 
   ngOnInit(): void {
     const raw = localStorage.getItem(OpsChatPanelComponent.STORAGE_KEY);
@@ -220,6 +222,24 @@ export class OpsChatPanelComponent implements OnInit, OnDestroy, AfterViewChecke
       case 'wait_seconds':           return { icon: '⏳', label: 'Waiting' + (input?.seconds ? ` ${input.seconds}s` : '') };
     }
     return { icon: '▸', label: 'Called ' + name };
+  }
+
+  /** Agent-policy outcome carried in a tool result: the call is queued for a
+   *  person ("pending_approval") or was refused ("policy_denied"). Parsed
+   *  once per result string and memoized — this runs from the template. */
+  private policyOutcomes = new Map<string, PolicyToolOutcome | null>();
+
+  policyOutcome(card: ToolCard): PolicyToolOutcome | null {
+    if (card.status === 'running' || !card.result) return null;
+    const key = card.id + '\u0000' + card.result;
+    if (!this.policyOutcomes.has(key)) {
+      this.policyOutcomes.set(key, ApprovalsService.parseToolOutcome(card.result));
+    }
+    return this.policyOutcomes.get(key) || null;
+  }
+
+  openApprovals(): void {
+    this.router.navigate(['/ops', 'activity'], { fragment: 'approvals' });
   }
 
   toolStatusIcon(card: ToolCard): string {


### PR DESCRIPTION
## What

The boundary between agents being useful and agents being safe, as infrastructure instead of prompt text. An admin decides per action — `tap:delete`, `pipeline:update:dest-types`, `secret:write`, … — whether an agent-initiated request runs on its own (**auto**), is parked for a person to approve (**approve**), or is refused (**deny**). Humans are never gated; they are the approvers.

- **Server**: new `ai.datris.policy` package + `PolicyInterceptor` between the capability check and role enforcement. Policy keys are validated against `CapabilityRoutes`, so a policy can only name actions the capability layer classifies (plus the `pipeline:update:dest-types` sub-action). Pending actions live in `{env}-pending-action` (TTL, duplicate-collapse by request hash). Approval replays the original request through the normal interceptor chain as the approver, with a single-use token; approvals go stale (409) if the target's version moved since queueing. Two rules are code, not policy: agents can never edit the policy or decide approvals.
- **Audit**: `policy/queued`, approval decisions, and the replayed action are linked by `approvalId`; mutating MCP tools take an optional `reason` recorded in the audit log and shown on approval cards.
- **MCP server**: `get_agent_policy`, `list_pending_approvals`, `get_approval`; APPROVAL RULE in the instructions (never re-issue, never claim done).
- **UI**: Configuration → Agent Policy (matrix, recommended template, tighten-only per-resource overrides, limits), Activity → Approvals (cards with request preview, approve/reject, decided history), chat tool cards for `pending_approval` / `policy_denied`. Also removes the Configuration → Environment tab.
- **Flag**: `USE_AGENT_POLICY` (default off). With it on and no rules set, everything is still auto — zero behavior change until an admin sets a rule.

## Testing

- `sbt test`: 329/329 (new: `AgentPolicySpec`, `PolicyRoutesSpec`, `PendingActionSpec`, `PolicyActorSpec`; MCP catalog drift-guarded at 68 tools).
- Live E2E on compose, two waves, 55/55: queue → dedupe → approve → replay executes → reject with note → stale 409 → forged token 403 → deny → hard-rule 403s → audit linkage; assistant-relay gating/attribution, `tap:*` wildcard, sub-action inheritance, per-resource tighten, per-actor queue cap 429, multipart `not_queueable`, expiry (410 + Mongo TTL purge), double-approve 409, replay-failure → `failed`/502.
- MCP-hop smoke through the real MCP server; `ng build` clean.

Docs: `agent-policy.mdx`, configuration reference, api-keys, mcp-server, OpenAPI. Standalone compose regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)