### PR TITLE
Recovery agent: platform-opened incidents with a bounded diagnose→repair→verify loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,15 @@ OPENAI_API_KEY=
 # See https://docs.datris.ai/agent-policy.
 # USE_AGENT_POLICY=false
 
+# Recovery agent. RECOVERY_AGENT_ENABLED=true lets the platform open an
+# incident when a scheduled tap finally fails, a pipeline job errors, a tap
+# goes stale, or a pipeline's volume swings — then diagnose it and, within the
+# limits you set under Configuration → Agent Policy (recovery mode: off /
+# propose / autopilot), repair and verify it. Requires USE_AGENT_POLICY=true.
+# INCIDENT_WEBHOOK_URL (optional) receives a JSON POST on incident events.
+# RECOVERY_AGENT_ENABLED=false
+# INCIDENT_WEBHOOK_URL=
+
 # Hardening (recommended for any internet-reachable deployment):
 # SESSION_COOKIE_SECURE=true marks the login cookie Secure so it is only sent
 #   over HTTPS. Leave unset for local HTTP dev; set true wherever TLS terminates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The MCP tool catalog exists on three hand-maintained surfaces
+      # (mcp-server/server.py, auth/MCPToolRoutes.scala, the UI's MCP tab).
+      # This fails the build when any of them drifts — a missing UI entry
+      # silently hides the tool from the Connect tab (happened in v1.22).
+      - name: MCP tool catalog drift check
+        run: python3 scripts/check-mcp-tool-catalog.py
+
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/datrisserver/src/main/resources/application.yaml
+++ b/datrisserver/src/main/resources/application.yaml
@@ -33,6 +33,7 @@ schedule:
   findJobsToStart: "5000"
   checkDatabaseSourceQueries: "30000"
   checkTapSchedules: "30000"
+  incidentSweep: "300000"  # recovery-agent sweep: resume approvals, stale/volume signals
 tapScriptTimeoutSeconds: "300"
 dateFormat: "yyyy-MM-dd HH:mm:ss z"
 dateTimezone: "America/New_York"
@@ -48,6 +49,15 @@ auditLog:
   retentionDays: 90       # Mongo TTL on entries; 0 = never expire
   logReads: false         # also record query/search/metadata/GET routes (high volume)
   emitLogLine: true       # mirror each entry to logger ai.datris.audit (JSON under the production profile)
+# Recovery agent: the platform opens incidents for final tap failures, failed
+# pipeline jobs, stale scheduled taps and volume anomalies, diagnoses them with
+# the Ops assistant's judgment, and — within the agent policy's recovery mode
+# and limits — repairs and verifies them. Requires useAgentPolicy for its
+# approval flow. Env vars: RECOVERY_AGENT_ENABLED, INCIDENT_WEBHOOK_URL.
+recoveryAgent:
+  enabled: "false"
+  webhookUrl: ""          # optional JSON POST on open / awaiting_approval / resolved / failed
+
 # Agent policy: per-action auto / approve / deny for agent-initiated requests,
 # with a human approval queue (Configuration → Agent Policy, Activity →
 # Approvals). Off by default; with it on and no policy saved, nothing changes

--- a/datrisserver/src/main/scala/ai/datris/ScheduledBatchTasks.scala
+++ b/datrisserver/src/main/scala/ai/datris/ScheduledBatchTasks.scala
@@ -49,6 +49,18 @@ class ScheduledBatchTasks {
         }
     }
 
+    @Scheduled(fixedRateString = "${schedule.incidentSweep:300000}")
+    private def incidentSweep(): Unit = {
+        try {
+            if (isAppInitialized) {
+                ai.datris.incident.IncidentSweep.run()
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("incidentSweep error: " + Throwables.getStackTraceAsString(e))
+        }
+    }
+
     @Scheduled(fixedRateString = "${schedule.checkFileNotifierQueue}")
     private def checkFileNotifierQueue(): Unit = {
         try {

--- a/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
@@ -52,6 +52,13 @@ class StartupRunner extends ApplicationRunner {
     @Value("${server.port:8080}")
     var serverPort: Int = _
 
+    // Recovery agent — autonomous incident loop. Off by default.
+    @Value("${recoveryAgent.enabled:false}")
+    var recoveryAgentEnabled: Boolean = _
+
+    @Value("${recoveryAgent.webhookUrl:}")
+    var incidentWebhookUrl: String = _
+
     @Value("${secrets.apiKeysSecretName:}")
     var apiKeysSecretName: String = _
 
@@ -185,6 +192,16 @@ class StartupRunner extends ApplicationRunner {
             ai.datris.util.TapScriptRunner.warnInProcess("startup")
         initDatrisEnvironment()
         ai.datris.policy.PolicyReplay.port = serverPort
+        if (recoveryAgentEnabled) {
+            if (!useAgentPolicy)
+                logger.warn(
+                    "RECOVERY_AGENT_ENABLED is true but USE_AGENT_POLICY is false — the recovery agent needs the approval queue and will stay dormant until the agent policy is enabled"
+                )
+            else {
+                ai.datris.incident.RecoveryKey.ensure()
+                logger.info("Recovery agent enabled: collection=" + environment + "-incident; mode comes from the agent policy's recovery.mode (off until set)")
+            }
+        }
         if (useAgentPolicy)
             logger.info(
                 "Agent policy enabled: collections=" + environment + "-agent-policy, " + environment + "-pending-action; approvals replay to port " + serverPort
@@ -344,6 +361,9 @@ class StartupRunner extends ApplicationRunner {
             useAgentPolicy = useAgentPolicy,
             agentPolicyTableName = environment + "-agent-policy",
             pendingActionTableName = environment + "-pending-action",
+            recoveryAgentEnabled = recoveryAgentEnabled,
+            incidentTableName = environment + "-incident",
+            incidentWebhookUrl = incidentWebhookUrl,
             auditLogLogReads = auditLogLogReads,
             auditLogEmitLogLine = auditLogEmitLogLine
         )

--- a/datrisserver/src/main/scala/ai/datris/api/ActivityAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/ActivityAPIController.scala
@@ -1,0 +1,45 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.ActivitySignals
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Server-side Activity signals — one definition of failures, stale taps
+  * and volume anomalies shared by the dashboard, the Ops chat context and
+  * the recovery agent (see [[ActivitySignals]]). */
+@RestController
+@RequestMapping(Array("/api/v1/activity"))
+class ActivityAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[ActivityAPIController])
+    private val gson = new Gson()
+
+    @GetMapping(path = Array("/signals"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def signals(@RequestParam(name = "window", required = false) window: String): ResponseEntity[String] = {
+        try {
+            val windowMs = Option(window).map(_.trim.toLowerCase).getOrElse("24h") match {
+                case "24h" | "" => 24L * 3600000L
+                case "7d" => 7L * 86400000L
+                case "30d" => 30L * 86400000L
+                case other =>
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body[String]("{\"error\":\"window must be 24h, 7d or 30d (got " + other.replace("\"", "") + ")\"}")
+            }
+            new ResponseEntity[String](gson.toJson(ActivitySignals.compute(windowMs).toJson), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error computing activity signals: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String]("{\"error\":\"" + Option(e.getMessage).getOrElse("").replace(
+                    "\"",
+                    "'"
+                ) + "\"}")
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/api/IncidentsAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/IncidentsAPIController.scala
@@ -1,0 +1,101 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditLog
+import ai.datris.config.RequiresRole
+import ai.datris.incident.{Incident, IncidentIO}
+import ai.datris.model.DatrisEnvironment
+import ai.datris.policy.PolicyActor
+import com.google.common.base.Throwables
+import com.google.gson.{Gson, JsonArray, JsonObject}
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Read access to the recovery agent's incidents, plus a human-only
+  * abandon. Nothing here opens incidents — the platform does that. */
+@RestController
+@RequestMapping(Array("/api/v1/incidents"))
+class IncidentsAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[IncidentsAPIController])
+    private val gson = new Gson()
+
+    private def enabled: Boolean =
+        DatrisEnvironment.values != null && DatrisEnvironment.values.recoveryAgentEnabled
+
+    @GetMapping(produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def list(
+        @RequestParam(name = "state", required = false) state: String,
+        @RequestParam(name = "limit", required = false) limit: Integer
+    ): ResponseEntity[String] = {
+        try {
+            val out = new JsonObject()
+            out.addProperty("enabled", enabled)
+            val arr = new JsonArray()
+            if (enabled) {
+                val st = Option(state).map(_.trim).filter(_.nonEmpty)
+                if (st.exists(s => s != "open" && !Incident.States.contains(s)))
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String](
+                        errorJson("state must be open or one of " + Incident.States.toSeq.sorted.mkString(", "))
+                    )
+                IncidentIO.list(st, Option(limit).map(_.intValue()).getOrElse(50)).foreach(i => arr.add(i.toPublicJson))
+            }
+            out.add("incidents", arr)
+            new ResponseEntity[String](gson.toJson(out), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error listing incidents: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    @GetMapping(path = Array("/{id}"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def get(@PathVariable("id") id: String): ResponseEntity[String] = {
+        try {
+            if (!enabled) return disabled()
+            IncidentIO.get(id) match {
+                case Some(i) => new ResponseEntity[String](gson.toJson(i.toPublicJson), HttpStatus.OK)
+                case None => ResponseEntity.status(HttpStatus.NOT_FOUND).body[String](errorJson("no incident " + id))
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("Error reading incident: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    /** A person closing an incident by hand: "stop working this". */
+    @PostMapping(path = Array("/{id}/abandon"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    @RequiresRole(Array("admin", "editor"))
+    def abandon(@PathVariable("id") id: String, request: HttpServletRequest): ResponseEntity[String] = {
+        try {
+            if (!enabled) return disabled()
+            if (PolicyActor.isAgent(request))
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body[String](errorJson("agents may not abandon incidents"))
+            val incident = IncidentIO.get(id).getOrElse(return ResponseEntity.status(HttpStatus.NOT_FOUND).body[String](errorJson("no incident " + id)))
+            if (!incident.isOpen)
+                return ResponseEntity.status(HttpStatus.CONFLICT).body[String](errorJson("incident is already " + incident.state))
+            val by = PolicyActor.label(request)
+            IncidentIO.transition(id, Incident.OpenStates, Incident.Abandoned, "outcome" -> ("abandoned by " + by))
+            IncidentIO.appendStep(id, ai.datris.incident.IncidentStep(java.time.Instant.now(), "close", "abandoned by " + by))
+            AuditLog.record(request, "incident", "abandon", "incident", id)
+            val updated = IncidentIO.get(id).getOrElse(incident)
+            new ResponseEntity[String](gson.toJson(updated.toPublicJson), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error abandoning incident: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](errorJson(e.getMessage))
+        }
+    }
+
+    private def disabled(): ResponseEntity[String] =
+        ResponseEntity.status(HttpStatus.NOT_FOUND).body[String]("{\"error\":\"the recovery agent is disabled\",\"enabled\":false}")
+
+    private def errorJson(msg: String): String =
+        "{\"error\":\"" + Option(msg).getOrElse("").replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ") + "\"}"
+}

--- a/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/KeysAPIController.scala
@@ -471,7 +471,10 @@ object KeysAPIController {
         ("policy", Seq("read", "update"), Seq.empty),
         // Approvals: agents read/poll what they queued (owner=self); deciding
         // is a person's job — the interceptor refuses agents even with the cap.
-        ("approval", Seq("read", "decide"), Seq("owner"))
+        ("approval", Seq("read", "decide"), Seq("owner")),
+        // Recovery-agent incidents: read for dashboards/agents; abandon is a
+        // person's call (role-gated; the controller refuses agents).
+        ("incident", Seq("read", "abandon"), Seq.empty)
     )
 
     /** Capability templates the Keys-UI wizard offers as starting points.

--- a/datrisserver/src/main/scala/ai/datris/api/OpsChatAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/OpsChatAPIController.scala
@@ -7,7 +7,8 @@ Copyright (C) 2026 Datris (https://datris.ai)
 
 import com.google.gson.{JsonObject, JsonParser}
 import ai.datris.model.{DatrisEnvironment, DatrisException, TenantContext, UserContext}
-import ai.datris.util.{AgentLoop, APIKeyValidator, MCPClient, SecretsUtil}
+import ai.datris.incident.{Incident, IncidentIO}
+import ai.datris.util.{AgentLoop, APIKeyValidator, MCPClient, OpsAgentPrompt, SecretsUtil}
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation._
@@ -149,15 +150,15 @@ class OpsChatAPIController {
         // and we'd rather the agent fall back to a build tool than refuse a
         // legitimate "create a new tap to retry this with a different
         // approach" ask. Decision recorded in the plan.
-        val toolDefs = reorderToolsOpsFirst(MCPClient.listTools(uiKey))
+        val toolDefs = OpsAgentPrompt.reorderToolsOpsFirst(MCPClient.listTools(uiKey))
 
-        val systemPrompt = buildOpsSystemPrompt(env.environment)
+        val systemPrompt = OpsAgentPrompt.buildOpsSystemPrompt(env.environment)
 
         // Re-inject the dashboard snapshot on every turn as a leading user
         // message. Cheapest possible cadence — ship dumb, optimize if
         // telemetry shows it wastes tokens (decision recorded in the plan).
         val withContext: List[(String, String)] = contextSnapshot match {
-            case Some(ctx) => ("user", renderContextMessage(ctx)) :: userMessages
+            case Some(ctx) => ("user", OpsAgentPrompt.renderContextMessage(ctx, openIncidents())) :: userMessages
             case None => userMessages
         }
 
@@ -195,205 +196,14 @@ class OpsChatAPIController {
         }
     }
 
-    /** Operational tools first, then the rest. This isn't filtering — the
-      * agent can still call build-mode tools when warranted (e.g. operator
-      * legitimately wants a new tap to recover a use case). Just biases the
-      * tool listing the model sees so the *first* tool it considers when
-      * recovering from a failure is the right one. */
-    private def reorderToolsOpsFirst(tools: List[JsonObject]): List[JsonObject] = {
-        val opsToolNames = Set(
-            "run_tap",
-            "get_pipeline_status",
-            "get_job_status",
-            "kill_job",
-            "get_tap_logs",
-            "get_tap",
-            "get_pipeline",
-            "list_taps",
-            "list_pipelines",
-            "list_tap_secrets",
-            "get_tap_secret_fields",
-            "update_tap",
-            "update_secret",
-            "wait_seconds"
-        )
-        val (ops, rest) = tools.partition { t =>
-            val n = Option(t.get("name")).map(_.getAsString).getOrElse("")
-            opsToolNames.contains(n)
+    /** Open incidents for the context message — the platform's own recovery
+      * work the operator should hear about instead of a re-diagnosis. Empty
+      * when the recovery agent is off or incidents can't be read. */
+    private def openIncidents(): List[Incident] =
+        try {
+            if (DatrisEnvironment.values != null && DatrisEnvironment.values.recoveryAgentEnabled) IncidentIO.listOpen()
+            else Nil
+        } catch {
+            case _: Exception => Nil
         }
-        ops ++ rest
-    }
-
-    /** Render the dashboard context snapshot as a compact, human-readable
-      * leading user message. We send it as `user` (not `system`) so the
-      * agent treats it as "what the operator is currently looking at" —
-      * grounding context for the operator's actual question that follows. */
-    private def renderContextMessage(ctx: JsonObject): String = {
-        val sb = new StringBuilder
-        sb.append("(Current Ops dashboard snapshot — what I'm looking at right now)\n\n")
-
-        val window = Option(ctx.get("window")).map(_.getAsString).getOrElse("24h")
-        sb.append("Window: ").append(window).append("\n\n")
-
-        val failing = Option(ctx.getAsJsonArray("failingItems")).map(_.asScala.toList).getOrElse(Nil)
-        if (failing.isEmpty) {
-            sb.append("Failures: none in window.\n\n")
-        } else {
-            sb.append("Failures (").append(failing.size).append("):\n")
-            failing.foreach { el =>
-                val f = el.getAsJsonObject
-                val kind = strOpt(f, "kind").getOrElse("?")
-                val name = strOpt(f, "name").getOrElse("?")
-                val catalog = strOpt(f, "catalog").map(c => " [" + c + "]").getOrElse("")
-                val reason = strOpt(f, "reason").getOrElse("")
-                val time = strOpt(f, "timeIso").getOrElse("")
-                val recovered = boolOpt(f, "recovered").getOrElse(false)
-                val count = intOpt(f, "failureCount").getOrElse(1)
-                val related = strOpt(f, "relatedTapName").map(t => ", upstream tap=" + t).getOrElse("")
-                val token = strOpt(f, "pipelineToken").map(t => ", pipeline_token=" + t).getOrElse("")
-                val recoveredLabel = if (recovered) " [RECOVERED]" else ""
-                sb.append("  - ").append(kind).append(" `").append(name).append("`").append(catalog)
-                    .append(": ").append(reason)
-                    .append(" (").append(count).append("x")
-                    .append(if (time.nonEmpty) ", " + time else "")
-                    .append(related).append(token).append(")").append(recoveredLabel).append("\n")
-            }
-            sb.append("\n")
-        }
-
-        val stale = Option(ctx.getAsJsonArray("staleTaps")).map(_.asScala.toList).getOrElse(Nil)
-        if (stale.nonEmpty) {
-            sb.append("Stale taps (").append(stale.size).append("):\n")
-            stale.foreach { el =>
-                val s = el.getAsJsonObject
-                val name = strOpt(s, "name").getOrElse("?")
-                val cadence = strOpt(s, "cadenceLabel").getOrElse("?")
-                val lastRun = strOpt(s, "lastRunIso").getOrElse("never")
-                sb.append("  - `").append(name).append("` expects ").append(cadence)
-                    .append(", last ran ").append(lastRun).append("\n")
-            }
-            sb.append("\n")
-        }
-
-        val vols = Option(ctx.getAsJsonArray("pipelineVolumes")).map(_.asScala.toList).getOrElse(Nil)
-        if (vols.nonEmpty) {
-            sb.append("Pipeline volume anomalies (top ").append(vols.size)
-                .append(" by |delta| this ").append(window).append(" vs the prior ").append(window).append("):\n")
-            vols.foreach { el =>
-                val v = el.getAsJsonObject
-                val name = strOpt(v, "name").getOrElse("?")
-                val current = intOpt(v, "current").getOrElse(0)
-                val prior = intOpt(v, "prior").getOrElse(0)
-                val delta = if (v.has("deltaPct") && !v.get("deltaPct").isJsonNull) v.get("deltaPct").getAsInt.toString + "%" else "n/a"
-                sb.append("  - `").append(name).append("`: this ").append(window).append("=").append(current)
-                    .append(", prior ").append(window).append("=").append(prior).append(", vs prior=").append(delta).append("\n")
-            }
-            sb.append("\n")
-        }
-
-        sb.append("Use this snapshot to ground your answers. Refer to taps and pipelines by name. ")
-            .append("If the operator asks about \"the failure\" or \"that one,\" pick the most recent unrecovered failure from the list above.")
-        sb.toString
-    }
-
-    private def strOpt(o: JsonObject, key: String): Option[String] =
-        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsString) else None
-
-    private def intOpt(o: JsonObject, key: String): Option[Int] =
-        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsInt) else None
-
-    private def boolOpt(o: JsonObject, key: String): Option[Boolean] =
-        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsBoolean) else None
-
-    private def buildOpsSystemPrompt(tenantEnv: String): String = {
-        val sb = new StringBuilder
-        sb.append("# Datris Ops Assistant\n\n")
-        sb.append("You are the Ops chat assistant for tenant `").append(tenantEnv).append("`. ")
-        sb.append(
-            "The operator is looking at a live Activity dashboard inside the Datris UI — failures, recovered taps, stale taps, per-pipeline volume anomalies. "
-        )
-        sb.append(
-            "When a dashboard snapshot is provided as the leading user message in this conversation, treat it as ground truth for what the operator is looking at *right now*. "
-        )
-        sb.append(
-            "When no snapshot is provided (the operator may be on a sub-tab that doesn't publish one), call `list_taps` and `list_pipelines` if you need to discover state, and answer based on what those tools return.\n\n"
-        )
-
-        sb.append("## Mission\n\n")
-        sb.append(
-            "You are NOT building new pipelines from scratch — there is a separate build-mode Assistant for that. Your job is to help the operator understand and recover the data flows that already exist:\n"
-        )
-        sb.append("- Explain failures in plain English. Cite the actual error and what likely caused it.\n")
-        sb.append("- Recover when asked. Re-run taps, kill stuck jobs, rotate secrets, fix scripts.\n")
-        sb.append(
-            "- Diagnose anomalies. When a pipeline's today-vs-7d-average is sharply off, walk through the likely causes (upstream slowdown, schedule miss, data shape change) and propose the next check.\n"
-        )
-        sb.append(
-            "- Triage stale taps. A tap that hasn't run in 2× its cadence is either upstream-broken or scheduler-broken — figure out which and propose the fix.\n\n"
-        )
-
-        sb.append("## Behavior rules\n\n")
-        sb.append(
-            "- **Act on items by name.** The snapshot above gives you tap and pipeline names. When the operator says \"why did it fail?\" or \"re-run that one,\" pick the most recent unrecovered failure from the snapshot — don't ask the operator to paste a name they can see on screen.\n"
-        )
-        sb.append(
-            "- **Use `pipeline_token` from the snapshot to read root causes.** Each pipeline-kind failure in the snapshot includes a `pipeline_token=<UUID>`. To explain *why* a job failed — including for [RECOVERED] failures whose original error has been superseded by a successful retry in the rollup — call `get_pipeline_status(pipeline_token=<that UUID>)`. The per-job response contains the full event trail, the platform's `error` and `warning` rows, and the AI explanation. Do NOT tell the operator you can't see the original error; the token is in the snapshot, use it.\n"
-        )
-        sb.append(
-            "- **Never act on a [RECOVERED] item without an explicit, item-specific request.** Items marked [RECOVERED] in the snapshot are healthy right now — the platform's own retry already fixed them. Diagnostic questions about a recovered item (\"why did it fail?\", \"what happened?\") get an explanation, NOT a fresh `run_tap`. Only re-run a recovered item if the operator explicitly says \"run it again\" / \"re-run X\" naming that specific item — and even then, push back once (\"the tap looks healthy; want me to run it anyway?\") before acting. The platform's spinner cost is non-trivial and an unrequested re-run is worse than no action.\n"
-        )
-        sb.append(
-            "- **Take side-effecting actions ONLY when the operator's most recent message names the action or unambiguously authorizes it.** `run_tap`, `update_tap`, `update_secret`, `kill_job`, `restore_tap_version`, `restore_pipeline_version`, `delete_*` all side-effect the platform. The trigger phrase has to be something like \"run X\", \"re-run\", \"go ahead\", \"do it\", \"yes\" (in response to a question you just asked) — applied to a specific named target. Vague follow-ups (\"try again\", \"retry\", \"and?\", \"keep going\") refer to **the previous diagnostic step**, not a new action. If the prior turn ended in an error reading data, \"try again\" means retry that read, not \"take an action you never proposed.\" When in doubt, ask one clarifying question (\"do you want me to retry the diagnostic, or actually re-run the tap?\") rather than guessing.\n"
-        )
-        sb.append(
-            "- **Version history is read-only until the operator asks to roll back.** `list_tap_versions`, `get_tap_version`, `diff_tap_versions` (and the pipeline equivalents) are safe diagnostics — use them freely to explain what changed in a tap/pipeline and when. `restore_tap_version` / `restore_pipeline_version` are side-effecting: call them ONLY when the operator explicitly asks to restore/roll back a SPECIFIC named entity to a SPECIFIC version (\"roll tap X back to version 3\"). A restore is append-only — it writes the chosen snapshot as a new latest version, so nothing is lost — but it still changes the live definition, so confirm the target version first if it's at all ambiguous. After a restore, report the new version number and STOP — do NOT chain into `run_tap`; re-running is a separate action that needs its own explicit request.\n"
-        )
-        sb.append(
-            "- **Prefer the recovery path over a redesign — but only when there's something to recover.** When a tap IS currently failing (unrecovered in the snapshot) on a transient cause (rate limit, network blip, missing API quota), the right action is usually `run_tap` again — not rebuilding the tap. Structural failures (API shape changed, credentials revoked, schema mismatch) need a rebuild. If the failure is already [RECOVERED], nothing needs recovering at all.\n"
-        )
-        sb.append(
-            "- **Confirm before destructive actions.** `kill_job`, `delete_tap`, `delete_pipeline`, `update_secret` on an existing secret — restate exactly what you'll do and wait for explicit confirmation. \"Yeah\" or \"do it\" counts; ambiguous answers do not.\n"
-        )
-        sb.append(
-            "- **Don't create new taps or pipelines from a blank slate.** If the operator wants new data ingested, route them to the Assistant tab — that's the build-mode chat. The exception is when an *existing* failed flow needs a near-clone with a small change (e.g. \"build the same thing pointing at the new endpoint\") and the operator has explicitly asked for it.\n"
-        )
-        sb.append(
-            "- **Monitor runs you start.** When you call `run_tap` and it returns a `publisher_token`, poll `get_pipeline_status` with adaptive backoff (5, 10, 20, 30, 60, 60, 60s) until `rollup.allDone`. Don't hand off mid-flight with \"check back in a bit.\" Report the terminal outcome.\n"
-        )
-        sb.append(
-            "- **Errors in `get_pipeline_status` are not run failures.** If the status endpoint itself errors, wait briefly and retry. Only a terminal `error` on the run rollup counts as a failure.\n"
-        )
-        sb.append(
-            "- **Be brief.** This is a side-panel chat with limited width. Short paragraphs, no elaborate restatements of what the operator already knows. One line of polling progress per cycle is enough.\n"
-        )
-        sb.append(
-            "- **Tap secrets are tagged `_type=tap`.** You can read and rotate them but you can only modify secrets the platform owns (the MCP layer enforces this). If a rotation fails with an ownership error, surface that clearly — don't retry.\n\n"
-        )
-
-        sb.append("## Actions that wait for approval\n\n")
-        sb.append(
-            "- **A `pending_approval` result means the action was NOT performed.** The agent policy on this instance may require a person to approve some actions. When a tool returns `status: pending_approval`, say the action is queued (approval `<approvalId>`, under Activity → Approvals on this same page) and never describe it as done; do not re-issue the call. `errorKind: policy_denied` means it is refused for agents here — report that and stop.\n\n"
-        )
-        sb.append("## When the snapshot looks empty\n\n")
-        sb.append(
-            "If the dashboard snapshot has no failures, no stale taps, and no volume anomalies, the platform is healthy. Say so plainly. Offer to spot-check anything the operator names, but don't fabricate problems to solve.\n\n"
-        )
-
-        sb.append("## Don't stall mid-task\n\n")
-        sb.append(
-            "- **If your reply ends by announcing work you have NOT done yet — \"Let me check X\", \"Now I'll Y\", \"Let me look at Z\" — make those tool calls in the SAME turn instead of ending.** Announcing the next step and then stopping forces the user to type \"continue\" to get work they already asked for. The sentence that narrates an action and the tool call that performs it belong in the same turn.\n"
-        )
-        sb.append(
-            "- **End your turn only when** the task is complete, OR you need a decision/approval/confirmation only the user can give, OR you are waiting on input the user must provide. In every other case — including right after you've described your next step — keep going and do it.\n"
-        )
-        sb.append(
-            "- This narrows nothing in the rules above: keep asking, proposing, confirming, and waiting exactly where they tell you to — scope/source choices, a plan to approve, destructive-action confirmation, acting only when explicitly authorized. The point is only this: once the next step is already decided or authorized and you are merely narrating it, perform it instead of ending the turn.\n\n"
-        )
-
-        sb.append("## Finish\n\n")
-        sb.append(
-            "When the action is done — re-run completed, secret rotated, job killed — say so in one or two sentences. The operator can see most of it in the dashboard already; you're the audit trail for what *just happened in this chat*."
-        )
-        sb.toString
-    }
 }

--- a/datrisserver/src/main/scala/ai/datris/api/PolicyAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/PolicyAPIController.scala
@@ -16,6 +16,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
 import org.springframework.web.bind.annotation._
 
+import scala.collection.JavaConverters._
+
 /** The agent policy document: what agents may do on their own, what waits
   * for a person, what is refused. Anyone may read it (agents use it to know
   * what will queue before they act); only an admin — never an agent — may
@@ -62,7 +64,23 @@ class PolicyAPIController {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body[String](errorJson("agents may not change the agent policy"))
             AgentPolicy.fromJson(body) match {
                 case Left(err) => ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String](errorJson(err))
-                case Right(p) =>
+                case Right(parsed) =>
+                    // A client that doesn't know about the recovery settings
+                    // (or the recovery overrides) must not silently reset them
+                    // by omission: merge the stored values in unless the body
+                    // spoke about them explicitly.
+                    val bodyObj = com.google.gson.JsonParser.parseString(body).getAsJsonObject
+                    val bodySetRecovery = bodyObj.has("recovery")
+                    val bodySetRecoveryOverrides =
+                        bodyObj.has("overrides") && bodyObj.get("overrides").isJsonObject &&
+                            bodyObj.getAsJsonObject("overrides").entrySet().asScala.exists(e =>
+                                e.getValue.isJsonObject && e.getValue.getAsJsonObject.has("recovery")
+                            )
+                    val current = PolicyIO.current
+                    val p = parsed.copy(
+                        recovery = if (bodySetRecovery) parsed.recovery else current.recovery,
+                        recoveryOverrides = if (bodySetRecovery || bodySetRecoveryOverrides) parsed.recoveryOverrides else current.recoveryOverrides
+                    )
                     val saved = PolicyIO.write(p, AuditActor.resolve(request).label)
                     logger.info("Agent policy updated to version " + saved.version + " by " + saved.updatedBy.getOrElse("?"))
                     val out = new JsonObject()

--- a/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
@@ -45,6 +45,7 @@ class VersionAPIController {
                 "useApiKeys" -> DatrisEnvironment.values.useApiKeys.toString,
                 "useAuditLog" -> DatrisEnvironment.values.useAuditLog.toString,
                 "useAgentPolicy" -> DatrisEnvironment.values.useAgentPolicy.toString,
+                "recoveryAgentEnabled" -> DatrisEnvironment.values.recoveryAgentEnabled.toString,
                 "postgresDatabase" -> DatrisEnvironment.current.postgresDatabase,
                 "mongodbDatabase" -> mongodbDatabase,
                 "useTapRunner" -> ai.datris.util.TapScriptRunner.useTapRunner.toString

--- a/datrisserver/src/main/scala/ai/datris/audit/AuditActor.scala
+++ b/datrisserver/src/main/scala/ai/datris/audit/AuditActor.scala
@@ -25,6 +25,10 @@ object AuditActor {
       * Agent Monitor's activity buffer while that buffer still holds it. */
     val HeaderAgentSession = "X-Datris-Agent-Session"
 
+    /** Incident id the recovery agent attaches to every call it makes while
+      * working an incident — joins audit entries to the incident record. */
+    val HeaderIncident = "X-Datris-Incident"
+
     /** Free-text intent an agent may attach to a mutating call (the MCP
       * tools' optional `reason` argument). Stored in audit metadata and on
       * pending approvals; never interpreted. */

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -167,7 +167,17 @@ object CapabilityRoutes {
         Route("GET", "/api/v1/approvals", "approval", "read"),
         Route("GET", "/api/v1/approvals/**", "approval", "read"),
         Route("POST", "/api/v1/approvals/*/approve", "approval", "decide"),
-        Route("POST", "/api/v1/approvals/*/reject", "approval", "decide")
+        Route("POST", "/api/v1/approvals/*/reject", "approval", "decide"),
+
+        // Recovery-agent incidents — read for everyone the key allows;
+        // abandoning one is a person's call (role-gated on top).
+        Route("GET", "/api/v1/incidents", "incident", "read"),
+        Route("GET", "/api/v1/incidents/**", "incident", "read"),
+        Route("POST", "/api/v1/incidents/*/abandon", "incident", "abandon"),
+
+        // Server-side Activity signals (failures / stale / volume) — derived
+        // operational metadata.
+        Route("GET", "/api/v1/activity/signals", "metadata", "read")
     )
 
     /** Every `resource:action` pair the table grants — the vocabulary the

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -137,7 +137,11 @@ object MCPToolRoutes {
         // Agent policy / approvals
         "get_agent_policy" -> Mapped("GET", "/api/v1/policy"),
         "list_pending_approvals" -> Mapped("GET", "/api/v1/approvals"),
-        "get_approval" -> Mapped("GET", "/api/v1/approvals/example")
+        "get_approval" -> Mapped("GET", "/api/v1/approvals/example"),
+
+        // Recovery-agent incidents (read-only; the platform opens them)
+        "list_incidents" -> Mapped("GET", "/api/v1/incidents"),
+        "get_incident" -> Mapped("GET", "/api/v1/incidents/example")
     )
 
     val allToolNames: Seq[String] = tools.map(_._1)

--- a/datrisserver/src/main/scala/ai/datris/config/AuditInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/AuditInterceptor.scala
@@ -76,6 +76,13 @@ class AuditInterceptor extends HandlerInterceptor {
                     if (!o.has("reason")) o.addProperty("reason", r.take(500))
                     o
                 }.orElse(withSession)
+                // Incident id from the recovery agent's calls — the audit log is
+                // the incident's ledger, joined on this field.
+                val withIncident = Option(request.getHeader(AuditActor.HeaderIncident)).map(_.trim).filter(_.nonEmpty).map { iid =>
+                    val o = withReason.getOrElse(new JsonObject())
+                    if (!o.has("incidentId")) o.addProperty("incidentId", iid.take(64))
+                    o
+                }.orElse(withReason)
 
                 AuditLog.submit(AuditEntry(
                     ts = Instant.now(),
@@ -89,7 +96,7 @@ class AuditInterceptor extends HandlerInterceptor {
                     durationMs = durationMs,
                     errorMessage = errorMessage,
                     request = Some(AuditLog.requestInfo(request)),
-                    metadata = withReason
+                    metadata = withIncident
                 ))
             }
         } catch {

--- a/datrisserver/src/main/scala/ai/datris/config/PolicyInterceptor.scala
+++ b/datrisserver/src/main/scala/ai/datris/config/PolicyInterceptor.scala
@@ -59,7 +59,20 @@ class PolicyInterceptor extends HandlerInterceptor {
         val resourceType = PolicyRoutes.resourceType(actionKey)
         val resourceName = PolicyGate.resourceName(request)
         val policy = PolicyIO.current
-        policy.decide(actionKey, Some(resourceType), resourceName) match {
+        val matrixMode = policy.decide(actionKey, Some(resourceType), resourceName)
+        // Recovery-agent calls (tagged with an incident id) additionally obey
+        // the recovery mode: `propose` parks EVERY mutation for approval
+        // regardless of the action matrix; `off` refuses them outright — the
+        // runner should not be acting at all. `autopilot` follows the matrix.
+        val incidentTagged = Option(request.getHeader(AuditActor.HeaderIncident)).exists(_.trim.nonEmpty)
+        val effectiveMode =
+            if (!incidentTagged) matrixMode
+            else policy.effectiveRecoveryMode(resourceType, resourceName.getOrElse("")) match {
+                case ai.datris.policy.RecoverySettings.Off => PolicyMode.Deny
+                case ai.datris.policy.RecoverySettings.Propose => PolicyMode.stricter(matrixMode, PolicyMode.Approve)
+                case _ => matrixMode
+            }
+        effectiveMode match {
             case PolicyMode.Auto => true
             case PolicyMode.Deny => deny(request, response, actionKey, "denied by agent policy", hardRule = false)
             case PolicyMode.Approve => queue(request, response, policy, actionKey, resourceType, resourceName)
@@ -144,6 +157,7 @@ class PolicyInterceptor extends HandlerInterceptor {
                     actor = actor,
                     reason = reasonOf(request),
                     agentSession = Option(request.getHeader(AuditActor.HeaderAgentSession)).map(_.trim).filter(_.nonEmpty).map(_.take(64)),
+                    incidentId = Option(request.getHeader(AuditActor.HeaderIncident)).map(_.trim).filter(_.nonEmpty).map(_.take(64)),
                     method = request.getMethod,
                     path = request.getRequestURI,
                     query = query,
@@ -235,6 +249,7 @@ class PolicyInterceptor extends HandlerInterceptor {
         m.addProperty("policyAction", actionKey)
         approvalId.foreach(m.addProperty("approvalId", _))
         reasonOf(request).foreach(m.addProperty("reason", _))
+        Option(request.getHeader(AuditActor.HeaderIncident)).map(_.trim).filter(_.nonEmpty).foreach(i => m.addProperty("incidentId", i.take(64)))
         m
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
@@ -193,6 +193,18 @@ class JobRunner(jobContext: JobContext) extends Runnable {
                     logger.info("AI Fix Suggestion: " + fix.summary)
                     statusUtil.suggestion(fix)
                 }
+                // Recovery agent: a pipeline job ended in error — open an
+                // incident (no-op unless enabled; one per resource; cooldowns
+                // and the recovered-rule apply inside).
+                try {
+                    val trigger = new com.google.gson.JsonObject()
+                    trigger.addProperty("pipelineToken", jobContext.pipelineToken)
+                    trigger.addProperty("error", errorMessage.take(500))
+                    if (fix != null) trigger.addProperty("aiSummary", fix.summary)
+                    ai.datris.incident.IncidentRunner.open(ai.datris.incident.Incident.KindPipelineFailure, "pipeline", jobContext.config.name, trigger)
+                } catch {
+                    case ie: Exception => logger.debug("incident open skipped: " + ie.getMessage)
+                }
                 throw new DatrisException("Pipeline error: " + errorMessage)
         }
     }

--- a/datrisserver/src/main/scala/ai/datris/incident/Incident.scala
+++ b/datrisserver/src/main/scala/ai/datris/incident/Incident.scala
@@ -1,0 +1,164 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import com.google.gson.{JsonArray, JsonObject, JsonParser}
+import org.bson.Document
+
+import java.security.SecureRandom
+import java.time.Instant
+import scala.collection.JavaConverters._
+
+/** One step of an incident's narrative: what phase did what, when, and —
+  * when an action was parked by the agent policy — which approval it waits on. */
+case class IncidentStep(
+    ts: Instant,
+    phase: String, // open | diagnose | propose | gate | execute | verify | close
+    summary: String,
+    detail: Option[String] = None,
+    approvalId: Option[String] = None
+) {
+    def toJson: JsonObject = {
+        val o = new JsonObject()
+        o.addProperty("ts", ts.toString)
+        o.addProperty("phase", phase)
+        o.addProperty("summary", summary)
+        detail.foreach(o.addProperty("detail", _))
+        approvalId.foreach(o.addProperty("approvalId", _))
+        o
+    }
+}
+
+/** A platform-opened operational incident: one failing / stale / anomalous
+  * resource, the recovery agent's diagnosis and actions, and the outcome.
+  * The audit log (joined by `metadata.incidentId`) is the ledger; this is
+  * the narrative. */
+case class Incident(
+    id: String,
+    kind: String, // tap_failure | pipeline_failure | stale | volume
+    resourceType: String, // tap | pipeline
+    resourceName: String,
+    openedAt: Instant,
+    state: String,
+    trigger: JsonObject,
+    steps: List[IncidentStep] = Nil,
+    classification: Option[String] = None, // transient | structural-script | structural-schema | needs-human
+    proposal: Option[JsonObject] = None, // the runner's parsed proposal, verbatim
+    aiCalls: Int = 0,
+    actionsTaken: Int = 0,
+    awaitingApprovalIds: List[String] = Nil,
+    revertToVersion: Option[Int] = None, // resource version to restore if verification fails
+    closedAt: Option[Instant] = None,
+    outcome: Option[String] = None
+) {
+
+    def isOpen: Boolean = Incident.OpenStates.contains(state)
+
+    def toPublicJson: JsonObject = {
+        val o = new JsonObject()
+        o.addProperty("id", id)
+        o.addProperty("kind", kind)
+        o.addProperty("resourceType", resourceType)
+        o.addProperty("resource", resourceName)
+        o.addProperty("openedAt", openedAt.toString)
+        o.addProperty("state", state)
+        o.add("trigger", trigger)
+        val arr = new JsonArray()
+        steps.foreach(s => arr.add(s.toJson))
+        o.add("steps", arr)
+        classification.foreach(o.addProperty("classification", _))
+        proposal.foreach(o.add("proposal", _))
+        o.addProperty("aiCalls", aiCalls)
+        o.addProperty("actionsTaken", actionsTaken)
+        if (awaitingApprovalIds.nonEmpty) {
+            val a = new JsonArray()
+            awaitingApprovalIds.foreach(a.add)
+            o.add("awaitingApprovalIds", a)
+        }
+        closedAt.foreach(c => o.addProperty("closedAt", c.toString))
+        outcome.foreach(o.addProperty("outcome", _))
+        o
+    }
+
+    def toDocument: Document = {
+        val d = Document.parse(toPublicJson.toString)
+        d.put("_id", id)
+        d.remove("id")
+        d.put("openedAtDate", java.util.Date.from(openedAt))
+        closedAt.foreach(c => d.put("closedAtDate", java.util.Date.from(c)))
+        d.put("revertToVersion", revertToVersion.map(v => v: java.lang.Integer).orNull)
+        d
+    }
+}
+
+object Incident {
+    val Open = "open"
+    val Diagnosing = "diagnosing"
+    val Proposed = "proposed"
+    val AwaitingApproval = "awaiting_approval"
+    val Executing = "executing"
+    val Verifying = "verifying"
+    val Resolved = "resolved"
+    val Failed = "failed"
+    val Abandoned = "abandoned"
+
+    val OpenStates: Set[String] = Set(Open, Diagnosing, Proposed, AwaitingApproval, Executing, Verifying)
+    val ClosedStates: Set[String] = Set(Resolved, Failed, Abandoned)
+    val States: Set[String] = OpenStates ++ ClosedStates
+
+    val KindTapFailure = "tap_failure"
+    val KindPipelineFailure = "pipeline_failure"
+    val KindStale = "stale"
+    val KindVolume = "volume"
+
+    private val random = new SecureRandom()
+
+    def newId(): String = {
+        val b = new Array[Byte](6)
+        random.nextBytes(b)
+        "inc_" + b.map("%02x".format(_)).mkString
+    }
+
+    private def opt(d: Document, k: String): Option[String] = Option(d.getString(k)).filter(_.nonEmpty)
+
+    def fromDocument(d: Document): Incident = {
+        def instant(k: String): Option[Instant] =
+            opt(d, k).flatMap(s =>
+                try Some(Instant.parse(s))
+                catch { case _: Exception => None }
+            )
+        val steps = Option(d.get("steps", classOf[java.util.List[Document]])).map(_.asScala.toList).getOrElse(Nil).map { sd =>
+            IncidentStep(
+                ts = Option(sd.getString("ts")).flatMap(s =>
+                    try Some(Instant.parse(s))
+                    catch { case _: Exception => None }
+                ).getOrElse(Instant.EPOCH),
+                phase = Option(sd.getString("phase")).getOrElse("?"),
+                summary = Option(sd.getString("summary")).getOrElse(""),
+                detail = Option(sd.getString("detail")),
+                approvalId = Option(sd.getString("approvalId"))
+            )
+        }
+        Incident(
+            id = d.getString("_id"),
+            kind = Option(d.getString("kind")).getOrElse("?"),
+            resourceType = Option(d.getString("resourceType")).getOrElse("?"),
+            resourceName = Option(d.getString("resource")).getOrElse("?"),
+            openedAt = instant("openedAt").getOrElse(Instant.EPOCH),
+            state = Option(d.getString("state")).getOrElse(Open),
+            trigger = Option(d.get("trigger", classOf[Document])).map(t => JsonParser.parseString(t.toJson).getAsJsonObject).getOrElse(new JsonObject()),
+            steps = steps,
+            classification = opt(d, "classification"),
+            proposal = Option(d.get("proposal", classOf[Document])).map(p => JsonParser.parseString(p.toJson).getAsJsonObject),
+            aiCalls = Option(d.getInteger("aiCalls")).map(_.intValue()).getOrElse(0),
+            actionsTaken = Option(d.getInteger("actionsTaken")).map(_.intValue()).getOrElse(0),
+            awaitingApprovalIds = Option(d.get("awaitingApprovalIds", classOf[java.util.List[String]])).map(_.asScala.toList).getOrElse(Nil),
+            revertToVersion = Option(d.getInteger("revertToVersion")).map(_.intValue()),
+            closedAt = instant("closedAt"),
+            outcome = opt(d, "outcome")
+        )
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/incident/IncidentIO.scala
+++ b/datrisserver/src/main/scala/ai/datris/incident/IncidentIO.scala
@@ -1,0 +1,122 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.{MongoDBUtil, NoSQLDbUtil}
+import com.mongodb.client.model.{Filters, Sorts, Updates}
+import org.bson.Document
+import org.bson.conversions.Bson
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/** Mongo store for incidents: `{env}-incident`. Incidents are few (bounded
+  * by maxOpenIncidents and closed by outcome), so no TTL — they are the
+  * operational history the Ops chat and Activity view read. */
+object IncidentIO {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val indexed = mutable.Set[String]()
+    val MaxListLimit = 200
+
+    private def collection(): com.mongodb.client.MongoCollection[Document] =
+        NoSQLDbUtil match {
+            case m: MongoDBUtil =>
+                val table = DatrisEnvironment.current.incidentTableName
+                val coll = m.collection(table)
+                ensureIndexes(table, coll)
+                coll
+            case _ => throw new IllegalStateException("Incidents require the MongoDB config store")
+        }
+
+    private def ensureIndexes(table: String, coll: com.mongodb.client.MongoCollection[Document]): Unit = synchronized {
+        if (indexed.contains(table)) return
+        try {
+            coll.createIndex(new Document("state", 1))
+            coll.createIndex(new Document("resourceType", 1).append("resource", 1))
+            coll.createIndex(new Document("openedAtDate", -1))
+            indexed += table
+        } catch {
+            case e: Exception => logger.warn("Could not ensure incident indexes on " + table + ": " + e.getMessage)
+        }
+    }
+
+    def insert(i: Incident): Unit = collection().insertOne(i.toDocument)
+
+    def get(id: String): Option[Incident] =
+        Option(collection().find(Filters.eq("_id", id)).first()).map(Incident.fromDocument)
+
+    def openFor(resourceType: String, resourceName: String): Option[Incident] =
+        Option(collection().find(Filters.and(
+            Filters.eq("resourceType", resourceType),
+            Filters.eq("resource", resourceName),
+            Filters.in("state", Incident.OpenStates.toSeq.asJava)
+        )).first()).map(Incident.fromDocument)
+
+    def countOpen(): Long =
+        collection().countDocuments(Filters.in("state", Incident.OpenStates.toSeq.asJava))
+
+    /** Most recent close time for a resource — the cooldown anchor. */
+    def lastClosedAt(resourceType: String, resourceName: String): Option[Instant] =
+        Option(collection().find(Filters.and(
+            Filters.eq("resourceType", resourceType),
+            Filters.eq("resource", resourceName),
+            Filters.in("state", Incident.ClosedStates.toSeq.asJava)
+        )).sort(Sorts.descending("closedAtDate")).first())
+            .map(Incident.fromDocument)
+            .flatMap(_.closedAt)
+
+    def list(state: Option[String], limit: Int): List[Incident] = {
+        val filter: Bson = state match {
+            case Some("open") => Filters.in("state", Incident.OpenStates.toSeq.asJava)
+            case Some(s) => Filters.eq("state", s)
+            case None => new Document()
+        }
+        collection().find(filter)
+            .sort(Sorts.descending("openedAtDate"))
+            .limit(math.max(1, math.min(limit, MaxListLimit)))
+            .asScala.map(Incident.fromDocument).toList
+    }
+
+    def listOpen(): List[Incident] = list(Some("open"), MaxListLimit)
+
+    /** Conditional state transition — only from the expected state. */
+    def transition(id: String, from: Set[String], to: String, sets: (String, Any)*): Boolean = {
+        val base: Seq[Bson] = Seq(Updates.set("state", to)) ++ sets.map { case (k, v) => Updates.set(k, v) }
+        val withClose =
+            if (Incident.ClosedStates.contains(to))
+                base ++ Seq(
+                    Updates.set("closedAt", Instant.now().toString),
+                    Updates.set("closedAtDate", java.util.Date.from(Instant.now()))
+                )
+            else base
+        val r = collection().updateOne(
+            Filters.and(Filters.eq("_id", id), Filters.in("state", from.toSeq.asJava)),
+            Updates.combine(withClose.asJava)
+        )
+        r.getModifiedCount == 1
+    }
+
+    def appendStep(id: String, step: IncidentStep): Unit =
+        collection().updateOne(Filters.eq("_id", id), Updates.push("steps", Document.parse(step.toJson.toString)))
+
+    def set(id: String, sets: (String, Any)*): Unit = {
+        if (sets.isEmpty) return
+        collection().updateOne(Filters.eq("_id", id), Updates.combine(sets.map { case (k, v) => Updates.set(k, v) }.asJava))
+    }
+
+    def incrementCounters(id: String, aiCalls: Int = 0, actions: Int = 0): Unit =
+        collection().updateOne(
+            Filters.eq("_id", id),
+            Updates.combine(
+                Updates.inc("aiCalls", aiCalls),
+                Updates.inc("actionsTaken", actions)
+            )
+        )
+}

--- a/datrisserver/src/main/scala/ai/datris/incident/IncidentRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/incident/IncidentRunner.scala
@@ -1,0 +1,878 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.audit.AuditLog
+import ai.datris.model.{DatrisEnvironment, TapConfig}
+import ai.datris.policy.{PendingAction, PendingActionIO, PolicyIO, RecoverySettings}
+import ai.datris.util._
+import com.google.gson.{Gson, JsonObject, JsonParser}
+import io.micrometer.core.instrument.Metrics
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.Executors
+
+/** The closed recovery loop: observe → diagnose → propose → gate → execute
+  * → verify → record.
+  *
+  * The LLM proposes, the code decides. Diagnosis runs the shared Ops-agent
+  * judgment (OpsAgentPrompt + AgentLoop) headless with READ-ONLY tools and
+  * must end in a JSON proposal; everything after that — which actions are
+  * executable, the policy gate, limits, verification, revert, cooldown —
+  * is deterministic Scala that no prompt can talk past. Every call the
+  * runner makes is authenticated as the `recovery-agent` key and tagged
+  * with the incident id, so the audit log is the incident's ledger. */
+object IncidentRunner {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val gson = new Gson()
+
+    /** Tools the diagnosis phase may call — reads only. A mutation can never
+      * happen during diagnosis because the model never sees the tool. */
+    val DiagnosisTools: Set[String] = Set(
+        "get_tap",
+        "get_tap_logs",
+        "get_tap_state",
+        "get_tap_ledger",
+        "list_taps",
+        "get_pipeline",
+        "list_pipelines",
+        "get_pipeline_status",
+        "get_job_status",
+        "list_tap_versions",
+        "get_tap_version",
+        "diff_tap_versions",
+        "get_agent_policy",
+        "check_service_health",
+        "get_version"
+    )
+
+    /** Actions the runner will execute from a proposal. Anything else —
+      * deletes, schema migrations, secret changes — is recorded but never
+      * run; those need a human. */
+    /** `create_tap` is here because it is the platform's documented path for
+      * replacing a tap's SCRIPT (update_tap deliberately cannot change
+      * scripts); the name-bound filter pins it to the incident's own tap, so
+      * it can never create a new one. */
+    val ExecutableTools: Set[String] = Set("run_tap", "test_tap", "update_tap", "create_tap")
+
+    case class ProposedAction(tool: String, args: JsonObject, purpose: String)
+    case class Proposal(
+        classification: String,
+        summary: String,
+        needsHuman: Boolean,
+        actions: List[ProposedAction],
+        learnNote: Option[String]
+    )
+
+    sealed trait ToolOutcome
+    object ToolOutcome {
+        case class Ok(text: String) extends ToolOutcome
+        case class PendingApproval(approvalId: String) extends ToolOutcome
+        case class Denied(message: String) extends ToolOutcome
+        case class Failed(message: String) extends ToolOutcome
+    }
+
+    /** Seams for IncidentRunnerSpec: the spec fakes both. */
+    trait Diagnoser {
+
+        /** Returns Left(error) or Right(proposal). Also reports how many LLM
+          * iterations were used, via the callback, for the aiCalls budget. */
+        def diagnose(incident: Incident, onAiCall: () => Unit): Either[String, Proposal]
+    }
+    trait ToolExecutor {
+        def call(tool: String, args: JsonObject, incidentId: String): ToolOutcome
+    }
+
+    @volatile var diagnoser: Diagnoser = RealDiagnoser
+    @volatile var executor: ToolExecutor = RealExecutor
+
+    /** Test seam: specs run incidents synchronously. */
+    @volatile var runAsync: Boolean = true
+
+    private lazy val pool = Executors.newFixedThreadPool(
+        2,
+        (r: Runnable) => {
+            val t = new Thread(r, "incident-runner-" + System.nanoTime())
+            t.setDaemon(true)
+            t
+        }
+    )
+
+    def enabled: Boolean = {
+        val v = DatrisEnvironment.values
+        v != null && v.recoveryAgentEnabled && PolicyIO.enabled
+    }
+
+    private[incident] def settings: RecoverySettings =
+        try PolicyIO.current.recovery
+        catch { case _: Exception => RecoverySettings() }
+
+    // ------------------------------------------------------------------
+    // Open
+    // ------------------------------------------------------------------
+
+    /** Open an incident for a signal, applying every guard. Returns the id
+      * when one was opened. Never throws. */
+    def open(kind: String, resourceType: String, resourceName: String, trigger: JsonObject): Option[String] = {
+        try {
+            if (!enabled) return None
+            val mode = PolicyIO.current.effectiveRecoveryMode(resourceType, resourceName)
+            if (mode == RecoverySettings.Off) return None
+
+            // One open incident per resource — a repeat signal is a step, not a new incident.
+            IncidentIO.openFor(resourceType, resourceName) match {
+                case Some(existing) =>
+                    IncidentIO.appendStep(existing.id, IncidentStep(Instant.now(), "open", "signal repeated: " + kind, Some(trigger.toString.take(500))))
+                    return None
+                case None =>
+            }
+
+            // Cooldown after a failed/abandoned attempt so the loop cannot thrash.
+            val cooldownUntil = IncidentIO.lastClosedAt(resourceType, resourceName)
+                .map(_.plus(settings.cooldownHours.toLong, ChronoUnit.HOURS))
+            if (cooldownUntil.exists(_.isAfter(Instant.now()))) {
+                logger.info("incident not opened for " + resourceType + ":" + resourceName + " — in cooldown until " + cooldownUntil.get)
+                return None
+            }
+
+            if (IncidentIO.countOpen() >= settings.maxOpenIncidents) {
+                logger.warn("incident not opened for " + resourceType + ":" + resourceName + " — maxOpenIncidents reached")
+                return None
+            }
+
+            // The [RECOVERED] rule as code: a FAILURE incident is never opened
+            // for a resource whose latest run is healthy — the platform's own
+            // retry already fixed it. Stale and volume signals are exempt: a
+            // stale tap's last run typically succeeded, that's the point.
+            if (kind == Incident.KindTapFailure && resourceType == "tap" && isTapHealthy(resourceName)) return None
+
+            val incident = Incident(
+                id = Incident.newId(),
+                kind = kind,
+                resourceType = resourceType,
+                resourceName = resourceName,
+                openedAt = Instant.now(),
+                state = Incident.Open,
+                trigger = trigger,
+                steps = List(IncidentStep(Instant.now(), "open", kind + " signal on " + resourceType + " " + resourceName))
+            )
+            IncidentIO.insert(incident)
+            AuditLog.system("incident", "open", resourceType, resourceName, metadata = md("incidentId" -> incident.id, "kind" -> kind))
+            Metrics.counter("datris_incidents_opened_total", "kind", kind).increment()
+            webhook("open", incident.id, kind, resourceType, resourceName, None)
+            logger.info("incident " + incident.id + " opened: " + kind + " on " + resourceType + " " + resourceName + " (mode=" + mode + ")")
+            submit(incident.id)
+            Some(incident.id)
+        } catch {
+            case e: Exception =>
+                logger.warn("incident open failed for " + resourceType + ":" + resourceName + ": " + e.getMessage)
+                None
+        }
+    }
+
+    private def submit(id: String): Unit =
+        if (runAsync) { pool.submit(new Runnable { override def run(): Unit = runIncident(id) }); () }
+        else runIncident(id)
+
+    private def isTapHealthy(name: String): Boolean =
+        try {
+            val t = TapConfigIO.read(DatrisEnvironment.current.tapTableName, name)
+            t != null && Option(t.lastRunStatus).map(_.toLowerCase).exists(s => s == "success" || s == "no_records")
+        } catch {
+            case _: Exception => false
+        }
+
+    // ------------------------------------------------------------------
+    // The loop
+    // ------------------------------------------------------------------
+
+    def runIncident(id: String): Unit = {
+        try {
+            val incident = IncidentIO.get(id).getOrElse(return
+            )
+            if (!incident.isOpen) return
+            if (!IncidentIO.transition(id, Set(Incident.Open), Incident.Diagnosing)) return
+
+            val s = settings
+            var aiCalls = 0
+            val onAiCall = () => { aiCalls += 1; IncidentIO.incrementCounters(id, aiCalls = 1) }
+
+            diagnoser.diagnose(incident, onAiCall) match {
+                case Left(err) =>
+                    step(id, "diagnose", "diagnosis failed", Some(err))
+                    close(id, Incident.Failed, "diagnosis failed: " + clip(err))
+                case Right(p) =>
+                    step(id, "diagnose", "classified " + p.classification, Some(p.summary))
+                    val filtered = filterActions(incident, p)
+                    IncidentIO.set(
+                        id,
+                        "classification" -> p.classification,
+                        "proposal" -> org.bson.Document.parse(proposalJson(p, filtered).toString)
+                    )
+                    if (aiCalls > s.maxAiCallsPerIncident) {
+                        close(id, Incident.Abandoned, "AI-call limit exceeded during diagnosis (" + aiCalls + " > " + s.maxAiCallsPerIncident + ")")
+                    } else if (incident.kind == Incident.KindVolume) {
+                        // Diagnosis only in v1: the value is the triage text.
+                        step(id, "close", "volume anomaly triaged — no automatic action taken")
+                        close(id, Incident.Resolved, "triaged: " + p.summary)
+                    } else if (p.needsHuman || filtered.isEmpty) {
+                        IncidentIO.transition(id, Set(Incident.Diagnosing), Incident.AwaitingApproval)
+                        step(id, "propose", "needs a human", Some(p.summary))
+                        webhook("awaiting_approval", id, incident.kind, incident.resourceType, incident.resourceName, Some(p.summary))
+                    } else {
+                        IncidentIO.transition(id, Set(Incident.Diagnosing), Incident.Proposed)
+                        step(id, "propose", filtered.size + " action(s): " + filtered.map(_.tool).mkString(", "), Some(p.summary))
+                        // Remember the version to revert to before any mutation.
+                        if (incident.resourceType == "tap")
+                            currentTapVersion(incident.resourceName).foreach(v => IncidentIO.set(id, "revertToVersion" -> (v: java.lang.Integer)))
+                        IncidentIO.set(id, "nextActionIndex" -> (0: java.lang.Integer))
+                        executeFrom(id, 0)
+                    }
+            }
+        } catch {
+            case e: Exception =>
+                logger.error("incident " + id + " runner error: " + e.getMessage, e)
+                try close(id, Incident.Failed, "runner error: " + clip(e.getMessage))
+                catch { case _: Exception => }
+        }
+    }
+
+    /** Cap and sanitize the proposal: executable tools only, at most
+      * maxActionsPerIncident, stale-kind limited to a single run. */
+    private[incident] def filterActions(incident: Incident, p: Proposal): List[ProposedAction] = {
+        // Executable, and pinned to the incident's own resource: an action
+        // naming any other tap (or none) is dropped, whatever the model said.
+        val executable = p.actions.filter(a =>
+            ExecutableTools.contains(a.tool) &&
+                Option(a.args).exists(o =>
+                    o.has("name") && o.get("name").isJsonPrimitive && o.get("name").getAsString == incident.resourceName
+                )
+        )
+        val kindLimited =
+            if (incident.kind == Incident.KindStale) executable.filter(_.tool == "run_tap").take(1)
+            else executable
+        kindLimited.take(settings.maxActionsPerIncident)
+    }
+
+    /** Execute proposed actions from an index (resumable after approvals). */
+    def executeFrom(id: String, fromIndex: Int): Unit = {
+        val incident = IncidentIO.get(id).getOrElse(return
+        )
+        val actions = parseStoredActions(incident)
+        val s = settings
+        IncidentIO.transition(id, Set(Incident.Proposed, Incident.AwaitingApproval, Incident.Executing), Incident.Executing)
+
+        var i = fromIndex
+        var lastRealRun: Option[String] = None
+        while (i < actions.length) {
+            if (runtimeExceeded(incident)) { close(id, Incident.Abandoned, "runtime limit reached during execution"); return }
+            val a = actions(i)
+            executor.call(a.tool, a.args, id) match {
+                case ToolOutcome.Ok(text) =>
+                    IncidentIO.incrementCounters(id, actions = 1)
+                    step(id, "execute", a.tool + " ok — " + a.purpose, Some(clip(text)))
+                    lastRealRun = if (a.tool == "run_tap") Some(text) else None
+                    i += 1
+                    IncidentIO.set(id, "nextActionIndex" -> (i: java.lang.Integer))
+                case ToolOutcome.PendingApproval(approvalId) =>
+                    IncidentIO.set(id, "awaitingApprovalIds" -> java.util.Arrays.asList(approvalId), "nextActionIndex" -> (i: java.lang.Integer))
+                    IncidentIO.transition(id, Set(Incident.Executing), Incident.AwaitingApproval)
+                    step(id, "gate", a.tool + " queued for approval", Some(a.purpose), approvalId = Some(approvalId))
+                    webhook("awaiting_approval", id, incident.kind, incident.resourceType, incident.resourceName, Some(a.tool + ": " + a.purpose))
+                    return // the sweep resumes when the approval is decided
+                case ToolOutcome.Denied(msg) =>
+                    step(id, "gate", a.tool + " denied by agent policy", Some(clip(msg)))
+                    close(id, Incident.Abandoned, "action denied by agent policy: " + a.tool)
+                    return
+                case ToolOutcome.Failed(msg) =>
+                    step(id, "execute", a.tool + " failed", Some(clip(msg)))
+                    revertIfNeeded(id, incident)
+                    close(id, Incident.Failed, a.tool + " failed: " + clip(msg))
+                    return
+            }
+        }
+        verify(id, lastRealRun)
+    }
+
+    /** Deterministic verification: the resource must prove it is healthy.
+      * For taps: a real run ends healthy, and — when it fed a pipeline — the
+      * rollup completes without error. Failure reverts the definition. */
+    def verify(id: String, priorRealRun: Option[String] = None): Unit = {
+        val incident = IncidentIO.get(id).getOrElse(return
+        )
+        IncidentIO.transition(id, Set(Incident.Executing, Incident.AwaitingApproval, Incident.Proposed), Incident.Verifying)
+        if (incident.resourceType != "tap") {
+            // Pipeline incidents have no executable actions in v1; reaching
+            // verify means diagnosis-only — record and resolve.
+            step(id, "verify", "no automatic verification for " + incident.resourceType + " incidents — closing with the diagnosis")
+            close(id, Incident.Resolved, "diagnosed; see steps")
+            return
+        }
+        val name = incident.resourceName
+
+        // When the last executed action already WAS a successful real run,
+        // judge that run instead of firing another (which would only hit the
+        // tap's duplicate-trigger debounce).
+        priorRealRun match {
+            case Some(text) =>
+                val publisherToken = extractString(text, "publisherToken")
+                val healthy = isTapHealthy(name)
+                val rollupOk = publisherToken.forall(t => pollRollup(id, t, incident))
+                if (healthy && rollupOk) {
+                    step(
+                        id,
+                        "verify",
+                        "verified: the executed real run is healthy" + publisherToken.map(_ => " and the pipeline rollup completed").getOrElse("")
+                    )
+                    close(id, Incident.Resolved, "recovered and verified")
+                } else {
+                    step(id, "verify", "verification failed on the executed run: healthy=" + healthy + ", rollupOk=" + rollupOk, Some(clip(text)))
+                    revertIfNeeded(id, incident)
+                    close(id, Incident.Failed, "verification failed after actions — definition reverted")
+                }
+                return
+            case None =>
+        }
+
+        val args = new JsonObject()
+        args.addProperty("name", name)
+        executor.call("run_tap", args, id) match {
+            case ToolOutcome.PendingApproval(approvalId) =>
+                IncidentIO.set(id, "awaitingApprovalIds" -> java.util.Arrays.asList(approvalId), "nextActionIndex" -> (Int.MaxValue: java.lang.Integer))
+                IncidentIO.transition(id, Set(Incident.Verifying), Incident.AwaitingApproval)
+                step(id, "gate", "verification run queued for approval", approvalId = Some(approvalId))
+            case ToolOutcome.Denied(msg) =>
+                step(id, "verify", "verification run denied by policy", Some(clip(msg)))
+                close(id, Incident.Abandoned, "verification denied by agent policy")
+            case ToolOutcome.Failed(msg) =>
+                step(id, "verify", "verification run failed", Some(clip(msg)))
+                revertIfNeeded(id, incident)
+                close(id, Incident.Failed, "verification run failed: " + clip(msg))
+            case ToolOutcome.Ok(text) =>
+                IncidentIO.incrementCounters(id, actions = 1)
+                val publisherToken = extractString(text, "publisherToken")
+                val healthy = isTapHealthy(name)
+                val rollupOk = publisherToken.forall(t => pollRollup(id, t, incident))
+                if (healthy && rollupOk) {
+                    step(id, "verify", "verified: real run healthy" + publisherToken.map(_ => ", pipeline rollup complete").getOrElse(""))
+                    close(id, Incident.Resolved, "recovered and verified")
+                } else {
+                    step(id, "verify", "verification failed: healthy=" + healthy + ", rollupOk=" + rollupOk, Some(clip(text)))
+                    revertIfNeeded(id, incident)
+                    close(id, Incident.Failed, "verification failed after actions — definition reverted")
+                }
+        }
+    }
+
+    /** Poll the pipeline rollup for a publisher token until done or the
+      * runtime budget runs out. Reads go through the executor so they are
+      * audited under the incident like everything else. */
+    private def pollRollup(id: String, publisherToken: String, incident: Incident): Boolean = {
+        val args = new JsonObject()
+        args.addProperty("publisher_token", publisherToken)
+        var attempts = 0
+        while (attempts < 20) {
+            if (runtimeExceeded(incident)) return false
+            executor.call("get_pipeline_status", args, id) match {
+                case ToolOutcome.Ok(text) =>
+                    val allDone = text.contains("\"allDone\":true") || text.contains("\"allDone\": true")
+                    val isError = text.contains("\"status\":\"error\"") || text.contains("\"status\": \"error\"")
+                    if (allDone) return !isError
+                case _ => return false
+            }
+            attempts += 1
+            try Thread.sleep(15000L)
+            catch { case _: InterruptedException => return false }
+        }
+        false
+    }
+
+    /** Restore the tap definition captured before the first mutation. Direct
+      * server-side restore — the safety net must not itself be gateable. */
+    private def revertIfNeeded(id: String, incident: Incident): Unit = {
+        try {
+            val fresh = IncidentIO.get(id).getOrElse(incident)
+            for (target <- fresh.revertToVersion if incident.resourceType == "tap") {
+                val env = DatrisEnvironment.current
+                val live = TapConfigIO.read(env.tapTableName, incident.resourceName)
+                if (live != null && live.version != target) {
+                    EntityVersionIO.get(env.tapVersionTableName, incident.resourceName, target).foreach { snapshot =>
+                        val snap = gson.fromJson(snapshot.config, classOf[TapConfig])
+                        val restored = snap.copy(
+                            createdAt = live.createdAt,
+                            createdByKeyLabel = live.createdByKeyLabel,
+                            lastRunStatus = live.lastRunStatus,
+                            lastRunTime = live.lastRunTime,
+                            lastRunRecordCount = live.lastRunRecordCount,
+                            lastRunError = live.lastRunError,
+                            lastRunDataType = live.lastRunDataType,
+                            lastRunColumns = live.lastRunColumns,
+                            lastTestRunStatus = live.lastTestRunStatus,
+                            lastTestRunTime = live.lastTestRunTime,
+                            lastTestRunRecordCount = live.lastTestRunRecordCount,
+                            lastTestRunError = live.lastTestRunError,
+                            lastTestRunDataType = live.lastTestRunDataType,
+                            lastTestRunColumns = live.lastTestRunColumns
+                        )
+                        TapConfigIO.writeVersioned(restored, "incident " + id + ": reverted after failed verification", RecoveryKey.Label)
+                        step(id, "execute", "reverted tap to version " + target)
+                        AuditLog.system("incident", "revert", "tap", incident.resourceName, metadata = md("incidentId" -> id, "toVersion" -> target.toString))
+                    }
+                }
+            }
+        } catch {
+            case e: Exception => step(id, "execute", "revert failed", Some(clip(e.getMessage)))
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Resume / timeout (called by the sweep)
+    // ------------------------------------------------------------------
+
+    /** Move incidents forward whose approvals were decided, and abandon
+      * whatever exceeded its limits. */
+    def sweepOpenIncidents(): Unit = {
+        if (!enabled) return
+        IncidentIO.listOpen().foreach { incident =>
+            try {
+                incident.state match {
+                    case Incident.AwaitingApproval if incident.awaitingApprovalIds.nonEmpty =>
+                        val decisions = incident.awaitingApprovalIds.flatMap(PendingActionIO.get)
+                        if (decisions.exists(_.state == PendingAction.Rejected))
+                            close(incident.id, Incident.Abandoned, "approval rejected by " + decisions.flatMap(_.decidedBy).headOption.getOrElse("a person"))
+                        else if (decisions.exists(d => d.state == PendingAction.Expired || d.isExpired()))
+                            close(incident.id, Incident.Abandoned, "approval expired undecided")
+                        else if (decisions.exists(_.state == PendingAction.Failed))
+                            close(incident.id, Incident.Failed, "approved action failed on execution")
+                        else if (decisions.nonEmpty && decisions.forall(_.state == PendingAction.Executed)) {
+                            IncidentIO.set(incident.id, "awaitingApprovalIds" -> java.util.Collections.emptyList[String]())
+                            step(incident.id, "gate", "approval executed — continuing")
+                            val next = storedNextActionIndex(incident)
+                            if (next == Int.MaxValue) {
+                                // the executed approval WAS the verification run
+                                pool.submit(new Runnable { override def run(): Unit = finishVerifyAfterApproval(incident.id) })
+                            } else {
+                                pool.submit(new Runnable { override def run(): Unit = executeFrom(incident.id, next + 1) })
+                            }
+                        }
+                    case Incident.AwaitingApproval =>
+                        // needs-human card with nothing queued: expire with the runtime budget ×8
+                        if (incident.openedAt.plus(settings.maxRuntimeMinutes.toLong * 8, ChronoUnit.MINUTES).isBefore(Instant.now()))
+                            close(incident.id, Incident.Abandoned, "no human decision arrived")
+                    case _ =>
+                        if (runtimeExceeded(incident))
+                            close(incident.id, Incident.Abandoned, "runtime limit reached")
+                }
+            } catch {
+                case e: Exception => logger.warn("incident sweep error on " + incident.id + ": " + e.getMessage)
+            }
+        }
+    }
+
+    private def finishVerifyAfterApproval(id: String): Unit = {
+        val incident = IncidentIO.get(id).getOrElse(return
+        )
+        val healthy = incident.resourceType != "tap" || isTapHealthy(incident.resourceName)
+        if (healthy) {
+            step(id, "verify", "verified after approved run: resource healthy")
+            close(id, Incident.Resolved, "recovered and verified (via approved run)")
+        } else {
+            revertIfNeeded(id, incident)
+            close(id, Incident.Failed, "approved run did not leave the resource healthy — definition reverted")
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private def runtimeExceeded(incident: Incident): Boolean =
+        incident.openedAt.plus(settings.maxRuntimeMinutes.toLong, ChronoUnit.MINUTES).isBefore(Instant.now())
+
+    private def currentTapVersion(name: String): Option[Int] =
+        try Option(TapConfigIO.read(DatrisEnvironment.current.tapTableName, name)).map(_.version)
+        catch { case _: Exception => None }
+
+    private def parseStoredActions(incident: Incident): Vector[ProposedAction] =
+        incident.proposal.map { p =>
+            if (!p.has("actions") || !p.get("actions").isJsonArray) Vector.empty[ProposedAction]
+            else {
+                val it = p.getAsJsonArray("actions").iterator()
+                val buf = Vector.newBuilder[ProposedAction]
+                while (it.hasNext) {
+                    val o = it.next().getAsJsonObject
+                    buf += ProposedAction(
+                        tool = if (o.has("tool")) o.get("tool").getAsString else "",
+                        args = if (o.has("args") && o.get("args").isJsonObject) o.getAsJsonObject("args") else new JsonObject(),
+                        purpose = if (o.has("purpose")) o.get("purpose").getAsString else ""
+                    )
+                }
+                buf.result()
+            }
+        }.getOrElse(Vector.empty)
+
+    private def storedNextActionIndex(incident: Incident): Int = {
+        // nextActionIndex is stored outside the case class; re-read the raw doc.
+        try {
+            IncidentIO.get(incident.id) // ensure fresh
+            val coll = ai.datris.util.NoSQLDbUtil match {
+                case m: MongoDBUtil => m.collection(DatrisEnvironment.current.incidentTableName)
+                case _ => return 0
+            }
+            Option(coll.find(com.mongodb.client.model.Filters.eq("_id", incident.id)).first())
+                .flatMap(d => Option(d.getInteger("nextActionIndex"))).map(_.intValue()).getOrElse(0)
+        } catch {
+            case _: Exception => 0
+        }
+    }
+
+    private def proposalJson(p: Proposal, filtered: List[ProposedAction]): JsonObject = {
+        val o = new JsonObject()
+        o.addProperty("classification", p.classification)
+        o.addProperty("summary", p.summary)
+        o.addProperty("needsHuman", p.needsHuman)
+        val arr = new com.google.gson.JsonArray()
+        filtered.foreach { a =>
+            val ao = new JsonObject()
+            ao.addProperty("tool", a.tool)
+            ao.add("args", a.args)
+            ao.addProperty("purpose", a.purpose)
+            arr.add(ao)
+        }
+        o.add("actions", arr)
+        p.learnNote.foreach(o.addProperty("learnNote", _))
+        o
+    }
+
+    private def step(id: String, phase: String, summary: String, detail: Option[String] = None, approvalId: Option[String] = None): Unit =
+        IncidentIO.appendStep(id, IncidentStep(Instant.now(), phase, summary, detail, approvalId))
+
+    private def close(id: String, state: String, outcome: String): Unit = {
+        val incident = IncidentIO.get(id)
+        if (IncidentIO.transition(id, Incident.OpenStates, state, "outcome" -> outcome)) {
+            step(id, "close", state + ": " + outcome)
+            incident.foreach { i =>
+                AuditLog.system(
+                    "incident",
+                    "close",
+                    i.resourceType,
+                    i.resourceName,
+                    metadata = md("incidentId" -> id, "state" -> state, "outcome" -> clip(outcome))
+                )
+                Metrics.counter("datris_incidents_total", "kind", i.kind, "outcome", state).increment()
+                Metrics.timer("datris_incident_duration_seconds", "kind", i.kind)
+                    .record(java.time.Duration.between(i.openedAt, Instant.now()))
+                webhook(state, id, i.kind, i.resourceType, i.resourceName, Some(outcome))
+            }
+            logger.info("incident " + id + " closed: " + state + " — " + outcome)
+        }
+    }
+
+    private def webhook(event: String, id: String, kind: String, resourceType: String, resourceName: String, detail: Option[String]): Unit = {
+        val url = Option(DatrisEnvironment.values).flatMap(v => Option(v.incidentWebhookUrl)).map(_.trim).filter(_.nonEmpty).getOrElse(return
+        )
+        try {
+            val o = new JsonObject()
+            o.addProperty("event", event)
+            o.addProperty("incidentId", id)
+            o.addProperty("kind", kind)
+            o.addProperty("resourceType", resourceType)
+            o.addProperty("resource", resourceName)
+            detail.foreach(o.addProperty("detail", _))
+            o.addProperty("ts", Instant.now().toString)
+            HttpUtil.post(url, "application/json", o.toString)
+        } catch {
+            case e: Exception => logger.debug("incident webhook failed: " + e.getMessage)
+        }
+    }
+
+    /** A tool result that reports an error INSIDE its JSON (a failed tap
+      * run's envelope, an API error object) is a failure even when the tool
+      * call itself returned cleanly. */
+    private[incident] def hasErrorField(jsonText: String): Boolean =
+        try {
+            val el = JsonParser.parseString(jsonText)
+            el.isJsonObject && {
+                val o = el.getAsJsonObject
+                o.has("error") && !o.get("error").isJsonNull &&
+                (!o.get("error").isJsonPrimitive || o.get("error").getAsString.trim.nonEmpty)
+            }
+        } catch {
+            case _: Exception => false
+        }
+
+    /** Depth-first search for an object with status=pending_approval and an
+      * approvalId, at any nesting level. */
+    private[incident] def findPendingApproval(jsonText: String): Option[String] = {
+        def walk(el: com.google.gson.JsonElement): Option[String] = {
+            if (el == null) None
+            else if (el.isJsonObject) {
+                val o = el.getAsJsonObject
+                val here =
+                    if (
+                        o.has("status") && o.get("status").isJsonPrimitive && o.get("status").getAsString == "pending_approval" &&
+                        o.has("approvalId") && o.get("approvalId").isJsonPrimitive
+                    )
+                        Some(o.get("approvalId").getAsString)
+                    else None
+                here.orElse {
+                    val it = o.entrySet().iterator()
+                    var found: Option[String] = None
+                    while (found.isEmpty && it.hasNext) found = walk(it.next().getValue)
+                    found
+                }
+            } else if (el.isJsonArray) {
+                val it = el.getAsJsonArray.iterator()
+                var found: Option[String] = None
+                while (found.isEmpty && it.hasNext) found = walk(it.next())
+                found
+            } else None
+        }
+        try walk(JsonParser.parseString(jsonText))
+        catch { case _: Exception => None }
+    }
+
+    private def extractString(jsonText: String, field: String): Option[String] =
+        try {
+            val el = JsonParser.parseString(jsonText)
+            if (el.isJsonObject && el.getAsJsonObject.has(field) && el.getAsJsonObject.get(field).isJsonPrimitive)
+                Some(el.getAsJsonObject.get(field).getAsString).filter(_.nonEmpty)
+            else None
+        } catch {
+            case _: Exception => None
+        }
+
+    /** One direct platform call, through the normal interceptor chain. */
+    private def restCall(method: String, path: String, body: Option[String], apiKey: String, incidentId: String): String = {
+        val url = "http://127.0.0.1:" + ai.datris.policy.PolicyReplay.port + path
+        val req: org.apache.http.client.methods.HttpRequestBase = method match {
+            case "GET" => new org.apache.http.client.methods.HttpGet(url)
+            case _ =>
+                val post = new org.apache.http.client.methods.HttpPost(url)
+                body.foreach { b =>
+                    post.setEntity(new org.apache.http.entity.StringEntity(b, java.nio.charset.StandardCharsets.UTF_8))
+                    post.setHeader("Content-Type", "application/json")
+                }
+                post
+        }
+        if (apiKey != null && apiKey.nonEmpty) req.setHeader("x-api-key", apiKey)
+        req.setHeader(ai.datris.audit.AuditActor.HeaderIncident, incidentId)
+        val config = org.apache.http.client.config.RequestConfig.custom().setConnectTimeout(5000).setSocketTimeout(10 * 60 * 1000).build()
+        val client = org.apache.http.impl.client.HttpClients.custom().setDefaultRequestConfig(config).build()
+        try {
+            val resp = client.execute(req)
+            Option(resp.getEntity).map(e => org.apache.http.util.EntityUtils.toString(e, java.nio.charset.StandardCharsets.UTF_8)).getOrElse("")
+        } finally {
+            try client.close()
+            catch { case _: Exception => }
+        }
+    }
+
+    private def clip(s: String): String = Option(s).getOrElse("").take(500)
+
+    private def md(pairs: (String, String)*): JsonObject = {
+        val o = new JsonObject()
+        pairs.foreach { case (k, v) => o.addProperty(k, v) }
+        o
+    }
+
+    // ------------------------------------------------------------------
+    // Real implementations
+    // ------------------------------------------------------------------
+
+    /** Headless run of the shared Ops-agent judgment: read-only tools, and
+      * the final message must be a JSON proposal. */
+    object RealDiagnoser extends Diagnoser {
+        override def diagnose(incident: Incident, onAiCall: () => Unit): Either[String, Proposal] = {
+            val env = DatrisEnvironment.current
+            val aiConfig = DatrisEnvironment.aiConfigForChat
+            if (aiConfig == null) return Left("AI configuration is not initialized")
+            val key = RecoveryKey.value().orNull
+            val toolDefs = OpsAgentPrompt.reorderToolsOpsFirst(MCPClient.listTools(key))
+                .filter(t => Option(t.get("name")).exists(n => DiagnosisTools.contains(n.getAsString)))
+
+            val system = OpsAgentPrompt.buildOpsSystemPrompt(env.environment) + RecoveryAddendum
+            val userMessage = buildDiagnosisMessage(incident)
+            val finalText = new StringBuilder
+            var error: Option[String] = None
+
+            MCPClient.incidentContext.set(incident.id)
+            try {
+                AgentLoop.run(
+                    aiConfig = aiConfig,
+                    system = system,
+                    userMessages = List(("user", userMessage)),
+                    toolDefs = toolDefs,
+                    apiKey = key,
+                    enableThinking = env.extendedThinking,
+                    maxIterations = settings.maxAiCallsPerIncident,
+                    maxTokensPerCall = 8000,
+                    cancelled = () => false,
+                    sink = {
+                        case AgentLoop.LoopEvent.IterationStart => onAiCall()
+                        case AgentLoop.LoopEvent.TextDelta(t) => finalText.append(t); ()
+                        case AgentLoop.LoopEvent.Error(msg) => error = Some(msg)
+                        case _ => ()
+                    }
+                )
+            } finally {
+                MCPClient.incidentContext.remove()
+            }
+            error match {
+                case Some(e) if finalText.isEmpty => Left(e)
+                case _ => parseProposal(finalText.toString)
+            }
+        }
+
+        private[incident] def parseProposal(text: String): Either[String, Proposal] = {
+            val jsonStr = {
+                val t = text.trim
+                val fenced = """(?s).*```(?:json)?\s*(\{.*?\})\s*```.*""".r
+                t match {
+                    case fenced(inner) => inner
+                    case _ =>
+                        val start = t.indexOf('{')
+                        val end = t.lastIndexOf('}')
+                        if (start >= 0 && end > start) t.substring(start, end + 1) else t
+                }
+            }
+            try {
+                val o = JsonParser.parseString(jsonStr).getAsJsonObject
+                val classification = if (o.has("classification")) o.get("classification").getAsString else "needs-human"
+                val actions =
+                    if (o.has("actions") && o.get("actions").isJsonArray) {
+                        val it = o.getAsJsonArray("actions").iterator()
+                        val buf = List.newBuilder[ProposedAction]
+                        while (it.hasNext) {
+                            val a = it.next().getAsJsonObject
+                            buf += ProposedAction(
+                                tool = if (a.has("tool")) a.get("tool").getAsString else "",
+                                args = if (a.has("args") && a.get("args").isJsonObject) a.getAsJsonObject("args") else new JsonObject(),
+                                purpose = if (a.has("purpose")) a.get("purpose").getAsString else ""
+                            )
+                        }
+                        buf.result()
+                    } else Nil
+                Right(Proposal(
+                    classification = classification,
+                    summary = if (o.has("summary")) o.get("summary").getAsString else "",
+                    needsHuman = (o.has("needsHuman") && o.get("needsHuman").getAsBoolean) || classification == "needs-human",
+                    actions = actions,
+                    learnNote = if (o.has("learnNote") && o.get("learnNote").isJsonPrimitive) Some(o.get("learnNote").getAsString) else None
+                ))
+            } catch {
+                case e: Exception => Left("proposal was not valid JSON: " + e.getMessage + " — text: " + clip(text))
+            }
+        }
+
+        private def buildDiagnosisMessage(incident: Incident): String = {
+            val sb = new StringBuilder
+            sb.append("(Automated incident — you are running headless as the platform's recovery agent; no operator is watching this conversation.)\n\n")
+            sb.append("Incident ").append(incident.id).append(": ").append(incident.kind)
+                .append(" on ").append(incident.resourceType).append(" `").append(incident.resourceName).append("`.\n")
+            sb.append("Trigger: ").append(incident.trigger.toString.take(2000)).append("\n\n")
+            sb.append("Diagnose this incident using the read-only tools available, then END your reply with ONLY a JSON object (no prose after it):\n")
+            sb.append(
+                """{"classification":"transient|structural-script|structural-schema|needs-human","summary":"<one line>","needsHuman":<bool>,"actions":[{"tool":"run_tap|test_tap|update_tap","args":{...},"purpose":"<one line>"}],"learnNote":"<optional source quirk worth remembering>"}"""
+            ).append("\n\n")
+            sb.append("Rules for the proposal:\n")
+            sb.append("- transient (rate limit, network blip, quota): propose at most one run_tap.\n")
+            sb.append("- every action's args MUST include \"name\": \"" + incident.resourceName + "\" — actions naming any other tap are discarded.\n")
+            sb.append(
+                "- structural-script (source shape changed, script bug): propose update_tap with args {\"name\": ..., \"script\": \"<the corrected full script>\"} (the platform replaces the tap's script with it), then test_tap, then run_tap.\n"
+            )
+            sb.append(
+                "- structural-schema (destination/type mismatch) or credentials/upstream outage: needsHuman=true with an empty actions list and a clear summary of what a person must do.\n"
+            )
+            sb.append("- Never propose deletes, secret changes, or schema migrations — they are not executable here.\n")
+            sb.append(
+                "- The platform (not you) executes the actions, gates each one through the agent policy, verifies with a real run, and reverts your script change if verification fails."
+            )
+            sb.toString
+        }
+    }
+
+    private val RecoveryAddendum: String =
+        "\n\n## Recovery-agent mode\n\n" +
+            "This is a HEADLESS diagnosis run: no operator is present, nothing you write is a conversation. " +
+            "Use only the read-only tools provided, keep tool calls few and purposeful, and end with the single JSON proposal object you were asked for. " +
+            "Do not ask questions; when information is missing, classify as needs-human and say what a person should check.\n"
+
+    /** REST-backed executor. Every executable action maps to exactly ONE
+      * platform call, so the policy gate queues exactly that call and an
+      * approval replay performs exactly it — composite MCP tools (which fan
+      * out into several calls) are deliberately not used for execution.
+      * Calls carry the recovery key + incident id like any agent. */
+    object RealExecutor extends ToolExecutor {
+
+        private def restFor(tool: String, args: JsonObject): Option[(String, String, Option[String])] = {
+            def name = if (args != null && args.has("name")) args.get("name").getAsString else ""
+            tool match {
+                case "update_tap" | "create_tap" if args != null && args.has("script") =>
+                    val body = new JsonObject()
+                    body.addProperty("tapName", name)
+                    body.addProperty("script", args.get("script").getAsString)
+                    Some(("POST", "/api/v1/tap/script", Some(body.toString)))
+                case "test_tap" =>
+                    // Same route the MCP tool uses: a run of the STORED script
+                    // in test mode (POST /tap/test would validate the posted
+                    // body's config instead of the stored one).
+                    val body = new JsonObject()
+                    body.addProperty("name", name)
+                    body.addProperty("mode", "test")
+                    Some(("POST", "/api/v1/tap/run", Some(body.toString)))
+                case "run_tap" =>
+                    val body = new JsonObject()
+                    body.addProperty("name", name)
+                    // The endpoint DEFAULTS to mode=test when absent — a real
+                    // run must say so explicitly or verification reads stale.
+                    body.addProperty("mode", "run")
+                    Some(("POST", "/api/v1/tap/run", Some(body.toString)))
+                case "get_pipeline_status" =>
+                    val token = if (args != null && args.has("publisher_token")) args.get("publisher_token").getAsString else ""
+                    Some(("GET", "/api/v1/pipeline/status?withrollup=true&publishertoken=" + java.net.URLEncoder.encode(token, "UTF-8"), None))
+                case _ => None
+            }
+        }
+
+        override def call(tool: String, args: JsonObject, incidentId: String): ToolOutcome = {
+            val key = RecoveryKey.value().orNull
+            MCPClient.incidentContext.set(incidentId)
+            try {
+                val text = restFor(tool, args) match {
+                    case Some((method, path, body)) => restCall(method, path, body, key, incidentId)
+                    case None =>
+                        // A config-only update_tap/create_tap (no script) is not a
+                        // single-call action — refuse rather than fan out.
+                        if (tool == "update_tap" || tool == "create_tap")
+                            return ToolOutcome.Failed("action '" + tool + "' without a script argument is not executable by the runner")
+                        MCPClient.callTool(tool, args, key)
+                }
+                // Composite MCP tools (create_tap and friends) make several
+                // REST calls and can wrap the platform's 202 queue response
+                // inside their own success envelope — so look for a
+                // pending_approval object ANYWHERE in the result tree, not
+                // just at the top level.
+                findPendingApproval(text) match {
+                    case Some(approvalId) => ToolOutcome.PendingApproval(approvalId)
+                    case None =>
+                        if (text.contains("\"errorKind\":\"policy_denied\"")) ToolOutcome.Denied(text)
+                        else if (hasErrorField(text)) ToolOutcome.Failed(text)
+                        else ToolOutcome.Ok(text)
+                }
+            } catch {
+                case e: Exception =>
+                    if (Option(e.getMessage).exists(_.contains("policy_denied"))) ToolOutcome.Denied(e.getMessage)
+                    else ToolOutcome.Failed(Option(e.getMessage).getOrElse(e.getClass.getSimpleName))
+            } finally {
+                MCPClient.incidentContext.remove()
+            }
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/incident/IncidentSweep.scala
+++ b/datrisserver/src/main/scala/ai/datris/incident/IncidentSweep.scala
@@ -1,0 +1,48 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.ActivitySignals
+import com.google.gson.JsonObject
+import org.slf4j.LoggerFactory
+
+/** The recovery agent's heartbeat: opens incidents for signals nothing else
+  * hooks (stale taps, volume anomalies), resumes incidents whose approvals
+  * were decided, and abandons whatever exceeded its limits. Runs on the
+  * platform scheduler; a no-op while the feature is off. */
+object IncidentSweep {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    def run(): Unit = {
+        if (!IncidentRunner.enabled) return
+        try {
+            // 1. Move existing incidents forward first — approvals decided,
+            //    limits exceeded.
+            IncidentRunner.sweepOpenIncidents()
+
+            // 2. Open incidents for sweep-only signals. Failures have their
+            //    own hooks at the point of failure; the sweep covers what
+            //    only shows up by looking: staleness and volume drift.
+            val signals = ActivitySignals.compute()
+            signals.staleTaps.foreach { s =>
+                val trigger = new JsonObject()
+                trigger.addProperty("cadence", s.cadenceLabel)
+                s.lastRunIso.foreach(trigger.addProperty("lastRun", _))
+                IncidentRunner.open(Incident.KindStale, "tap", s.name, trigger)
+            }
+            signals.anomalies.foreach { v =>
+                val trigger = new JsonObject()
+                trigger.addProperty("current", v.current)
+                trigger.addProperty("prior", v.prior)
+                v.deltaPct.foreach(d => trigger.addProperty("deltaPct", d))
+                IncidentRunner.open(Incident.KindVolume, "pipeline", v.name, trigger)
+            }
+        } catch {
+            case e: Exception => logger.warn("incident sweep failed: " + e.getMessage)
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/incident/RecoveryKey.scala
+++ b/datrisserver/src/main/scala/ai/datris/incident/RecoveryKey.scala
@@ -1,0 +1,122 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.DatrisEnvironment
+import ai.datris.util.{APIKeyValidator, SecretsUtil}
+import com.google.gson.{Gson, JsonArray, JsonObject}
+import org.slf4j.LoggerFactory
+
+import java.security.SecureRandom
+import scala.collection.JavaConverters._
+
+/** The recovery agent's own identity: an ordinary labeled API key issued by
+  * the platform at startup when the feature is on. Every action the runner
+  * takes is attributable to this label, scoped by its capability bundle,
+  * policy-gated like any other agent, and revocable — revoke the key and
+  * the runner is dead, independent of any flag.
+  *
+  * Deliberately minimal bundle (open decision #2 in the plan, resolved to
+  * the recommendation): reads, tap run/update, job read, approvals it
+  * queued. No deletes, no secrets, no pipeline definition changes — schema
+  * changes are always proposed to a human via the approval queue. */
+object RecoveryKey {
+
+    val Label = "recovery-agent"
+
+    val Capabilities: Seq[String] = Seq(
+        "tap:read",
+        "tap:run",
+        "tap:update",
+        // The MCP `update_tap` tool writes through the upsert route
+        // (POST /api/v1/tap), which the capability table classifies as
+        // tap:create — without it, script repairs are refused at the gate.
+        "tap:create",
+        "pipeline:read",
+        "job:read",
+        "metadata:read",
+        "query:postgres",
+        "query:mongodb",
+        "query:snowflake",
+        "query:databricks",
+        "query:objectstore",
+        "policy:read",
+        "approval:read:owner=self"
+    )
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val random = new SecureRandom()
+
+    private def apiKeysSecretName: String = DatrisEnvironment.current.environment + "/api-keys"
+    private def metadataSecretName: String = DatrisEnvironment.current.environment + "/api-key-metadata"
+
+    /** Issue the key if it does not exist. No-op when API keys are off (the
+      * runner then calls anonymously, like every other client). Never
+      * rotates or repairs an existing key — an operator who revoked it has
+      * turned the runner off on purpose. */
+    def ensure(): Unit = {
+        val env = DatrisEnvironment.values
+        if (env == null || !env.useApiKeys) return
+        try {
+            val existing = SecretsUtil.getSecretMap(apiKeysSecretName).map(_.asScala.toMap).getOrElse(Map.empty[String, String])
+            if (existing.contains(Label)) return
+
+            val value = randomHex(32)
+            val keyId = "k_" + randomHex(6)
+            val sdf = new java.text.SimpleDateFormat(DatrisEnvironment.current.dateFormat)
+            sdf.setTimeZone(java.util.TimeZone.getTimeZone(DatrisEnvironment.current.dateTimezone))
+            val now = sdf.format(new java.util.Date())
+
+            val keys = new java.util.LinkedHashMap[String, Object]()
+            existing.foreach { case (k, v) => keys.put(k, v) }
+            keys.put(Label, value)
+            SecretsUtil.writeSecret(apiKeysSecretName, keys)
+
+            val meta = new JsonObject()
+            val caps = new JsonArray()
+            Capabilities.foreach(caps.add)
+            meta.add("capabilities", caps)
+            meta.addProperty("createdAt", now)
+            meta.addProperty("createdBy", "system:recovery-agent")
+            meta.addProperty("revoked", false)
+            meta.addProperty("keyId", keyId)
+            val existingMeta = SecretsUtil.getSecretMap(metadataSecretName).map(_.asScala.toMap).getOrElse(Map.empty[String, String])
+            val metaMap = new java.util.LinkedHashMap[String, Object]()
+            existingMeta.foreach { case (k, v) => metaMap.put(k, v) }
+            metaMap.put(Label, new Gson().toJson(meta))
+            SecretsUtil.writeSecret(metadataSecretName, metaMap)
+
+            APIKeyValidator.invalidateCache()
+            ai.datris.audit.AuditLog.system("key", "issue", "key", Label)
+            logger.info("Issued the recovery-agent API key (keyId=" + keyId + ")")
+        } catch {
+            case e: Exception => logger.error("Could not ensure the recovery-agent key: " + e.getMessage)
+        }
+    }
+
+    /** The key's secret value, for the runner's MCP calls. None when keys are
+      * off (call anonymously) or the key is missing/revoked (runner refuses
+      * to act and says why). */
+    def value(): Option[String] = {
+        val env = DatrisEnvironment.values
+        if (env == null || !env.useApiKeys) return None
+        SecretsUtil.getSecretMap(apiKeysSecretName).flatMap(m => Option(m.get(Label))).filter(_.nonEmpty)
+    }
+
+    def isRevoked: Boolean =
+        SecretsUtil.getSecretMap(metadataSecretName).flatMap(m => Option(m.get(Label))).exists { json =>
+            try {
+                val o = com.google.gson.JsonParser.parseString(json).getAsJsonObject
+                o.has("revoked") && !o.get("revoked").isJsonNull && o.get("revoked").getAsBoolean
+            } catch { case _: Exception => false }
+        }
+
+    private def randomHex(bytes: Int): String = {
+        val b = new Array[Byte](bytes)
+        random.nextBytes(b)
+        b.map(x => f"${x & 0xff}%02x").mkString
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/model/DatrisEnvironment.scala
+++ b/datrisserver/src/main/scala/ai/datris/model/DatrisEnvironment.scala
@@ -89,6 +89,7 @@ object DatrisEnvironment {
             auditLogTableName = env + "-audit-log",
             agentPolicyTableName = env + "-agent-policy",
             pendingActionTableName = env + "-pending-action",
+            incidentTableName = env + "-incident",
             postgresDatabase = env
         )
     }
@@ -247,7 +248,13 @@ case class DatrisEnvironment(
     // default; with it on and no policy saved, everything is still `auto`.
     useAgentPolicy: Boolean = false,
     agentPolicyTableName: String = null,
-    pendingActionTableName: String = null
+    pendingActionTableName: String = null,
+    // Recovery agent: platform-opened incidents with an autonomous
+    // diagnose→propose→gate→execute→verify loop (see ai.datris.incident).
+    // Off by default; requires useAgentPolicy for its approval flow.
+    recoveryAgentEnabled: Boolean = false,
+    incidentTableName: String = null,
+    incidentWebhookUrl: String = null
 ) {
 
     /** Append-only definition-version collections. Derived from the live table

--- a/datrisserver/src/main/scala/ai/datris/policy/AgentPolicy.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/AgentPolicy.scala
@@ -26,6 +26,26 @@ object PolicyMode {
 
 case class PolicyLimits(pendingTtlHours: Int = 24, maxPendingPerActor: Int = 50)
 
+/** The recovery agent's dial: off (suggestions only, exactly as before),
+  * propose (open incidents, diagnose, queue every action for approval),
+  * autopilot (actions follow the action matrix). Limits are enforced by the
+  * runner's code, never by its prompt. */
+case class RecoverySettings(
+    mode: String = RecoverySettings.Off,
+    maxAiCallsPerIncident: Int = 12,
+    maxActionsPerIncident: Int = 3,
+    maxRuntimeMinutes: Int = 15,
+    maxOpenIncidents: Int = 10,
+    cooldownHours: Int = 6
+)
+
+object RecoverySettings {
+    val Off = "off"
+    val Propose = "propose"
+    val Autopilot = "autopilot"
+    val Modes: Set[String] = Set(Off, Propose, Autopilot)
+}
+
 /** The agent policy: for every `resource:action[:sub]` key the capability
   * layer already classifies, whether an agent-initiated request runs
   * (`auto`), is parked for a human (`approve`), or is refused (`deny`).
@@ -42,9 +62,18 @@ case class AgentPolicy(
     actions: Map[String, PolicyMode] = Map.empty,
     overrides: Map[String, Map[String, PolicyMode]] = Map.empty,
     limits: PolicyLimits = PolicyLimits(),
+    recovery: RecoverySettings = RecoverySettings(),
+    /** Per-resource recovery mode, keyed `pipeline:<name>` / `tap:<name>` —
+      * the per-resource autopilot toggle. Unlike action overrides this may
+      * move in either direction: one tap on autopilot while the environment
+      * proposes, or one on propose while the environment is on autopilot. */
+    recoveryOverrides: Map[String, String] = Map.empty,
     updatedAt: Option[String] = None,
     updatedBy: Option[String] = None
 ) {
+
+    def effectiveRecoveryMode(resourceType: String, resourceName: String): String =
+        recoveryOverrides.getOrElse(resourceType + ":" + resourceName, recovery.mode)
 
     def isEmpty: Boolean = actions.isEmpty && overrides.isEmpty
 
@@ -67,9 +96,11 @@ case class AgentPolicy(
         actions.toSeq.sortBy(_._1).foreach { case (k, v) => a.addProperty(k, v.name) }
         o.add("actions", a)
         val ov = new JsonObject()
-        overrides.toSeq.sortBy(_._1).foreach { case (res, m) =>
+        val overrideKeys = (overrides.keySet ++ recoveryOverrides.keySet).toSeq.sorted
+        overrideKeys.foreach { res =>
             val inner = new JsonObject()
-            m.toSeq.sortBy(_._1).foreach { case (k, v) => inner.addProperty(k, v.name) }
+            overrides.getOrElse(res, Map.empty).toSeq.sortBy(_._1).foreach { case (k, v) => inner.addProperty(k, v.name) }
+            recoveryOverrides.get(res).foreach(inner.addProperty("recovery", _))
             ov.add(res, inner)
         }
         o.add("overrides", ov)
@@ -77,6 +108,14 @@ case class AgentPolicy(
         l.addProperty("pendingTtlHours", limits.pendingTtlHours)
         l.addProperty("maxPendingPerActor", limits.maxPendingPerActor)
         o.add("limits", l)
+        val r = new JsonObject()
+        r.addProperty("mode", recovery.mode)
+        r.addProperty("maxAiCallsPerIncident", recovery.maxAiCallsPerIncident)
+        r.addProperty("maxActionsPerIncident", recovery.maxActionsPerIncident)
+        r.addProperty("maxRuntimeMinutes", recovery.maxRuntimeMinutes)
+        r.addProperty("maxOpenIncidents", recovery.maxOpenIncidents)
+        r.addProperty("cooldownHours", recovery.cooldownHours)
+        o.add("recovery", r)
         updatedAt.foreach(o.addProperty("updatedAt", _))
         updatedBy.foreach(o.addProperty("updatedBy", _))
         o
@@ -147,6 +186,8 @@ object AgentPolicy {
             else if (!root.get("actions").isJsonObject) { errors += "actions must be an object"; Map.empty[String, PolicyMode] }
             else parseActions(root.getAsJsonObject("actions"), "actions")
 
+        val recoveryOverridesB = scala.collection.mutable.Map.empty[String, String]
+
         val overrides =
             if (!root.has("overrides") || root.get("overrides").isJsonNull) Map.empty[String, Map[String, PolicyMode]]
             else if (!root.get("overrides").isJsonObject) { errors += "overrides must be an object"; Map.empty[String, Map[String, PolicyMode]] }
@@ -158,7 +199,20 @@ object AgentPolicy {
                 } else if (!e.getValue.isJsonObject) {
                     errors += "overrides: value for '" + key + "' must be an object"
                     None
-                } else Some(key -> parseActions(e.getValue.getAsJsonObject, "overrides." + key))
+                } else {
+                    // "recovery" is not an action key: it sets the recovery
+                    // agent's mode for this one resource. Split it out before
+                    // the action-key validation sees it.
+                    val obj = e.getValue.getAsJsonObject.deepCopy()
+                    if (obj.has("recovery")) {
+                        val v = obj.get("recovery")
+                        if (!v.isJsonPrimitive || !RecoverySettings.Modes.contains(v.getAsString.trim.toLowerCase))
+                            errors += "overrides." + key + ": recovery must be off, propose or autopilot"
+                        else recoveryOverridesB += (key -> v.getAsString.trim.toLowerCase)
+                        obj.remove("recovery")
+                    }
+                    Some(key -> parseActions(obj, "overrides." + key))
+                }
             }.toMap
 
         var limits = PolicyLimits()
@@ -180,6 +234,36 @@ object AgentPolicy {
             )
         }
 
+        var recovery = RecoverySettings()
+        if (root.has("recovery") && root.get("recovery").isJsonObject) {
+            val r = root.getAsJsonObject("recovery")
+            def rInt(name: String, default: Int, min: Int, max: Int): Int =
+                if (!r.has(name) || r.get(name).isJsonNull) default
+                else
+                    try {
+                        val v = r.get(name).getAsInt
+                        if (v < min || v > max) { errors += "recovery." + name + " must be between " + min + " and " + max; default }
+                        else v
+                    } catch {
+                        case _: Exception => errors += "recovery." + name + " must be an integer"; default
+                    }
+            val mode =
+                if (!r.has("mode") || r.get("mode").isJsonNull) RecoverySettings.Off
+                else {
+                    val m = r.get("mode").getAsString.trim.toLowerCase
+                    if (!RecoverySettings.Modes.contains(m)) { errors += "recovery.mode must be off, propose or autopilot"; RecoverySettings.Off }
+                    else m
+                }
+            recovery = RecoverySettings(
+                mode = mode,
+                maxAiCallsPerIncident = rInt("maxAiCallsPerIncident", 12, 1, 100),
+                maxActionsPerIncident = rInt("maxActionsPerIncident", 3, 1, 20),
+                maxRuntimeMinutes = rInt("maxRuntimeMinutes", 15, 1, 240),
+                maxOpenIncidents = rInt("maxOpenIncidents", 10, 1, 100),
+                cooldownHours = rInt("cooldownHours", 6, 1, 24 * 14)
+            )
+        }
+
         val version =
             if (root.has("version") && root.get("version").isJsonPrimitive)
                 try root.get("version").getAsInt
@@ -188,6 +272,13 @@ object AgentPolicy {
 
         val errs = errors.result()
         if (errs.nonEmpty) Left(errs.mkString("; "))
-        else Right(AgentPolicy(version = version, actions = actions, overrides = overrides, limits = limits))
+        else Right(AgentPolicy(
+            version = version,
+            actions = actions,
+            overrides = overrides,
+            limits = limits,
+            recovery = recovery,
+            recoveryOverrides = recoveryOverridesB.toMap
+        ))
     }
 }

--- a/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
+++ b/datrisserver/src/main/scala/ai/datris/policy/PendingAction.scala
@@ -32,6 +32,7 @@ case class PendingAction(
     actor: AuditActorInfo,
     reason: Option[String],
     agentSession: Option[String],
+    incidentId: Option[String] = None,
     method: String,
     path: String,
     query: Option[String],
@@ -72,6 +73,7 @@ case class PendingAction(
         o.add("actor", actor.toJson)
         reason.foreach(o.addProperty("reason", _))
         agentSession.foreach(o.addProperty("agentSession", _))
+        incidentId.foreach(o.addProperty("incidentId", _))
         val rq = new JsonObject()
         rq.addProperty("method", method)
         rq.addProperty("path", path)
@@ -101,6 +103,7 @@ case class PendingAction(
         d.put("actor", Document.parse(actor.toJson.toString))
         reason.foreach(d.put("reason", _))
         agentSession.foreach(d.put("agentSession", _))
+        incidentId.foreach(d.put("incidentId", _))
         d.put("method", method)
         d.put("path", path)
         query.foreach(d.put("query", _))
@@ -178,6 +181,7 @@ object PendingAction {
             actor = actor,
             reason = opt(d, "reason"),
             agentSession = opt(d, "agentSession"),
+            incidentId = opt(d, "incidentId"),
             method = d.getString("method"),
             path = d.getString("path"),
             query = opt(d, "query"),

--- a/datrisserver/src/main/scala/ai/datris/util/ActivitySignals.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/ActivitySignals.scala
@@ -1,0 +1,284 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{DatrisEnvironment, PipelineStatusSummaryTable, TapRunLog}
+import com.google.gson.{Gson, JsonArray, JsonObject}
+import org.slf4j.LoggerFactory
+
+/** Server-side computation of the Activity dashboard's operational signals:
+  * failures (with the recovered flag), stale scheduled taps, and pipeline
+  * volume anomalies. One definition shared by the UI (`GET
+  * /api/v1/activity/signals`), the Ops chat context, and the recovery
+  * agent's sweep — ported from the Activity component so the platform can
+  * react to what previously only the browser could see. */
+object ActivitySignals {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val gson = new Gson()
+
+    val DefaultWindowMs: Long = 24L * 3600000L
+    private val MaxRows = 5000
+
+    /** Volume anomaly thresholds: |current vs prior| beyond this with at
+      * least this many prior-window runs to trust the baseline. */
+    val AnomalyDeltaPct: Int = 60
+    val AnomalyMinPriorRuns: Int = 3
+
+    case class FailingItem(
+        kind: String, // tap | pipeline
+        name: String,
+        catalog: Option[String],
+        reason: String,
+        timeIso: Option[String],
+        recovered: Boolean,
+        failureCount: Int,
+        pipelineToken: Option[String],
+        relatedTapName: Option[String]
+    ) {
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("kind", kind)
+            o.addProperty("name", name)
+            catalog.foreach(o.addProperty("catalog", _))
+            o.addProperty("reason", reason)
+            timeIso.foreach(o.addProperty("timeIso", _))
+            o.addProperty("recovered", recovered)
+            o.addProperty("failureCount", failureCount)
+            pipelineToken.foreach(o.addProperty("pipelineToken", _))
+            relatedTapName.foreach(o.addProperty("relatedTapName", _))
+            o
+        }
+    }
+
+    case class StaleTap(name: String, catalog: Option[String], cadenceLabel: String, cadenceMs: Long, lastRunIso: Option[String]) {
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("name", name)
+            catalog.foreach(o.addProperty("catalog", _))
+            o.addProperty("cadenceLabel", cadenceLabel)
+            o.addProperty("cadenceMs", cadenceMs)
+            lastRunIso.foreach(o.addProperty("lastRunIso", _))
+            o
+        }
+    }
+
+    case class PipelineVolume(name: String, catalog: Option[String], current: Long, prior: Long, priorRuns: Int, deltaPct: Option[Int]) {
+        def isAnomaly: Boolean =
+            priorRuns >= AnomalyMinPriorRuns && deltaPct.exists(d => math.abs(d) >= AnomalyDeltaPct)
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("name", name)
+            catalog.foreach(o.addProperty("catalog", _))
+            o.addProperty("current", current)
+            o.addProperty("prior", prior)
+            o.addProperty("priorRuns", priorRuns)
+            deltaPct.foreach(d => o.addProperty("deltaPct", d))
+            o.addProperty("anomaly", isAnomaly)
+            o
+        }
+    }
+
+    case class Signals(
+        windowMs: Long,
+        computedAtMs: Long,
+        failing: List[FailingItem],
+        staleTaps: List[StaleTap],
+        volumes: List[PipelineVolume]
+    ) {
+        def anomalies: List[PipelineVolume] = volumes.filter(_.isAnomaly)
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("windowMs", windowMs)
+            o.addProperty("computedAt", java.time.Instant.ofEpochMilli(computedAtMs).toString)
+            val f = new JsonArray(); failing.foreach(x => f.add(x.toJson)); o.add("failing", f)
+            val s = new JsonArray(); staleTaps.foreach(x => s.add(x.toJson)); o.add("staleTaps", s)
+            val v = new JsonArray(); volumes.foreach(x => v.add(x.toJson)); o.add("volumes", v)
+            val a = new JsonArray(); anomalies.foreach(x => a.add(x.toJson)); o.add("anomalies", a)
+            o
+        }
+    }
+
+    def compute(windowMs: Long = DefaultWindowMs): Signals = {
+        val now = System.currentTimeMillis()
+        val env = DatrisEnvironment.current
+        val taps =
+            try TapConfigIO.readAll(env.tapTableName)
+            catch { case _: Exception => Nil }
+        val tapByName = taps.map(t => t.name -> t).toMap
+
+        // Tap runs since 1× window (failures) — rows are {key, value: TapRunLog}.
+        val tapLogs: List[TapRunLog] =
+            try NoSQLDbUtil.getItemsSinceAsJSON(env.tapLogTableName, "created_at", now - windowMs, MaxRows).flatMap { json =>
+                    try {
+                        val row = com.google.gson.JsonParser.parseString(json).getAsJsonObject
+                        if (row.has("value")) Some(gson.fromJson(row.get("value"), classOf[TapRunLog])) else None
+                    } catch { case _: Exception => None }
+                }
+            catch { case e: Exception => logger.debug("signals: tap log read failed: " + e.getMessage); Nil }
+
+        // Pipeline job summaries since 2× window (current + prior, for volumes).
+        val summaries: List[PipelineStatusSummaryTable] =
+            try NoSQLDbUtil.getItemsSinceAsJSON(env.pipelineStatusTableName + "-summary", "created_at", now - 2 * windowMs, MaxRows).flatMap { json =>
+                    try Some(gson.fromJson(json, classOf[PipelineStatusSummaryTable]))
+                    catch { case _: Exception => None }
+                }
+            catch { case e: Exception => logger.debug("signals: summary read failed: " + e.getMessage); Nil }
+
+        Signals(
+            windowMs = windowMs,
+            computedAtMs = now,
+            failing = computeFailing(now, windowMs, taps.map(t => t.name -> t).toMap, tapLogs, summaries),
+            staleTaps = computeStale(now, taps),
+            volumes = computeVolumes(now, windowMs, summaries)
+        )
+    }
+
+    // ------------------------------------------------------------------
+
+    private def isFailureStatus(s: String): Boolean = {
+        val v = Option(s).getOrElse("").toLowerCase
+        v == "failure" || v == "error" || v == "timed_out"
+    }
+
+    private def computeFailing(
+        now: Long,
+        windowMs: Long,
+        tapByName: Map[String, ai.datris.model.TapConfig],
+        tapLogs: List[TapRunLog],
+        summaries: List[PipelineStatusSummaryTable]
+    ): List[FailingItem] = {
+        val out = List.newBuilder[FailingItem]
+
+        // Tap-side: latest failure per tap in the window; recovered when the
+        // tap's current lastRunStatus is healthy (success or no_records —
+        // an empty incremental poll is a healthy outcome).
+        val tapFailures = tapLogs.filter(l => isFailureStatus(l.status))
+        tapFailures.groupBy(_.tapName).foreach { case (name, logs) =>
+            val latest = logs.maxBy(l => Option(l.runTime).getOrElse(""))
+            val lastStatus = tapByName.get(name).flatMap(t => Option(t.lastRunStatus)).getOrElse("").toLowerCase
+            val recovered = lastStatus == "success" || lastStatus == "no_records"
+            out += FailingItem(
+                kind = "tap",
+                name = name,
+                catalog = tapByName.get(name).flatMap(t => Option(t.catalog)),
+                reason = Option(latest.error).filter(_.nonEmpty).getOrElse("Run failed"),
+                timeIso = Option(latest.runTime),
+                recovered = recovered,
+                failureCount = logs.size,
+                pipelineToken = None,
+                relatedTapName = None
+            )
+        }
+
+        // Pipeline-side: latest errored job per pipeline in the window;
+        // recovered when a newer job for the same pipeline ended healthy.
+        val tapForPipeline: Map[String, String] =
+            tapByName.values.flatMap(t => Option(t.targetPipeline).filter(_.nonEmpty).map(_ -> t.name)).toMap
+        val inWindow = summaries.filter(s => s.created_at != null && s.created_at.longValue() >= now - windowMs)
+        inWindow.groupBy(_.json.pipeline).foreach { case (pipeline, rows) =>
+            if (pipeline != null && pipeline.nonEmpty) {
+                val sorted = rows.sortBy(_.created_at.longValue())
+                val errors = sorted.filter(r => Option(r.json.status).exists(_.equalsIgnoreCase("error")))
+                if (errors.nonEmpty) {
+                    val latestError = errors.last
+                    val recovered = sorted.reverse.headOption.exists(r => !Option(r.json.status).exists(_.equalsIgnoreCase("error")))
+                    out += FailingItem(
+                        kind = "pipeline",
+                        name = pipeline,
+                        catalog = None,
+                        reason = Option(latestError.json.aiSummary).filter(_.nonEmpty).getOrElse("Job ended in error"),
+                        timeIso = Option(latestError.json.endTime).filter(_ != null).orElse(Option(latestError.json.startTime)),
+                        recovered = recovered,
+                        failureCount = errors.size,
+                        pipelineToken = Option(latestError.json.pipelineToken),
+                        relatedTapName = tapForPipeline.get(pipeline)
+                    )
+                }
+            }
+        }
+
+        out.result().sortBy(f => f.timeIso.getOrElse("")).reverse
+    }
+
+    /** Same conservative cadence heuristic the Activity UI uses: only cron
+      * shapes we can classify get a staleness check; everything else is
+      * skipped rather than guessed. */
+    private[datris] def parseCronCadenceMs(cron: String): Option[Long] = {
+        val c = Option(cron).getOrElse("").trim
+        if (c == "0 0 * * * ?") return Some(3600000L)
+        if (c == "0 0 0 * * ?") return Some(86400000L)
+        if (c == "0 0 0 ? * MON-FRI") return Some(86400000L)
+        if (c == "0 0 0 ? * MON") return Some(7L * 86400000L)
+        val everyN = """^0\s+0\s+\*/(\d+)\s+\*\s+\*\s+\?$""".r
+        c match {
+            case everyN(n) => Some(n.toLong * 3600000L)
+            case _ =>
+                val everyNMin = """^0\s+\*/(\d+)\s+\*\s+\*\s+\*\s+\?$""".r
+                c match {
+                    case everyNMin(n) => Some(n.toLong * 60000L)
+                    case _ => None
+                }
+        }
+    }
+
+    private[datris] def cronLabel(cadenceMs: Long): String = {
+        if (cadenceMs == 3600000L) "hourly"
+        else if (cadenceMs == 86400000L) "daily"
+        else if (cadenceMs == 7L * 86400000L) "weekly"
+        else if (cadenceMs < 3600000L) "every " + (cadenceMs / 60000L) + "m"
+        else "every " + math.round(cadenceMs / 3600000.0) + "h"
+    }
+
+    private[datris] def computeStale(
+        now: Long,
+        taps: List[ai.datris.model.TapConfig],
+        dateFormat: String = DatrisEnvironment.current.dateFormat,
+        timezone: String = DatrisEnvironment.current.dateTimezone
+    ): List[StaleTap] = {
+        val sdf = new java.text.SimpleDateFormat(dateFormat)
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone(timezone))
+        def parseMs(s: String): Option[Long] =
+            Option(s).filter(_.nonEmpty).flatMap(v =>
+                try Some(sdf.parse(v).getTime)
+                catch { case _: Exception => None }
+            )
+
+        taps.flatMap { t =>
+            if (!t.enabled || t.cronExpression == null || t.cronExpression.isEmpty) None
+            else parseCronCadenceMs(t.cronExpression).flatMap { cadence =>
+                parseMs(t.lastRunTime).flatMap { lastMs =>
+                    if (now - lastMs > cadence * 2)
+                        Some(StaleTap(t.name, Option(t.catalog), cronLabel(cadence), cadence, Option(t.lastRunTime)))
+                    else None
+                }
+            }
+        }.sortBy(_.lastRunIso.getOrElse(""))
+    }
+
+    private[datris] def computeVolumes(now: Long, windowMs: Long, summaries: List[PipelineStatusSummaryTable]): List[PipelineVolume] = {
+        val winStart = now - windowMs
+        val prevStart = winStart - windowMs
+        summaries
+            .filter(s => s.json != null && s.json.pipeline != null && s.json.pipeline.nonEmpty)
+            .groupBy(_.json.pipeline)
+            .map { case (pipeline, rows) =>
+                var current = 0L
+                var prior = 0L
+                var priorRuns = 0
+                rows.foreach { r =>
+                    val t = r.created_at.longValue()
+                    val records = r.json.recordCount.toLong
+                    if (t >= winStart && t <= now) current += records
+                    else if (t >= prevStart && t < winStart) { prior += records; priorRuns += 1 }
+                }
+                val deltaPct = if (prior > 0) Some(math.round(((current - prior).toDouble / prior) * 100).toInt) else None
+                PipelineVolume(pipeline, None, current, prior, priorRuns, deltaPct)
+            }
+            .toList
+            .sortBy(v => -math.abs(v.deltaPct.getOrElse(0)))
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/MCPClient.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/MCPClient.scala
@@ -35,6 +35,11 @@ import scala.collection.JavaConverters._
   * key resolution works the same as for external clients (Claude Desktop / Cursor).
   */
 object MCPClient {
+
+    /** Incident id attached to every MCP call made on this thread — set by
+      * IncidentRunner around its tool executions, cleared in its finally. */
+    val incidentContext: ThreadLocal[String] = new ThreadLocal[String]()
+
     private val logger: Logger = LoggerFactory.getLogger(getClass)
 
     private val mcpBaseUrl: String = Option(System.getenv("MCP_SERVER_URL"))
@@ -183,6 +188,9 @@ object MCPClient {
         // REST hop and TenantInterceptor attributes the resulting actions to
         // the user (only for the trusted `ui` key — see AuditActor).
         UserContext.get().foreach(u => httpPost.addHeader(AuditActor.HeaderOnBehalfOf, u.username))
+        // Recovery-agent calls carry the incident id so the audit log is the
+        // incident's ledger; the MCP server relays it on the REST hop.
+        Option(MCPClient.incidentContext.get()).filter(_.nonEmpty).foreach(id => httpPost.addHeader(AuditActor.HeaderIncident, id))
         httpPost.setEntity(new StringEntity(body, StandardCharsets.UTF_8))
 
         val response = httpClient.execute(httpPost)

--- a/datrisserver/src/main/scala/ai/datris/util/OpsAgentPrompt.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/OpsAgentPrompt.scala
@@ -1,0 +1,231 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.incident.Incident
+import com.google.gson.JsonObject
+
+import scala.collection.JavaConverters._
+
+/** The Ops assistant's judgment, shared verbatim between the Ops chat and
+  * the recovery agent's headless runs (IncidentRunner) so the two never
+  * drift: same tool ordering, same context rendering, same system prompt. */
+object OpsAgentPrompt {
+
+    /** Operational tools first, then the rest. This isn't filtering — the
+      * agent can still call build-mode tools when warranted (e.g. operator
+      * legitimately wants a new tap to recover a use case). Just biases the
+      * tool listing the model sees so the *first* tool it considers when
+      * recovering from a failure is the right one. */
+    def reorderToolsOpsFirst(tools: List[JsonObject]): List[JsonObject] = {
+        val opsToolNames = Set(
+            "run_tap",
+            "get_pipeline_status",
+            "get_job_status",
+            "kill_job",
+            "get_tap_logs",
+            "get_tap",
+            "get_pipeline",
+            "list_taps",
+            "list_pipelines",
+            "list_tap_secrets",
+            "get_tap_secret_fields",
+            "update_tap",
+            "update_secret",
+            "wait_seconds"
+        )
+        val (ops, rest) = tools.partition { t =>
+            val n = Option(t.get("name")).map(_.getAsString).getOrElse("")
+            opsToolNames.contains(n)
+        }
+        ops ++ rest
+    }
+
+    /** Render the dashboard context snapshot as a compact, human-readable
+      * leading user message. We send it as `user` (not `system`) so the
+      * agent treats it as "what the operator is currently looking at" —
+      * grounding context for the operator's actual question that follows. */
+    def renderContextMessage(ctx: JsonObject, openIncidents: List[Incident] = Nil): String = {
+        val sb = new StringBuilder
+        sb.append("(Current Ops dashboard snapshot — what I'm looking at right now)\n\n")
+
+        val window = Option(ctx.get("window")).map(_.getAsString).getOrElse("24h")
+        sb.append("Window: ").append(window).append("\n\n")
+
+        val failing = Option(ctx.getAsJsonArray("failingItems")).map(_.asScala.toList).getOrElse(Nil)
+        if (failing.isEmpty) {
+            sb.append("Failures: none in window.\n\n")
+        } else {
+            sb.append("Failures (").append(failing.size).append("):\n")
+            failing.foreach { el =>
+                val f = el.getAsJsonObject
+                val kind = strOpt(f, "kind").getOrElse("?")
+                val name = strOpt(f, "name").getOrElse("?")
+                val catalog = strOpt(f, "catalog").map(c => " [" + c + "]").getOrElse("")
+                val reason = strOpt(f, "reason").getOrElse("")
+                val time = strOpt(f, "timeIso").getOrElse("")
+                val recovered = boolOpt(f, "recovered").getOrElse(false)
+                val count = intOpt(f, "failureCount").getOrElse(1)
+                val related = strOpt(f, "relatedTapName").map(t => ", upstream tap=" + t).getOrElse("")
+                val token = strOpt(f, "pipelineToken").map(t => ", pipeline_token=" + t).getOrElse("")
+                val recoveredLabel = if (recovered) " [RECOVERED]" else ""
+                sb.append("  - ").append(kind).append(" `").append(name).append("`").append(catalog)
+                    .append(": ").append(reason)
+                    .append(" (").append(count).append("x")
+                    .append(if (time.nonEmpty) ", " + time else "")
+                    .append(related).append(token).append(")").append(recoveredLabel).append("\n")
+            }
+            sb.append("\n")
+        }
+
+        val stale = Option(ctx.getAsJsonArray("staleTaps")).map(_.asScala.toList).getOrElse(Nil)
+        if (stale.nonEmpty) {
+            sb.append("Stale taps (").append(stale.size).append("):\n")
+            stale.foreach { el =>
+                val s = el.getAsJsonObject
+                val name = strOpt(s, "name").getOrElse("?")
+                val cadence = strOpt(s, "cadenceLabel").getOrElse("?")
+                val lastRun = strOpt(s, "lastRunIso").getOrElse("never")
+                sb.append("  - `").append(name).append("` expects ").append(cadence)
+                    .append(", last ran ").append(lastRun).append("\n")
+            }
+            sb.append("\n")
+        }
+
+        val vols = Option(ctx.getAsJsonArray("pipelineVolumes")).map(_.asScala.toList).getOrElse(Nil)
+        if (vols.nonEmpty) {
+            sb.append("Pipeline volume anomalies (top ").append(vols.size)
+                .append(" by |delta| this ").append(window).append(" vs the prior ").append(window).append("):\n")
+            vols.foreach { el =>
+                val v = el.getAsJsonObject
+                val name = strOpt(v, "name").getOrElse("?")
+                val current = intOpt(v, "current").getOrElse(0)
+                val prior = intOpt(v, "prior").getOrElse(0)
+                val delta = if (v.has("deltaPct") && !v.get("deltaPct").isJsonNull) v.get("deltaPct").getAsInt.toString + "%" else "n/a"
+                sb.append("  - `").append(name).append("`: this ").append(window).append("=").append(current)
+                    .append(", prior ").append(window).append("=").append(prior).append(", vs prior=").append(delta).append("\n")
+            }
+            sb.append("\n")
+        }
+
+        if (openIncidents.nonEmpty) {
+            sb.append("Open incidents (the platform's recovery agent is already working these — explain them, don't re-diagnose from scratch):\n")
+            openIncidents.foreach { i =>
+                sb.append("  - ").append(i.id).append(": ").append(i.kind).append(" on ").append(i.resourceType)
+                    .append(" `").append(i.resourceName).append("`, state=").append(i.state)
+                i.classification.foreach(c => sb.append(", classified ").append(c))
+                i.steps.lastOption.foreach(st => sb.append(" — ").append(st.summary))
+                sb.append("\n")
+            }
+            sb.append("\n")
+        }
+
+        sb.append("Use this snapshot to ground your answers. Refer to taps and pipelines by name. ")
+            .append("If the operator asks about \"the failure\" or \"that one,\" pick the most recent unrecovered failure from the list above.")
+        sb.toString
+    }
+
+    def strOpt(o: JsonObject, key: String): Option[String] =
+        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsString) else None
+
+    def intOpt(o: JsonObject, key: String): Option[Int] =
+        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsInt) else None
+
+    def boolOpt(o: JsonObject, key: String): Option[Boolean] =
+        if (o.has(key) && !o.get(key).isJsonNull) Some(o.get(key).getAsBoolean) else None
+
+    def buildOpsSystemPrompt(tenantEnv: String): String = {
+        val sb = new StringBuilder
+        sb.append("# Datris Ops Assistant\n\n")
+        sb.append("You are the Ops chat assistant for tenant `").append(tenantEnv).append("`. ")
+        sb.append(
+            "The operator is looking at a live Activity dashboard inside the Datris UI — failures, recovered taps, stale taps, per-pipeline volume anomalies. "
+        )
+        sb.append(
+            "When a dashboard snapshot is provided as the leading user message in this conversation, treat it as ground truth for what the operator is looking at *right now*. "
+        )
+        sb.append(
+            "When no snapshot is provided (the operator may be on a sub-tab that doesn't publish one), call `list_taps` and `list_pipelines` if you need to discover state, and answer based on what those tools return.\n\n"
+        )
+
+        sb.append("## Mission\n\n")
+        sb.append(
+            "You are NOT building new pipelines from scratch — there is a separate build-mode Assistant for that. Your job is to help the operator understand and recover the data flows that already exist:\n"
+        )
+        sb.append("- Explain failures in plain English. Cite the actual error and what likely caused it.\n")
+        sb.append("- Recover when asked. Re-run taps, kill stuck jobs, rotate secrets, fix scripts.\n")
+        sb.append(
+            "- Diagnose anomalies. When a pipeline's today-vs-7d-average is sharply off, walk through the likely causes (upstream slowdown, schedule miss, data shape change) and propose the next check.\n"
+        )
+        sb.append(
+            "- Triage stale taps. A tap that hasn't run in 2× its cadence is either upstream-broken or scheduler-broken — figure out which and propose the fix.\n\n"
+        )
+
+        sb.append("## Behavior rules\n\n")
+        sb.append(
+            "- **Act on items by name.** The snapshot above gives you tap and pipeline names. When the operator says \"why did it fail?\" or \"re-run that one,\" pick the most recent unrecovered failure from the snapshot — don't ask the operator to paste a name they can see on screen.\n"
+        )
+        sb.append(
+            "- **Use `pipeline_token` from the snapshot to read root causes.** Each pipeline-kind failure in the snapshot includes a `pipeline_token=<UUID>`. To explain *why* a job failed — including for [RECOVERED] failures whose original error has been superseded by a successful retry in the rollup — call `get_pipeline_status(pipeline_token=<that UUID>)`. The per-job response contains the full event trail, the platform's `error` and `warning` rows, and the AI explanation. Do NOT tell the operator you can't see the original error; the token is in the snapshot, use it.\n"
+        )
+        sb.append(
+            "- **Never act on a [RECOVERED] item without an explicit, item-specific request.** Items marked [RECOVERED] in the snapshot are healthy right now — the platform's own retry already fixed them. Diagnostic questions about a recovered item (\"why did it fail?\", \"what happened?\") get an explanation, NOT a fresh `run_tap`. Only re-run a recovered item if the operator explicitly says \"run it again\" / \"re-run X\" naming that specific item — and even then, push back once (\"the tap looks healthy; want me to run it anyway?\") before acting. The platform's spinner cost is non-trivial and an unrequested re-run is worse than no action.\n"
+        )
+        sb.append(
+            "- **Take side-effecting actions ONLY when the operator's most recent message names the action or unambiguously authorizes it.** `run_tap`, `update_tap`, `update_secret`, `kill_job`, `restore_tap_version`, `restore_pipeline_version`, `delete_*` all side-effect the platform. The trigger phrase has to be something like \"run X\", \"re-run\", \"go ahead\", \"do it\", \"yes\" (in response to a question you just asked) — applied to a specific named target. Vague follow-ups (\"try again\", \"retry\", \"and?\", \"keep going\") refer to **the previous diagnostic step**, not a new action. If the prior turn ended in an error reading data, \"try again\" means retry that read, not \"take an action you never proposed.\" When in doubt, ask one clarifying question (\"do you want me to retry the diagnostic, or actually re-run the tap?\") rather than guessing.\n"
+        )
+        sb.append(
+            "- **Version history is read-only until the operator asks to roll back.** `list_tap_versions`, `get_tap_version`, `diff_tap_versions` (and the pipeline equivalents) are safe diagnostics — use them freely to explain what changed in a tap/pipeline and when. `restore_tap_version` / `restore_pipeline_version` are side-effecting: call them ONLY when the operator explicitly asks to restore/roll back a SPECIFIC named entity to a SPECIFIC version (\"roll tap X back to version 3\"). A restore is append-only — it writes the chosen snapshot as a new latest version, so nothing is lost — but it still changes the live definition, so confirm the target version first if it's at all ambiguous. After a restore, report the new version number and STOP — do NOT chain into `run_tap`; re-running is a separate action that needs its own explicit request.\n"
+        )
+        sb.append(
+            "- **Prefer the recovery path over a redesign — but only when there's something to recover.** When a tap IS currently failing (unrecovered in the snapshot) on a transient cause (rate limit, network blip, missing API quota), the right action is usually `run_tap` again — not rebuilding the tap. Structural failures (API shape changed, credentials revoked, schema mismatch) need a rebuild. If the failure is already [RECOVERED], nothing needs recovering at all.\n"
+        )
+        sb.append(
+            "- **Confirm before destructive actions.** `kill_job`, `delete_tap`, `delete_pipeline`, `update_secret` on an existing secret — restate exactly what you'll do and wait for explicit confirmation. \"Yeah\" or \"do it\" counts; ambiguous answers do not.\n"
+        )
+        sb.append(
+            "- **Don't create new taps or pipelines from a blank slate.** If the operator wants new data ingested, route them to the Assistant tab — that's the build-mode chat. The exception is when an *existing* failed flow needs a near-clone with a small change (e.g. \"build the same thing pointing at the new endpoint\") and the operator has explicitly asked for it.\n"
+        )
+        sb.append(
+            "- **Monitor runs you start.** When you call `run_tap` and it returns a `publisher_token`, poll `get_pipeline_status` with adaptive backoff (5, 10, 20, 30, 60, 60, 60s) until `rollup.allDone`. Don't hand off mid-flight with \"check back in a bit.\" Report the terminal outcome.\n"
+        )
+        sb.append(
+            "- **Errors in `get_pipeline_status` are not run failures.** If the status endpoint itself errors, wait briefly and retry. Only a terminal `error` on the run rollup counts as a failure.\n"
+        )
+        sb.append(
+            "- **Be brief.** This is a side-panel chat with limited width. Short paragraphs, no elaborate restatements of what the operator already knows. One line of polling progress per cycle is enough.\n"
+        )
+        sb.append(
+            "- **Tap secrets are tagged `_type=tap`.** You can read and rotate them but you can only modify secrets the platform owns (the MCP layer enforces this). If a rotation fails with an ownership error, surface that clearly — don't retry.\n\n"
+        )
+
+        sb.append("## Actions that wait for approval\n\n")
+        sb.append(
+            "- **A `pending_approval` result means the action was NOT performed.** The agent policy on this instance may require a person to approve some actions. When a tool returns `status: pending_approval`, say the action is queued (approval `<approvalId>`, under Activity → Approvals on this same page) and never describe it as done; do not re-issue the call. `errorKind: policy_denied` means it is refused for agents here — report that and stop.\n\n"
+        )
+        sb.append("## When the snapshot looks empty\n\n")
+        sb.append(
+            "If the dashboard snapshot has no failures, no stale taps, and no volume anomalies, the platform is healthy. Say so plainly. Offer to spot-check anything the operator names, but don't fabricate problems to solve.\n\n"
+        )
+
+        sb.append("## Don't stall mid-task\n\n")
+        sb.append(
+            "- **If your reply ends by announcing work you have NOT done yet — \"Let me check X\", \"Now I'll Y\", \"Let me look at Z\" — make those tool calls in the SAME turn instead of ending.** Announcing the next step and then stopping forces the user to type \"continue\" to get work they already asked for. The sentence that narrates an action and the tool call that performs it belong in the same turn.\n"
+        )
+        sb.append(
+            "- **End your turn only when** the task is complete, OR you need a decision/approval/confirmation only the user can give, OR you are waiting on input the user must provide. In every other case — including right after you've described your next step — keep going and do it.\n"
+        )
+        sb.append(
+            "- This narrows nothing in the rules above: keep asking, proposing, confirming, and waiting exactly where they tell you to — scope/source choices, a plan to approve, destructive-action confirmation, acting only when explicitly authorized. The point is only this: once the next step is already decided or authorized and you are merely narrating it, perform it instead of ending the turn.\n\n"
+        )
+
+        sb.append("## Finish\n\n")
+        sb.append(
+            "When the action is done — re-run completed, secret rotated, job killed — say so in one or two sentences. The operator can see most of it in the dashboard already; you're the audit trail for what *just happened in this chat*."
+        )
+        sb.toString
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/TapScheduler.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapScheduler.scala
@@ -156,5 +156,15 @@ object TapScheduler {
         val enriched = runLog.copy(aiSummary = fix.summary, aiDiagnosis = fix.diagnosis, aiSuggestion = fix.suggestion)
         NoSQLDbUtil.putItemJSON(env.tapLogTableName, "key", key, "value", gson.toJson(enriched), "created_at", System.currentTimeMillis(): java.lang.Long)
         logger.info("TapScheduler: fix suggestion recorded for tap: " + tap.name + " — " + fix.summary)
+
+        // Recovery agent: the ladder is exhausted and the failure is final —
+        // this is the platform's cue to open an incident (no-op unless
+        // RECOVERY_AGENT_ENABLED and the recovery mode allows it).
+        val trigger = new com.google.gson.JsonObject()
+        trigger.addProperty("runTime", tap.lastRunTime)
+        Option(tap.lastRunError).foreach(e => trigger.addProperty("error", e.take(500)))
+        trigger.addProperty("aiSummary", fix.summary)
+        trigger.addProperty("retryCount", tap.retryCount)
+        ai.datris.incident.IncidentRunner.open(ai.datris.incident.Incident.KindTapFailure, "tap", tap.name, trigger)
     }
 }

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -33,7 +33,7 @@ class MCPToolRoutesSpec extends AnyFunSuite {
     )
 
     test("catalog has one row per MCP tool, no duplicates") {
-        assert(MCPToolRoutes.allToolNames.size == 68)
+        assert(MCPToolRoutes.allToolNames.size == 70)
         assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
     }
 

--- a/datrisserver/src/test/scala/ai/datris/incident/ActivitySignalsSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/incident/ActivitySignalsSpec.scala
@@ -1,0 +1,133 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{PipelineStatusSummary, PipelineStatusSummaryTable, TapConfig}
+import ai.datris.util.ActivitySignals
+import org.scalatest.funsuite.AnyFunSuite
+
+class ActivitySignalsSpec extends AnyFunSuite {
+
+    private val Fmt = "yyyy-MM-dd HH:mm:ss"
+    private val Hour = 3600000L
+    private val Day = 86400000L
+
+    private def tap(name: String, cron: String, lastRun: String, enabled: Boolean = true) =
+        TapConfig(name = name, description = "d", targetPipeline = null, cronExpression = cron, enabled = enabled, lastRunTime = lastRun)
+
+    private def fmt(ms: Long): String = {
+        val sdf = new java.text.SimpleDateFormat(Fmt)
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        sdf.format(new java.util.Date(ms))
+    }
+
+    test("classifies the known cron shapes") {
+        assert(ActivitySignals.parseCronCadenceMs("0 0 * * * ?").contains(Hour))
+        assert(ActivitySignals.parseCronCadenceMs("0 0 0 * * ?").contains(Day))
+        assert(ActivitySignals.parseCronCadenceMs("0 0 0 ? * MON-FRI").contains(Day))
+        assert(ActivitySignals.parseCronCadenceMs("0 0 0 ? * MON").contains(7 * Day))
+        assert(ActivitySignals.parseCronCadenceMs("0 0 */2 * * ?").contains(2 * Hour))
+        assert(ActivitySignals.parseCronCadenceMs("0 */15 * * * ?").contains(15 * 60000L))
+    }
+
+    test("unclassifiable crons are skipped, not guessed") {
+        assert(ActivitySignals.parseCronCadenceMs("0 30 9 ? * TUE").isEmpty)
+        assert(ActivitySignals.parseCronCadenceMs("").isEmpty)
+        assert(ActivitySignals.parseCronCadenceMs(null).isEmpty)
+    }
+
+    test("cadence labels read naturally") {
+        assert(ActivitySignals.cronLabel(Hour) == "hourly")
+        assert(ActivitySignals.cronLabel(Day) == "daily")
+        assert(ActivitySignals.cronLabel(7 * Day) == "weekly")
+        assert(ActivitySignals.cronLabel(2 * Hour) == "every 2h")
+        assert(ActivitySignals.cronLabel(15 * 60000L) == "every 15m")
+    }
+
+    test("a tap past 2x its cadence is stale; one within it is not") {
+        val now = 1000L * Day
+        val stale = ActivitySignals.computeStale(
+            now,
+            List(
+                tap("late-hourly", "0 0 * * * ?", fmt(now - 3 * Hour)),
+                tap("ok-hourly", "0 0 * * * ?", fmt(now - Hour)),
+                tap("late-daily", "0 0 0 * * ?", fmt(now - 3 * Day))
+            ),
+            Fmt,
+            "UTC"
+        )
+        assert(stale.map(_.name).toSet == Set("late-hourly", "late-daily"))
+        assert(stale.find(_.name == "late-hourly").exists(_.cadenceLabel == "hourly"))
+    }
+
+    test("disabled, cron-less, unclassifiable and never-run taps are skipped") {
+        val now = 1000L * Day
+        val stale = ActivitySignals.computeStale(
+            now,
+            List(
+                tap("disabled", "0 0 * * * ?", fmt(now - 10 * Hour), enabled = false),
+                tap("no-cron", null, fmt(now - 10 * Hour)),
+                tap("weird-cron", "0 30 9 ? * TUE", fmt(now - 30 * Day)),
+                tap("never-ran", "0 0 * * * ?", null)
+            ),
+            Fmt,
+            "UTC"
+        )
+        assert(stale.isEmpty)
+    }
+
+    private def summary(pipeline: String, atMs: Long, records: Int) = PipelineStatusSummaryTable(
+        pipeline_token = "t-" + atMs,
+        json = PipelineStatusSummary(
+            createdAtTimestamp = "x",
+            createdAt = atMs,
+            updatedAt = atMs,
+            pipeline = pipeline,
+            pipelineToken = "t-" + atMs,
+            process = "p",
+            startTime = "s",
+            endTime = "e",
+            totalTime = "1s",
+            status = "success",
+            recordCount = records
+        ),
+        created_at = atMs
+    )
+
+    test("a big swing with a solid baseline is an anomaly; a thin baseline is not") {
+        val now = 1000L * Day
+        val win = Day
+        val rows =
+            List(
+                summary("dropped", now - win - 2 * Hour, 100),
+                summary("dropped", now - win - 4 * Hour, 100),
+                summary("dropped", now - win - 6 * Hour, 100),
+                summary("dropped", now - Hour, 10)
+            ) ++
+                List(summary("thin", now - win - 2 * Hour, 100), summary("thin", now - Hour, 1)) ++
+                List(
+                    summary("steady", now - win - 2 * Hour, 50),
+                    summary("steady", now - win - 3 * Hour, 50),
+                    summary("steady", now - win - 5 * Hour, 50),
+                    summary("steady", now - Hour, 500)
+                )
+        val vols = ActivitySignals.computeVolumes(now, win, rows)
+        val dropped = vols.find(_.name == "dropped").get
+        assert(dropped.deltaPct.exists(_ <= -90))
+        assert(dropped.isAnomaly)
+        assert(!vols.find(_.name == "thin").get.isAnomaly)
+        val steady = vols.find(_.name == "steady").get
+        assert(steady.deltaPct.contains(233)) // 500 vs 150 baseline
+        assert(steady.isAnomaly) // over-volume counts too
+    }
+
+    test("no prior data means no delta and no anomaly") {
+        val now = 1000L * Day
+        val vols = ActivitySignals.computeVolumes(now, Day, List(summary("new", now - Hour, 500)))
+        val n = vols.find(_.name == "new").get
+        assert(n.deltaPct.isEmpty && !n.isAnomaly)
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/incident/IncidentRunnerSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/incident/IncidentRunnerSpec.scala
@@ -1,0 +1,201 @@
+package ai.datris.incident
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.incident.IncidentRunner.{ProposedAction, RealDiagnoser}
+import com.google.gson.{JsonObject, JsonParser}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.Instant
+
+class IncidentRunnerSpec extends AnyFunSuite {
+
+    private def incident(kind: String) = Incident(
+        id = "inc_000000000001",
+        kind = kind,
+        resourceType = "tap",
+        resourceName = "prices",
+        openedAt = Instant.now(),
+        state = Incident.Open,
+        trigger = new JsonObject()
+    )
+
+    private def action(tool: String, name: String = "prices") = {
+        val args = new JsonObject()
+        if (name != null) args.addProperty("name", name)
+        ProposedAction(tool, args, "p")
+    }
+
+    // ------------------------------------------------------------------
+    // Proposal parsing (the LLM/code boundary)
+    // ------------------------------------------------------------------
+
+    test("parses a bare JSON proposal") {
+        val r = RealDiagnoser.parseProposal(
+            """{"classification":"structural-script","summary":"field renamed","needsHuman":false,
+              |"actions":[{"tool":"create_tap","args":{"name":"prices"},"purpose":"fix field"},{"tool":"test_tap","args":{"name":"prices"},"purpose":"validate"}],
+              |"learnNote":"source renamed account_id"}""".stripMargin
+        )
+        assert(r.isRight)
+        val p = r.right.get
+        assert(p.classification == "structural-script")
+        assert(!p.needsHuman)
+        assert(p.actions.map(_.tool) == List("create_tap", "test_tap"))
+        assert(p.learnNote.contains("source renamed account_id"))
+    }
+
+    test("parses a fenced proposal with prose around it") {
+        val text =
+            """I inspected the logs. Here is my proposal:
+              |```json
+              |{"classification":"transient","summary":"rate limited","needsHuman":false,"actions":[{"tool":"run_tap","args":{"name":"prices"},"purpose":"retry"}]}
+              |```
+              |""".stripMargin
+        val r = RealDiagnoser.parseProposal(text)
+        assert(r.isRight)
+        assert(r.right.get.classification == "transient")
+        assert(r.right.get.actions.map(_.tool) == List("run_tap"))
+    }
+
+    test("prose with an embedded object still parses via brace extraction") {
+        val r = RealDiagnoser.parseProposal(
+            """Diagnosis done. {"classification":"needs-human","summary":"credentials revoked","needsHuman":true,"actions":[]} That's all."""
+        )
+        assert(r.isRight)
+        assert(r.right.get.needsHuman)
+    }
+
+    test("needs-human classification forces needsHuman even when the flag is absent") {
+        val r = RealDiagnoser.parseProposal("""{"classification":"needs-human","summary":"upstream outage","actions":[]}""")
+        assert(r.isRight && r.right.get.needsHuman)
+    }
+
+    test("non-JSON output is a Left, never a crash") {
+        assert(RealDiagnoser.parseProposal("I could not determine the cause.").isLeft)
+        assert(RealDiagnoser.parseProposal("").isLeft)
+    }
+
+    // ------------------------------------------------------------------
+    // Action filtering (code decides, not the model)
+    // ------------------------------------------------------------------
+
+    test("only executable tools survive filtering — deletes and migrations never run") {
+        val p = IncidentRunner.Proposal(
+            "structural-script",
+            "s",
+            needsHuman = false,
+            List(action("delete_tap"), action("update_tap"), action("apply_dest_types"), action("create_tap"), action("test_tap"), action("update_secret")),
+            None
+        )
+        val filtered = IncidentRunner.filterActions(incident(Incident.KindTapFailure), p)
+        assert(filtered.map(_.tool) == List("update_tap", "create_tap", "test_tap"))
+    }
+
+    test("actions are pinned to the incident's own resource — other names are discarded") {
+        val p = IncidentRunner.Proposal(
+            "structural-script",
+            "s",
+            needsHuman = false,
+            List(action("run_tap", "someone-elses-tap"), action("create_tap", null), action("run_tap")),
+            None
+        )
+        val filtered = IncidentRunner.filterActions(incident(Incident.KindTapFailure), p)
+        assert(filtered.map(_.tool) == List("run_tap"))
+        assert(filtered.forall(_.args.get("name").getAsString == "prices"))
+    }
+
+    test("stale incidents are limited to a single run_tap") {
+        val p = IncidentRunner.Proposal("transient", "s", needsHuman = false, List(action("update_tap"), action("run_tap"), action("run_tap")), None)
+        val filtered = IncidentRunner.filterActions(incident(Incident.KindStale), p)
+        assert(filtered.map(_.tool) == List("run_tap"))
+    }
+
+    test("action count is capped by maxActionsPerIncident") {
+        val many = List.fill(10)(action("run_tap"))
+        val p = IncidentRunner.Proposal("transient", "s", needsHuman = false, many, None)
+        val filtered = IncidentRunner.filterActions(incident(Incident.KindTapFailure), p)
+        assert(filtered.size == IncidentRunner.settings.maxActionsPerIncident)
+    }
+
+    // ------------------------------------------------------------------
+    // Outcome classification
+    // ------------------------------------------------------------------
+
+    test("pending_approval is detected at any nesting depth (composite tools wrap it)") {
+        assert(IncidentRunner.findPendingApproval("""{"status":"pending_approval","approvalId":"pa_1"}""").contains("pa_1"))
+        assert(IncidentRunner.findPendingApproval(
+            """{"message":"Tap created successfully","tap":{"status":"pending_approval","approvalId":"pa_2","action":"tap:create"}}"""
+        ).contains("pa_2"))
+        assert(IncidentRunner.findPendingApproval("""{"results":[{"ok":true},{"inner":{"status":"pending_approval","approvalId":"pa_3"}}]}""").contains("pa_3"))
+        assert(IncidentRunner.findPendingApproval("""{"status":"ok","approvalId":"x"}""").isEmpty)
+        assert(IncidentRunner.findPendingApproval("not json").isEmpty)
+    }
+
+    test("a tool result with an embedded error field is a failure") {
+        assert(IncidentRunner.hasErrorField("""{"mode":"test","recordCount":0,"error":"Tap script failed (exit code 1)"}"""))
+        assert(IncidentRunner.hasErrorField("""{"error":"capability denied"}"""))
+        assert(!IncidentRunner.hasErrorField("""{"mode":"run","recordCount":10,"error":""}"""))
+        assert(!IncidentRunner.hasErrorField("""{"mode":"run","recordCount":10}"""))
+        assert(!IncidentRunner.hasErrorField("plain text"))
+    }
+
+    // ------------------------------------------------------------------
+    // Guards
+    // ------------------------------------------------------------------
+
+    test("open is a no-op while the feature is disabled") {
+        assert(!IncidentRunner.enabled)
+        assert(IncidentRunner.open(Incident.KindTapFailure, "tap", "x", new JsonObject()).isEmpty)
+    }
+
+    test("diagnosis tools are strictly read-only and executable tools are strictly bounded") {
+        val mutating = Set(
+            "run_tap",
+            "test_tap",
+            "update_tap",
+            "create_tap",
+            "delete_tap",
+            "update_secret",
+            "apply_dest_types",
+            "kill_job",
+            "restore_tap_version",
+            "delete_pipeline",
+            "create_pipeline",
+            "upload_data"
+        )
+        assert(IncidentRunner.DiagnosisTools.intersect(mutating).isEmpty)
+        assert(IncidentRunner.ExecutableTools == Set("run_tap", "test_tap", "update_tap", "create_tap"))
+    }
+
+    // ------------------------------------------------------------------
+    // Incident model round-trip
+    // ------------------------------------------------------------------
+
+    test("incident document round-trips") {
+        val trigger = JsonParser.parseString("""{"error":"KeyError: account_id","retryCount":3}""").getAsJsonObject
+        val i = incident(Incident.KindTapFailure).copy(
+            trigger = trigger,
+            steps = List(IncidentStep(Instant.parse("2026-08-31T10:00:00Z"), "open", "opened", Some("d"), Some("pa_1"))),
+            classification = Some("structural-script"),
+            aiCalls = 4,
+            actionsTaken = 2,
+            awaitingApprovalIds = List("pa_2"),
+            revertToVersion = Some(7),
+            closedAt = Some(Instant.parse("2026-08-31T10:10:00Z")),
+            outcome = Some("recovered")
+        )
+        val back = Incident.fromDocument(i.toDocument)
+        assert(back == i)
+    }
+
+    test("public JSON exposes the narrative but keeps state machinery consistent") {
+        val i = incident(Incident.KindVolume)
+        val json = i.toPublicJson.toString
+        assert(json.contains("\"kind\":\"volume\""))
+        assert(json.contains("\"state\":\"open\""))
+        assert(Incident.OpenStates.contains(i.state))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/policy/RecoveryPolicySpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/policy/RecoveryPolicySpec.scala
@@ -1,0 +1,64 @@
+package ai.datris.policy
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class RecoveryPolicySpec extends AnyFunSuite {
+
+    private def policy(json: String): AgentPolicy = AgentPolicy.fromJson(json) match {
+        case Right(p) => p
+        case Left(err) => fail("expected a valid policy: " + err)
+    }
+
+    test("recovery defaults to off with the documented limits") {
+        val p = policy("""{}""")
+        assert(p.recovery == RecoverySettings())
+        assert(p.recovery.mode == RecoverySettings.Off)
+        assert(p.recovery.maxAiCallsPerIncident == 12)
+        assert(p.recovery.maxActionsPerIncident == 3)
+        assert(p.recovery.maxRuntimeMinutes == 15)
+        assert(p.recovery.maxOpenIncidents == 10)
+        assert(p.recovery.cooldownHours == 6)
+    }
+
+    test("recovery block parses and round-trips") {
+        val p = policy(
+            """{"recovery":{"mode":"autopilot","maxAiCallsPerIncident":5,"maxActionsPerIncident":2,"maxRuntimeMinutes":10,"maxOpenIncidents":4,"cooldownHours":12}}"""
+        )
+        assert(p.recovery.mode == RecoverySettings.Autopilot)
+        assert(p.recovery.maxActionsPerIncident == 2)
+        val back = policy(p.toJson.toString)
+        assert(back.recovery == p.recovery)
+    }
+
+    test("bad recovery modes and out-of-range limits are rejected") {
+        assert(AgentPolicy.fromJson("""{"recovery":{"mode":"yolo"}}""").isLeft)
+        assert(AgentPolicy.fromJson("""{"recovery":{"maxRuntimeMinutes":0}}""").isLeft)
+        assert(AgentPolicy.fromJson("""{"recovery":{"maxAiCallsPerIncident":"many"}}""").isLeft)
+    }
+
+    test("per-resource recovery override moves in either direction") {
+        val p = policy("""{"recovery":{"mode":"propose"},"overrides":{"tap:prices":{"recovery":"autopilot"},"tap:hr-data":{"recovery":"off"}}}""")
+        assert(p.effectiveRecoveryMode("tap", "prices") == RecoverySettings.Autopilot)
+        assert(p.effectiveRecoveryMode("tap", "hr-data") == RecoverySettings.Off)
+        assert(p.effectiveRecoveryMode("tap", "other") == RecoverySettings.Propose)
+        assert(p.effectiveRecoveryMode("pipeline", "prices") == RecoverySettings.Propose)
+    }
+
+    test("recovery override coexists with action overrides in the same object and round-trips") {
+        val p = policy("""{"actions":{"tap:run":"auto"},"overrides":{"tap:prices":{"tap:run":"approve","recovery":"autopilot"}}}""")
+        assert(p.decide("tap:run", Some("tap"), Some("prices")) == PolicyMode.Approve)
+        assert(p.effectiveRecoveryMode("tap", "prices") == RecoverySettings.Autopilot)
+        val back = policy(p.toJson.toString)
+        assert(back == p)
+    }
+
+    test("a bad recovery override mode is rejected, naming the resource") {
+        val r = AgentPolicy.fromJson("""{"overrides":{"tap:prices":{"recovery":"sometimes"}}}""")
+        assert(r.isLeft && r.left.get.contains("tap:prices"))
+    }
+}

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -313,6 +313,12 @@ services:
       # approve queued ones under Activity → Approvals. Off by default; when on
       # with no policy saved, behavior is unchanged until a rule is set.
       USEAGENTPOLICY: "${USE_AGENT_POLICY:-false}"
+      # Recovery agent: platform-opened incidents with an autonomous
+      # diagnose→repair→verify loop, bounded by the agent policy's recovery
+      # mode and limits. Needs USE_AGENT_POLICY=true. INCIDENT_WEBHOOK_URL
+      # (optional) gets a JSON POST on incident lifecycle events.
+      RECOVERYAGENT_ENABLED: "${RECOVERY_AGENT_ENABLED:-false}"
+      RECOVERYAGENT_WEBHOOKURL: "${INCIDENT_WEBHOOK_URL:-}"
       # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
       # the server requires MinIO to present it as a bearer token (see
       # minio-init.sh auth_token). Empty by default so existing deployments keep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,6 +292,12 @@ services:
       # approve queued ones under Activity → Approvals. Off by default; when on
       # with no policy saved, behavior is unchanged until a rule is set.
       USEAGENTPOLICY: "${USE_AGENT_POLICY:-false}"
+      # Recovery agent: platform-opened incidents with an autonomous
+      # diagnose→repair→verify loop, bounded by the agent policy's recovery
+      # mode and limits. Needs USE_AGENT_POLICY=true. INCIDENT_WEBHOOK_URL
+      # (optional) gets a JSON POST on incident lifecycle events.
+      RECOVERYAGENT_ENABLED: "${RECOVERY_AGENT_ENABLED:-false}"
+      RECOVERYAGENT_WEBHOOKURL: "${INCIDENT_WEBHOOK_URL:-}"
       # Shared secret authenticating the MinIO -> /minio-events webhook. When set,
       # the server requires MinIO to present it as a bearer token (see
       # minio-init.sh auth_token). Empty by default so existing deployments keep

--- a/docs/agent-policy.mdx
+++ b/docs/agent-policy.mdx
@@ -86,6 +86,10 @@ Every mutating tool also accepts an optional `reason` — one line stating why t
 | Pending approval TTL | 24 hours | Undecided approvals expire after this |
 | Max pending per agent | 50 | An agent with this many undecided approvals is told to wait |
 
+## Recovery mode
+
+The policy document also carries the [recovery agent](/incidents)'s dial — `recovery.mode` (`off` / `propose` / `autopilot`) and its limits — plus per-resource `recovery` overrides. The recovery agent's every action passes through this same policy gate: under `propose`, everything it wants to do queues here for your approval.
+
 ## Related
 
 - [API Keys](/api-keys) — what a key *may* do; the policy decides what it may do *unattended*

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -87,6 +87,8 @@ Two independent flags control access. Set them together — see [the supported m
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries in the config store; `0` keeps them forever. Maps to `auditLog.retentionDays` |
 | `AUDIT_LOG_READS` | `false` | Also record reads — queries, searches, listings, metadata. Off by default because they dwarf the write trail. Maps to `auditLog.logReads` |
 | `USE_AGENT_POLICY` | `false` | Per-action auto / approve / deny for agent-initiated changes, with a human approval queue under Activity → Approvals. With it on and no rules set, nothing changes. Restart to change. See [Agent Policy](/agent-policy) |
+| `RECOVERY_AGENT_ENABLED` | `false` | The platform opens, diagnoses and — within the agent policy's recovery mode — repairs incidents for failed, stale or anomalous data flows. Needs `USE_AGENT_POLICY=true`. See [Incidents](/incidents) |
+| `INCIDENT_WEBHOOK_URL` | _(empty)_ | Optional URL receiving a JSON POST on incident open / awaiting-approval / resolved / failed |
 
 One further audit setting lives only in `application.yaml`: `auditLog.emitLogLine` (default `true`; mirror each entry to the `ai.datris.audit` logger for SIEM pickup).
 
@@ -351,6 +353,7 @@ The following buckets are created automatically by the `minio-init` container:
 | `{environment}-audit-log` | Audit entries (when `USE_AUDIT_LOG=true`); TTL-expired per `AUDIT_LOG_RETENTION_DAYS` |
 | `{environment}-agent-policy` | The [agent policy](/agent-policy) document (when `USE_AGENT_POLICY=true`) |
 | `{environment}-pending-action` | Agent actions queued for approval; TTL-expired at their own expiry |
+| `{environment}-incident` | Recovery-agent incidents (when `RECOVERY_AGENT_ENABLED=true`) — the operational history behind Activity → Incidents |
 
 ## Container Environment Variables
 
@@ -369,3 +372,5 @@ These environment variables are read by `docker-compose.yml` and passed into the
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries; `0` = forever. |
 | `AUDIT_LOG_READS` | `false` | Also record reads (queries, searches, listings). |
 | `USE_AGENT_POLICY` | `false` | Enable the [Agent Policy](/agent-policy) — auto / approve / deny per agent action, with a human approval queue. |
+| `RECOVERY_AGENT_ENABLED` | `false` | Enable the [recovery agent](/incidents) — platform-opened incidents with a bounded repair loop. |
+| `INCIDENT_WEBHOOK_URL` | _(empty)_ | Optional JSON webhook for incident lifecycle events. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -111,6 +111,7 @@
               "api-keys",
               "audit-log",
               "agent-policy",
+              "incidents",
               "monitoring",
               "notifications"
             ]

--- a/docs/incidents.mdx
+++ b/docs/incidents.mdx
@@ -1,0 +1,79 @@
+---
+title: "Incidents & Recovery Agent"
+description: "The platform opens an incident when a data flow breaks, diagnoses it, and — within limits you set — repairs and verifies it."
+---
+
+With the recovery agent on, Datris stops waiting for you to notice a broken data flow. When a scheduled tap finally fails (after the platform's own retries), a pipeline job errors, a tap goes stale, or a pipeline's volume swings hard, the platform opens an **incident**, diagnoses it with the same judgment as the Ops chat, proposes a fix, passes every action through the [agent policy](/agent-policy), executes what it may, **verifies the fix with a real run — reverting it if verification fails** — and records the whole story.
+
+The loop is: observe → diagnose → propose → gate → execute → verify → record. The AI proposes; deterministic platform code decides. Limits, verification and the revert are code the model cannot talk its way past.
+
+## Enabling it
+
+Requires the [agent policy](/agent-policy) (`USE_AGENT_POLICY=true`) for its approval flow.
+
+1. Add to your `.env`:
+
+   ```bash
+   RECOVERY_AGENT_ENABLED=true
+   # optional: JSON POST on incident open / awaiting-approval / resolved / failed
+   INCIDENT_WEBHOOK_URL=
+   ```
+
+2. Recreate the Datris container:
+
+   ```bash
+   docker compose up -d --force-recreate datris
+   ```
+
+3. Set the **recovery mode** in Configuration → Agent Policy. It ships as `off`, so nothing changes until you choose:
+
+| Mode | Behavior |
+|------|----------|
+| `off` | Today's behavior: failures get an AI suggestion in Run History, nothing more |
+| `propose` | Incidents open and are diagnosed; **every** proposed action queues under Activity → Approvals — nothing executes without a person |
+| `autopilot` | Actions follow your per-action policy matrix (`auto` runs, `approve` queues, `deny` refuses) |
+
+A per-tap or per-pipeline override can put one resource on a different mode — one critical tap on `propose` while everything else runs `autopilot`, or the reverse.
+
+## What opens an incident
+
+| Signal | When |
+|--------|------|
+| Tap failure | A scheduled run fails **after** the retry ladder is exhausted |
+| Pipeline failure | A pipeline job ends in error |
+| Stale tap | A scheduled tap hasn't run within 2× its cadence |
+| Volume anomaly | A pipeline's records this day are ±60 % vs its 7-day baseline (with at least 3 prior runs) |
+
+Guards, all enforced in code: one open incident per resource; a resource whose latest run is healthy never gets one; a cooldown (default 6 h) after a failed or abandoned attempt; a cap on simultaneous open incidents. Volume incidents are **diagnosis-only** — the value is the triage, not an action.
+
+## What the agent may do
+
+During diagnosis it holds **read-only tools** — it cannot change anything while investigating. Its proposal may only contain: re-run the tap, fix the tap script (then test it), or "this needs a human" with an explanation. Deletes, schema migrations and secret changes are structurally impossible for it. Script fixes land as a new version, so history is never lost.
+
+**Verification is mandatory**: after acting, the tap must complete a real run healthily, and when it feeds a pipeline the load must finish without error. If verification fails, the platform reverts the script to the pre-incident version, closes the incident as failed, and starts the cooldown.
+
+Every call it makes runs as its own `recovery-agent` API key and is tagged with the incident id, so the [audit log](/audit-log) is the incident's complete ledger — and revoking that key stops the agent entirely, independent of any flag.
+
+## Limits
+
+Set under the agent policy's `recovery` section; enforced by the runner, not the prompt:
+
+| Limit | Default |
+|-------|---------|
+| AI calls per incident | 12 |
+| Actions per incident | 3 |
+| Runtime per incident | 15 minutes |
+| Simultaneous open incidents | 10 |
+| Cooldown after a failure | 6 hours |
+
+## Watching it
+
+- **Activity → Incidents**: every incident with its state, classification, step-by-step narrative, and any approvals it waits on; a person can abandon one at any time.
+- **Ops chat**: incidents the platform is working appear in the assistant's context — ask "what happened to the prices tap?" and it explains the incident record instead of re-diagnosing.
+- **Agents**: `list_incidents` / `get_incident` MCP tools (read-only — only the platform opens incidents).
+- **Metrics**: `datris_incidents_total{kind,outcome}` and `datris_incident_duration_seconds` on the Prometheus endpoint.
+
+## Related
+
+- [Agent Policy](/agent-policy) — the gate every recovery action passes through
+- [Audit Log](/audit-log) — the incident's ledger, joined on the incident id

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -134,6 +134,13 @@ For a document tap, `create_tap` **requires** the `target_pipeline` to have an `
 
 Every tool that changes platform state also accepts an optional `reason` — one line the agent gives for the change. It is recorded in the [audit log](/audit-log) and shown on the approval card. When the policy requires approval, the mutating tool returns `status: pending_approval` with an `approvalId` instead of performing the action.
 
+### Incidents (recovery agent)
+
+| Tool | Description |
+|------|-------------|
+| `list_incidents` | The platform's [recovery-agent incidents](/incidents), newest first — kind, resource, state, classification and narrative. Read-only: only the platform opens incidents |
+| `get_incident` | One incident by id, with its full step-by-step story and any approvals it waits on. When the operator asks about a failure the platform is already working, explain this record instead of re-diagnosing |
+
 ## Monitoring Active Agents
 
 The [Datris UI](http://localhost:4200) includes an **Agent Monitor** tab that shows a live view of every agent currently connected to the MCP server and a streaming log of the tool calls each one is making. Agents are labeled using their MCP `clientInfo.name` — so Claude Desktop appears as `claude-ai`, Claude Code as `claude-code`, Cursor as `cursor`, and so on — with graceful fallbacks to tenant name, API-key name, or session id for clients that don't supply one. See [Monitoring → Agent Monitor](/monitoring#agent-monitor) for details.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28,6 +28,56 @@ components:
       description: Optional API key for authentication (enabled via application.yaml)
 
   schemas:
+    Incident:
+      type: object
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+          enum: [tap_failure, pipeline_failure, stale, volume]
+        resourceType:
+          type: string
+        resource:
+          type: string
+        openedAt:
+          type: string
+        state:
+          type: string
+          enum: [open, diagnosing, proposed, awaiting_approval, executing, verifying, resolved, failed, abandoned]
+        trigger:
+          type: object
+        steps:
+          type: array
+          items:
+            type: object
+            properties:
+              ts:
+                type: string
+              phase:
+                type: string
+              summary:
+                type: string
+              detail:
+                type: string
+              approvalId:
+                type: string
+        classification:
+          type: string
+        proposal:
+          type: object
+        aiCalls:
+          type: integer
+        actionsTaken:
+          type: integer
+        awaitingApprovalIds:
+          type: array
+          items:
+            type: string
+        closedAt:
+          type: string
+        outcome:
+          type: string
     AgentPolicy:
       type: object
       properties:
@@ -3368,6 +3418,93 @@ paths:
                 $ref: '#/components/schemas/PendingAction'
         '409':
           description: No longer pending
+  /api/v1/incidents:
+    get:
+      tags: [Recovery Agent]
+      summary: List recovery-agent incidents
+      description: >-
+        Incidents the platform opened for failed, stale or anomalous data
+        flows, newest first. Read-only — only the platform opens incidents.
+        `enabled` is false while RECOVERY_AGENT_ENABLED is off.
+      parameters:
+        - in: query
+          name: state
+          schema:
+            type: string
+          description: "`open` (any active state) or a specific state name"
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+      responses:
+        '200':
+          description: Incidents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  incidents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Incident'
+  /api/v1/incidents/{id}:
+    get:
+      tags: [Recovery Agent]
+      summary: Read one incident
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The incident
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '404':
+          description: Unknown id, or the recovery agent is off
+  /api/v1/incidents/{id}/abandon:
+    post:
+      tags: [Recovery Agent]
+      summary: Abandon an open incident (admin / editor)
+      description: A person closing an incident by hand. Never permitted from an agent-initiated request.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The abandoned incident
+        '409':
+          description: Already closed
+  /api/v1/activity/signals:
+    get:
+      tags: [Recovery Agent]
+      summary: Server-side Activity signals
+      description: >-
+        One definition of operational signals — failures (with the recovered
+        flag), stale scheduled taps, and pipeline volume anomalies — shared
+        by the dashboard, the Ops chat context and the recovery agent.
+      parameters:
+        - in: query
+          name: window
+          schema:
+            type: string
+            enum: [24h, 7d, 30d]
+            default: 24h
+      responses:
+        '200':
+          description: Signals for the window
   /api/v1/keys:
     get:
       tags: [API Keys]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -62,6 +62,10 @@ _session_id: contextvars.ContextVar[str] = contextvars.ContextVar("_session_id",
 # to the platform as X-Datris-Reason (audit metadata + approval cards).
 _call_reason: contextvars.ContextVar[str] = contextvars.ContextVar("_call_reason", default="")
 
+# Incident id forwarded by the platform's recovery agent (its MCP calls carry
+# X-Datris-Incident) so the REST hop lands in the audit log under the incident.
+_session_incident: contextvars.ContextVar[str] = contextvars.ContextVar("_session_incident", default="")
+
 # Agent-monitor: in-process activity buffer + session tracker.
 # Ephemeral; cleared on restart. Safe to read via a plain lock.
 _activity_buffer: deque = deque(maxlen=200)
@@ -493,6 +497,9 @@ def _identity_headers():
     reason = _call_reason.get()
     if reason:
         h["X-Datris-Reason"] = reason[:500]
+    incident = _session_incident.get()
+    if incident:
+        h["X-Datris-Incident"] = incident[:64]
     return h
 
 
@@ -2803,6 +2810,38 @@ def _base_tools():
                 "required": ["approval_id"],
             }
         ),
+        # --- Recovery-agent incidents (read-only; the platform opens them) ---
+        Tool(
+            name="list_incidents",
+            description="List the platform's recovery-agent incidents, newest first. An incident is opened by the platform itself when a scheduled tap finally fails, a pipeline job errors, a tap goes stale, or a pipeline's volume swings; the recovery agent diagnoses it and — within the agent policy's recovery mode — repairs and verifies it. Each entry carries kind, resource, state (open | diagnosing | proposed | awaiting_approval | executing | verifying | resolved | failed | abandoned), classification, and a step-by-step narrative. Use state=open for what is being worked right now. Returns {enabled:false, incidents:[]} when the recovery agent is off.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "type": "string",
+                        "description": "Filter: open (any active state) or a specific state name. Omit for all.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum incidents to return (default 50).",
+                    },
+                },
+            }
+        ),
+        Tool(
+            name="get_incident",
+            description="Read one recovery-agent incident by id — its trigger, classification, proposal, step-by-step narrative, approvals it is waiting on, and outcome. When the operator asks about a failure the platform is already working, explain THIS record instead of re-diagnosing from scratch.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "incident_id": {
+                        "type": "string",
+                        "description": "The incident id (inc_…).",
+                    },
+                },
+                "required": ["incident_id"],
+            }
+        ),
     ]
 
 
@@ -3801,6 +3840,20 @@ def _dispatch(name: str, args: dict) -> str:
             return json.dumps({"error": "approval_id is required"})
         return _call("get", f"/api/v1/approvals/{approval_id}")
 
+    elif name == "list_incidents":
+        params = {}
+        if args.get("state"):
+            params["state"] = args["state"]
+        if args.get("limit"):
+            params["limit"] = args["limit"]
+        return _call("get", "/api/v1/incidents", params=params)
+
+    elif name == "get_incident":
+        incident_id = str(args.get("incident_id", "")).strip()
+        if not incident_id:
+            return json.dumps({"error": "incident_id is required"})
+        return _call("get", f"/api/v1/incidents/{incident_id}")
+
     else:
         return json.dumps({"error": f"Unknown tool: {name}"})
 
@@ -3911,6 +3964,7 @@ async def run_sse(port: int):
                     return
                 _session_api_key.set(api_key)
                 _session_on_behalf_of.set(_extract_header(scope, b"x-datris-on-behalf-of"))
+                _session_incident.set(_extract_header(scope, b"x-datris-incident"))
                 sess_id = uuid.uuid4().hex
                 _session_id.set(sess_id)
                 _activity_session_open(sess_id, api_key)
@@ -3946,6 +4000,7 @@ async def run_sse(port: int):
                     return
                 _session_api_key.set(api_key)
                 _session_on_behalf_of.set(_extract_header(scope, b"x-datris-on-behalf-of"))
+                _session_incident.set(_extract_header(scope, b"x-datris-incident"))
                 sess_id = uuid.uuid4().hex
                 _session_id.set(sess_id)
                 _activity_session_open(sess_id, api_key)
@@ -4001,6 +4056,7 @@ async def run_streamable_http(port: int):
                     return
                 _session_api_key.set(api_key)
                 _session_on_behalf_of.set(_extract_header(scope, b"x-datris-on-behalf-of"))
+                _session_incident.set(_extract_header(scope, b"x-datris-incident"))
                 sess_id = uuid.uuid4().hex
                 _session_id.set(sess_id)
                 _activity_session_open(sess_id, api_key)

--- a/scripts/check-mcp-tool-catalog.py
+++ b/scripts/check-mcp-tool-catalog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Drift guard for the MCP tool catalog's three hand-maintained surfaces.
+
+The single source of truth is mcp-server/server.py (_base_tools). Two other
+surfaces must list exactly the same tools:
+
+  - datrisserver/.../auth/MCPToolRoutes.scala — capability-based visibility.
+    A tool missing here is hidden from every scoped key (fail-closed).
+  - ui/src/app/mcp/mcp.component.ts — the MCP Connect tab's catalog.
+    A tool missing here silently disappears from the UI (bit us in v1.22:
+    get_dest_types / apply_dest_types shipped invisible to the tab).
+
+Run from anywhere: paths resolve relative to this script. Exits non-zero,
+naming every difference, when any surface drifts. Wired into the CI
+ui-build job; run locally via `npm run check:mcp-catalog` (ui/) or directly.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVER = ROOT / "mcp-server" / "server.py"
+ROUTES = ROOT / "datrisserver" / "src" / "main" / "scala" / "ai" / "datris" / "auth" / "MCPToolRoutes.scala"
+UI = ROOT / "ui" / "src" / "app" / "mcp" / "mcp.component.ts"
+
+
+def server_tools() -> set:
+    text = SERVER.read_text()
+    # Tool definitions: Tool( followed by name="..." on the next line.
+    names = re.findall(r'Tool\(\s*\n\s*name="([a-z_0-9]+)"', text)
+    if not names:
+        sys.exit(f"could not parse any Tool(name=...) entries from {SERVER}")
+    return set(names)
+
+
+def routes_tools() -> set:
+    text = ROUTES.read_text()
+    names = re.findall(r'"([a-z_0-9]+)"\s*->\s*(?:Mapped|Local)', text)
+    if not names:
+        sys.exit(f"could not parse any tool rows from {ROUTES}")
+    return set(names)
+
+
+def ui_tools() -> set:
+    text = UI.read_text()
+    # Tool entries (not parameters): name: '...' immediately followed by description:.
+    names = re.findall(r"name: '([a-z_0-9]+)',\n\s+description:", text)
+    if not names:
+        sys.exit(f"could not parse any toolCatalog entries from {UI}")
+    return set(names)
+
+
+def main() -> int:
+    server = server_tools()
+    failures = []
+    for label, path, got in (
+        ("MCPToolRoutes.scala", ROUTES, routes_tools()),
+        ("UI MCP tab catalog", UI, ui_tools()),
+    ):
+        missing = sorted(server - got)
+        extra = sorted(got - server)
+        if missing:
+            failures.append(f"{label} is MISSING tools the MCP server defines: {', '.join(missing)}")
+        if extra:
+            failures.append(f"{label} lists tools the MCP server does not define: {', '.join(extra)}")
+    if failures:
+        print(f"MCP tool catalog drift ({len(server)} tools in mcp-server/server.py):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print("Fix the drifted surface(s); server.py is the source of truth.", file=sys.stderr)
+        return 1
+    print(f"MCP tool catalog in sync across server.py, MCPToolRoutes.scala and the UI ({len(server)} tools).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "check:mcp-catalog": "python3 ../scripts/check-mcp-tool-catalog.py"
   },
   "private": true,
   "overrides": {

--- a/ui/src/app/activity/activity.component.css
+++ b/ui/src/app/activity/activity.component.css
@@ -849,3 +849,179 @@
 .approval-state.state-failed { background: rgba(248, 113, 113, 0.14); color: #f87171; }
 .approval-state.state-rejected { background: rgba(248, 113, 113, 0.14); color: #f87171; }
 .approval-state.state-expired { background: rgba(148, 163, 184, 0.14); color: #94a3b8; }
+
+/* ─── Incidents (recovery agent) ─────────────────────────────────── */
+.incidents-panel .panel-header { border-bottom: none; padding-bottom: 8px; }
+
+.incident-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.incident-card {
+  background: rgba(0, 180, 255, 0.03);
+  border: 1px solid var(--border-color, rgba(99, 179, 237, 0.2));
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.incident-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary, #f0f4ff);
+}
+
+/* State chip — same geometry as .approval-state, tone by lifecycle bucket:
+   worked states amber, in-motion states blue, resolved green, failed red,
+   abandoned grey. */
+.incident-state {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.incident-state.istate-working { background: rgba(251, 191, 36, 0.14); color: #fbbf24; }
+.incident-state.istate-active  { background: rgba(0, 180, 255, 0.14); color: var(--accent-cyan, #00b4ff); }
+.incident-state.istate-ok      { background: rgba(74, 222, 128, 0.14); color: #4ade80; }
+.incident-state.istate-err     { background: rgba(248, 113, 113, 0.14); color: #f87171; }
+.incident-state.istate-muted   { background: rgba(148, 163, 184, 0.14); color: #94a3b8; }
+
+.incident-kind {
+  font-size: 12px;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.incident-resource {
+  font-weight: 600;
+  color: var(--text-primary, #f0f4ff);
+}
+
+.incident-classification {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: rgba(192, 132, 252, 0.10);
+  border: 1px solid rgba(192, 132, 252, 0.25);
+  color: #c084fc;
+}
+
+.incident-times {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}
+
+.incident-latest {
+  color: var(--text-secondary, #94a3b8);
+}
+
+/* Timeline — one line per agent step, phase chip on the left. */
+.incident-steps {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 6px 0 0 10px;
+  border-left: 1px solid var(--border-color, rgba(99, 179, 237, 0.15));
+}
+
+.incident-step {
+  padding: 3px 0;
+}
+
+.incident-step-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.incident-phase {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(99, 179, 237, 0.12);
+  color: var(--text-secondary, #94a3b8);
+  min-width: 64px;
+  text-align: center;
+}
+
+.incident-phase.phase-open     { color: #fbbf24; background: rgba(251, 191, 36, 0.12); }
+.incident-phase.phase-diagnose { color: var(--accent-cyan, #00b4ff); background: rgba(0, 180, 255, 0.10); }
+.incident-phase.phase-propose  { color: #c084fc; background: rgba(192, 132, 252, 0.12); }
+.incident-phase.phase-gate     { color: #fbbf24; background: rgba(251, 191, 36, 0.12); }
+.incident-phase.phase-execute  { color: var(--accent-cyan, #00b4ff); background: rgba(0, 180, 255, 0.10); }
+.incident-phase.phase-verify   { color: var(--accent-cyan, #00b4ff); background: rgba(0, 180, 255, 0.10); }
+.incident-phase.phase-close    { color: #4ade80; background: rgba(74, 222, 128, 0.12); }
+
+.incident-step-time {
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+  white-space: nowrap;
+}
+
+.incident-step-summary {
+  color: var(--text-primary, #f0f4ff);
+  word-break: break-word;
+}
+
+.incident-approval-link {
+  font-size: 11px;
+  color: #fbbf24;
+  text-decoration: none;
+  border-bottom: 1px dotted rgba(251, 191, 36, 0.5);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.incident-approval-link:hover { color: #fde68a; }
+
+.incident-detail-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-secondary, #94a3b8);
+  cursor: pointer;
+  text-decoration: underline dotted;
+}
+
+.incident-detail-toggle:hover { color: var(--text-primary, #f0f4ff); }
+
+.incident-step-detail {
+  margin: 4px 0 2px;
+  padding: 8px 10px;
+  background: var(--bg-primary, #0a0e1a);
+  border: 1px solid var(--border-color, rgba(99, 179, 237, 0.15));
+  border-radius: 4px;
+  font-size: 11px;
+  line-height: 1.4;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.incident-confirm-text {
+  font-size: 12px;
+  color: #fbbf24;
+}
+
+.incident-outcome-cell {
+  max-width: 380px;
+  word-break: break-word;
+}

--- a/ui/src/app/activity/activity.component.html
+++ b/ui/src/app/activity/activity.component.html
@@ -150,6 +150,112 @@
     </div>
   </section>
 
+  <!-- Incidents: problems the recovery agent detected and is working (or has
+       closed). Sibling of Approvals — only rendered when RECOVERY_AGENT is on. -->
+  <section class="panel incidents-panel" id="incidents" *ngIf="recoveryEnabled">
+    <div class="panel-header">
+      <h3 class="panel-title">Incidents</h3>
+      <span class="panel-count" [class.panel-count-ok]="openIncidents.length === 0">{{ openIncidents.length }}</span>
+      <span class="panel-sub">problems the recovery agent is working</span>
+      <span class="approvals-spacer"></span>
+      <button class="action-btn action-btn-ghost" (click)="toggleClosedIncidents()">
+        {{ showClosedIncidents ? 'Hide closed' : 'Show closed' }}
+      </button>
+    </div>
+
+    <div class="error-banner approvals-error" *ngIf="incidentsError">{{ incidentsError }}</div>
+
+    <div class="panel-empty" *ngIf="incidentsLoaded && openIncidents.length === 0 && !incidentsError">
+      <span class="panel-empty-check">✓</span> No open incidents.
+    </div>
+
+    <ul class="incident-list" *ngIf="openIncidents.length > 0">
+      <li class="incident-card" *ngFor="let i of openIncidents; trackBy: trackByIncident">
+        <div class="incident-head">
+          <span class="incident-state" [class]="'incident-state ' + incidentStateClass(i.state)">{{ incidentStateLabel(i.state) }}</span>
+          <span class="incident-kind">{{ incidentKindLabel(i) }}</span>
+          <span class="failing-kind" [class.kind-tap]="i.resourceType === 'tap'" [class.kind-pipeline]="i.resourceType === 'pipeline'">
+            {{ i.resourceType }}
+          </span>
+          <span class="incident-resource">{{ i.resource }}</span>
+          <span class="incident-classification" *ngIf="i.classification">{{ i.classification }}</span>
+        </div>
+        <div class="incident-times">
+          opened {{ formatRelative(i.openedAt) }}
+          <ng-container *ngIf="latestStep(i) as last">
+            · latest: <span class="incident-latest">{{ last.summary }}</span>
+          </ng-container>
+        </div>
+
+        <button class="approval-req-toggle" (click)="toggleTimeline(i)">
+          {{ timelineOpen.has(i.id) ? '▾' : '▸' }} Timeline ({{ i.steps.length || 0 }} steps)
+        </button>
+        <ol class="incident-steps" *ngIf="timelineOpen.has(i.id)">
+          <li class="incident-step" *ngFor="let s of i.steps; let si = index">
+            <div class="incident-step-line">
+              <span class="incident-phase" [class]="'incident-phase phase-' + s.phase">{{ s.phase }}</span>
+              <span class="incident-step-time">{{ formatRelative(s.ts) }}</span>
+              <span class="incident-step-summary">{{ s.summary }}</span>
+              <a class="incident-approval-link" *ngIf="s.approvalId" href="#approvals"
+                 (click)="scrollToApprovals($event)"
+                 title="Jump to the Approvals section — this step queued an action for a person">
+                approval {{ s.approvalId }}
+              </a>
+              <button class="incident-detail-toggle" *ngIf="s.detail" (click)="toggleStepDetail(i, si)">
+                {{ stepDetailOpen.has(stepKey(i, si)) ? 'hide detail' : 'detail' }}
+              </button>
+            </div>
+            <pre class="incident-step-detail" *ngIf="s.detail && stepDetailOpen.has(stepKey(i, si))">{{ s.detail }}</pre>
+          </li>
+        </ol>
+
+        <div class="approval-outcome approval-outcome-warn" *ngIf="incidentErrorFor(i) as e">{{ e }}</div>
+
+        <div class="approval-actions" *ngIf="auth.canWrite()">
+          <button class="action-btn action-btn-ghost"
+                  *ngIf="!abandonConfirm.has(i.id)"
+                  [disabled]="isAbandoning(i)"
+                  (click)="openAbandonConfirm(i)"
+                  title="Stop the agent working this incident and close it">
+            Abandon
+          </button>
+          <ng-container *ngIf="abandonConfirm.has(i.id)">
+            <span class="incident-confirm-text">Close this incident without further agent action?</span>
+            <button class="action-btn approval-reject-confirm"
+                    [disabled]="isAbandoning(i)"
+                    (click)="abandon(i)">
+              <span class="action-spinner" *ngIf="isAbandoning(i)"></span>
+              {{ isAbandoning(i) ? 'Working…' : 'Confirm abandon' }}
+            </button>
+            <button class="action-btn action-btn-ghost"
+                    [disabled]="isAbandoning(i)"
+                    (click)="openAbandonConfirm(i)">
+              Cancel
+            </button>
+          </ng-container>
+        </div>
+      </li>
+    </ul>
+
+    <div class="approval-decided" *ngIf="showClosedIncidents">
+      <div class="panel-empty" *ngIf="closedIncidents.length === 0">No closed incidents yet.</div>
+      <table class="approval-decided-table" *ngIf="closedIncidents.length > 0">
+        <thead>
+          <tr><th>State</th><th>Kind</th><th>Resource</th><th>Outcome</th><th>Closed at</th></tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let i of closedIncidents; trackBy: trackByIncident">
+            <td><span class="incident-state" [class]="'incident-state ' + incidentStateClass(i.state)">{{ incidentStateLabel(i.state) }}</span></td>
+            <td>{{ incidentKindLabel(i) }}</td>
+            <td>{{ i.resourceType }} {{ i.resource }}</td>
+            <td class="incident-outcome-cell">{{ i.outcome || '—' }}</td>
+            <td>{{ formatTs(i.closedAt) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
   <!-- Region 2: timeline charts -->
   <section class="timeline-row">
     <div class="chart-card">

--- a/ui/src/app/activity/activity.component.ts
+++ b/ui/src/app/activity/activity.component.ts
@@ -11,6 +11,7 @@ import { OpsChatContextService } from '../ops-chat/ops-chat-context.service';
 import { OpsActionBus } from '../ops-chat/ops-action-bus.service';
 import { OpsAssistantStateService } from '../ops-chat/ops-assistant-state.service';
 import { Approval, ApprovalsService } from '../approvals.service';
+import { ActivitySignals, Incident, IncidentsService } from '../incidents.service';
 
 type Window = '24h' | '7d' | '30d';
 
@@ -130,6 +131,33 @@ export class ActivityComponent implements OnInit, OnDestroy {
   decisionOutcome = new Map<string, { tone: 'ok' | 'err' | 'warn'; text: string; detail?: string }>();
   private approvalsScrollPending = false;
 
+  // ── Incidents (recovery agent) ────────────────────────────────────────────
+  // Only rendered when RECOVERY_AGENT is on. Open incidents are problems the
+  // agent detected and is working (or waiting on a person for); closed ones
+  // are shown behind a toggle. Refreshed on the same 30s cycle as the rest of
+  // the dashboard and immediately after an abandon made here.
+  recoveryEnabled = false;
+  openIncidents: Incident[] = [];
+  closedIncidents: Incident[] = [];
+  showClosedIncidents = false;
+  incidentsError = '';
+  incidentsLoaded = false;
+  /** Incident ids whose timeline is expanded. */
+  timelineOpen = new Set<string>();
+  /** "incidentId:stepIndex" keys whose step detail is expanded. */
+  stepDetailOpen = new Set<string>();
+  /** Incident ids with the inline abandon confirmation showing. */
+  abandonConfirm = new Set<string>();
+  /** Incident ids with an abandon call in flight. */
+  abandoning = new Set<string>();
+  /** Per-incident error banner after a failed abandon from this page. */
+  incidentActionError = new Map<string, string>();
+
+  // Latest server-side signals response (null until the first successful
+  // fetch, or when the endpoint errors — client-computed values are the
+  // fallback so the dashboard never breaks).
+  private serverSignals: ActivitySignals | null = null;
+
   constructor(
     private tapService: TapService,
     private pipelineService: PipelineService,
@@ -140,6 +168,7 @@ export class ActivityComponent implements OnInit, OnDestroy {
     private opsActionBus: OpsActionBus,
     private opsState: OpsAssistantStateService,
     private approvalsService: ApprovalsService,
+    private incidentsService: IncidentsService,
     private route: ActivatedRoute
   ) {}
 
@@ -151,6 +180,10 @@ export class ActivityComponent implements OnInit, OnDestroy {
     this.approvalsService.policyEnabled().subscribe(on => {
       this.policyEnabled = on;
       if (on) this.loadApprovals();
+    });
+    this.incidentsService.recoveryEnabled().subscribe(on => {
+      this.recoveryEnabled = on;
+      if (on) this.loadIncidents();
     });
     this.loadData();
     this.refreshTimer = setInterval(() => this.loadData(true), this.REFRESH_MS);
@@ -197,6 +230,7 @@ export class ActivityComponent implements OnInit, OnDestroy {
       this.loadError = '';
     }
     if (this.policyEnabled) this.loadApprovals();
+    if (this.recoveryEnabled) this.loadIncidents();
 
     try {
       // Pull tap logs covering both the current window and the prior window so the
@@ -204,12 +238,17 @@ export class ActivityComponent implements OnInit, OnDestroy {
       // the server — single round trip regardless of tap count.
       const sinceMs = Date.now() - 2 * this.windowMs();
 
-      const { taps, pipelines, jobsFirstPage, tapLogs } = await firstValueFrom(forkJoin({
+      const { taps, pipelines, jobsFirstPage, tapLogs, signals } = await firstValueFrom(forkJoin({
         taps: this.tapService.getTaps().pipe(catchError(() => of([] as any[]))),
         pipelines: this.pipelineService.getPipelines().pipe(catchError(() => of([] as any[]))),
         jobsFirstPage: this.pipelineStatusService.getPipelineStatus(1).pipe(catchError(() => of([] as PipelineStatus[]))),
-        tapLogs: this.tapService.getAllTapLogsSince(sinceMs).pipe(catchError(() => of([] as any[])))
+        tapLogs: this.tapService.getAllTapLogsSince(sinceMs).pipe(catchError(() => of([] as any[]))),
+        // Server-side signals (same detection the recovery agent runs). null on
+        // error — the client-computed values below are the fallback so the
+        // dashboard never breaks when the endpoint is unavailable.
+        signals: this.incidentsService.signals(this.window).pipe(catchError(() => of(null as ActivitySignals | null)))
       }));
+      this.serverSignals = signals;
 
       // Page through pipeline status until we cover the prior window too (for the
       // "vs prior" delta), capped to avoid runaway requests on chatty tenants.
@@ -227,7 +266,20 @@ export class ActivityComponent implements OnInit, OnDestroy {
       this.computeTiles(jobs, tapFailures);
       this.computeFailing(taps || [], pipelines || [], jobs, tapFailures);
       this.computeSuccessful(pipelines || [], jobs);
-      this.computeStale(taps || []);
+      // Stale-taps panel prefers the server's detection (it's what the
+      // recovery agent acts on, so panel and agent agree); the client-side
+      // heuristic remains the fallback when the endpoint errored.
+      if (signals?.staleTaps) {
+        this.stale = signals.staleTaps.map(s => ({
+          name: s.name,
+          catalog: s.catalog || null,
+          cadenceLabel: s.cadenceLabel,
+          cadenceMs: s.cadenceMs,
+          lastRunIso: s.lastRunIso || null
+        }));
+      } else {
+        this.computeStale(taps || []);
+      }
       this.computeCharts(jobs, tapFailures);
       this.computePipelineVolumes(pipelines || [], jobs);
       // Fresh data landed — chat-triggered optimistic spinners can clear,
@@ -430,13 +482,211 @@ export class ActivityComponent implements OnInit, OnDestroy {
     return a.id;
   }
 
+  // ── Incidents (recovery agent) ────────────────────────────────────────────
+
+  loadIncidents(): void {
+    // state=open covers every active state (open … verifying).
+    this.incidentsService.list('open', 100).subscribe({
+      next: (page) => {
+        this.recoveryEnabled = page.enabled !== false;
+        this.openIncidents = page.incidents || [];
+        this.incidentsLoaded = true;
+        this.incidentsError = '';
+        // Drop stale per-card state for incidents that left the open list.
+        const ids = new Set(this.openIncidents.map(i => i.id));
+        for (const id of Array.from(this.timelineOpen)) if (!ids.has(id)) this.timelineOpen.delete(id);
+        for (const id of Array.from(this.abandonConfirm)) if (!ids.has(id)) this.abandonConfirm.delete(id);
+        for (const key of Array.from(this.stepDetailOpen)) {
+          if (!ids.has(key.slice(0, key.lastIndexOf(':')))) this.stepDetailOpen.delete(key);
+        }
+      },
+      error: (err) => {
+        this.incidentsLoaded = true;
+        this.incidentsError = err?.error?.error || 'Failed to load incidents';
+      }
+    });
+    if (this.showClosedIncidents) this.loadClosedIncidents();
+  }
+
+  private loadClosedIncidents(): void {
+    // The server lists newest first; ask for enough to fill 15 after
+    // filtering out whatever is still active.
+    this.incidentsService.list(undefined, 60).subscribe({
+      next: (page) => {
+        this.closedIncidents = (page.incidents || [])
+          .filter(i => this.isClosedIncident(i))
+          .slice(0, 15);
+      },
+      error: () => { /* keep the last list; the open fetch reports errors */ }
+    });
+  }
+
+  toggleClosedIncidents(): void {
+    this.showClosedIncidents = !this.showClosedIncidents;
+    if (this.showClosedIncidents) this.loadClosedIncidents();
+  }
+
+  isClosedIncident(i: Incident): boolean {
+    return i.state === 'resolved' || i.state === 'failed' || i.state === 'abandoned';
+  }
+
+  incidentKindLabel(i: Incident): string {
+    switch (i.kind) {
+      case 'tap_failure': return 'tap failure';
+      case 'pipeline_failure': return 'pipeline failure';
+      case 'stale': return 'stale';
+      case 'volume': return 'volume';
+      default: return i.kind;
+    }
+  }
+
+  /** Tone bucket for the state chip: worked states amber, in-motion states
+   *  blue, resolved green, failed red, abandoned grey. */
+  incidentStateClass(state: string): string {
+    switch (state) {
+      case 'executing':
+      case 'verifying': return 'istate-active';
+      case 'resolved': return 'istate-ok';
+      case 'failed': return 'istate-err';
+      case 'abandoned': return 'istate-muted';
+      default: return 'istate-working';   // open / diagnosing / proposed / awaiting_approval
+    }
+  }
+
+  /** Human label for the chip — underscores read poorly in a 10px chip. */
+  incidentStateLabel(state: string): string {
+    return state.replace(/_/g, ' ');
+  }
+
+  latestStep(i: Incident): { summary: string; ts: string | null } | null {
+    if (!i.steps || i.steps.length === 0) return null;
+    const s = i.steps[i.steps.length - 1];
+    return { summary: s.summary, ts: s.ts || null };
+  }
+
+  toggleTimeline(i: Incident): void {
+    if (this.timelineOpen.has(i.id)) this.timelineOpen.delete(i.id);
+    else this.timelineOpen.add(i.id);
+  }
+
+  stepKey(i: Incident, idx: number): string {
+    return i.id + ':' + idx;
+  }
+
+  toggleStepDetail(i: Incident, idx: number): void {
+    const key = this.stepKey(i, idx);
+    if (this.stepDetailOpen.has(key)) this.stepDetailOpen.delete(key);
+    else this.stepDetailOpen.add(key);
+  }
+
+  /** "approval <id>" link on a gate step — jumps to the Approvals section,
+   *  which shows the queued action the incident is waiting on. */
+  scrollToApprovals(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    document.getElementById('approvals')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  openAbandonConfirm(i: Incident): void {
+    if (this.abandonConfirm.has(i.id)) this.abandonConfirm.delete(i.id);
+    else this.abandonConfirm.add(i.id);
+  }
+
+  isAbandoning(i: Incident): boolean {
+    return this.abandoning.has(i.id);
+  }
+
+  incidentErrorFor(i: Incident): string | undefined {
+    return this.incidentActionError.get(i.id);
+  }
+
+  abandon(i: Incident): void {
+    if (this.abandoning.has(i.id)) return;
+    this.abandoning.add(i.id);
+    this.incidentActionError.delete(i.id);
+    this.incidentsService.abandon(i.id).subscribe({
+      next: () => {
+        this.abandoning.delete(i.id);
+        this.abandonConfirm.delete(i.id);
+        this.loadIncidents();
+      },
+      error: (err) => {
+        this.abandoning.delete(i.id);
+        this.abandonConfirm.delete(i.id);
+        const body = err?.error || {};
+        if (err?.status === 409) {
+          // Already closed (the agent finished, or someone else abandoned it)
+          // — the refresh below moves the card out of the open list.
+          this.incidentActionError.set(i.id, body.message || body.error || 'Already closed.');
+        } else {
+          this.incidentActionError.set(i.id, body.error || body.message || 'Abandon failed.');
+        }
+        this.loadIncidents();
+      }
+    });
+  }
+
+  trackByIncident(_i: number, inc: Incident): string {
+    return inc.id;
+  }
+
   /** Push a compact dashboard snapshot to the chat panel's context service.
    *  Top-N caps keep the system prompt bounded — the chat doesn't need
-   *  every row, just enough to ground its answers in the current state. */
+   *  every row, just enough to ground its answers in the current state.
+   *
+   *  Stale taps and volume anomalies come from the server's signals endpoint
+   *  when it responded (same detection the recovery agent runs, so the chat
+   *  and the agent agree on what's stale/anomalous); the client-computed
+   *  values are the fallback when it errored. failingItems stays
+   *  client-computed — it feeds the Failures panel's row actions too. */
   private publishOpsContext(): void {
     const TOP_FAILING = 20;
     const TOP_STALE = 10;
     const TOP_VOLUMES = 15;
+    const signals = this.serverSignals;
+
+    const staleTaps = signals?.staleTaps
+      ? signals.staleTaps.slice(0, TOP_STALE).map(s => ({
+          name: s.name,
+          catalog: s.catalog || null,
+          cadenceLabel: s.cadenceLabel,
+          lastRunIso: s.lastRunIso || null
+        }))
+      : this.stale.slice(0, TOP_STALE).map(s => ({
+          name: s.name,
+          catalog: s.catalog,
+          cadenceLabel: s.cadenceLabel,
+          lastRunIso: s.lastRunIso
+        }));
+
+    // Server path: the signals endpoint already filters to anomalies, so the
+    // chat sees only the volumes worth reasoning about. Client fallback:
+    // sort by largest |deltaPct| first so anomalies — over- and under-volume
+    // — come before the long tail of pipelines running at their usual rate.
+    const pipelineVolumes = signals?.anomalies
+      ? signals.anomalies.slice(0, TOP_VOLUMES).map(v => ({
+          name: v.name,
+          catalog: v.catalog || null,
+          current: v.current,
+          prior: v.prior,
+          deltaPct: v.deltaPct == null ? null : v.deltaPct
+        }))
+      : this.pipelineVolumes
+          .slice()
+          .sort((a, b) => {
+            const da = a.deltaPct == null ? -1 : Math.abs(a.deltaPct);
+            const db = b.deltaPct == null ? -1 : Math.abs(b.deltaPct);
+            return db - da;
+          })
+          .slice(0, TOP_VOLUMES)
+          .map(v => ({
+            name: v.name,
+            catalog: v.catalog,
+            current: v.current,
+            prior: v.prior,
+            deltaPct: v.deltaPct
+          }));
+
     this.opsContext.publish({
       window: this.window,
       failingItems: this.failing.slice(0, TOP_FAILING).map(f => ({
@@ -450,30 +700,8 @@ export class ActivityComponent implements OnInit, OnDestroy {
         relatedTapName: f.relatedTapName,
         pipelineToken: f.pipelineToken
       })),
-      staleTaps: this.stale.slice(0, TOP_STALE).map(s => ({
-        name: s.name,
-        catalog: s.catalog,
-        cadenceLabel: s.cadenceLabel,
-        lastRunIso: s.lastRunIso
-      })),
-      // Volumes sorted by largest |deltaPct| first so the chat sees
-      // anomalies — over- and under-volume — before the long tail of
-      // pipelines running at their usual rate.
-      pipelineVolumes: this.pipelineVolumes
-        .slice()
-        .sort((a, b) => {
-          const da = a.deltaPct == null ? -1 : Math.abs(a.deltaPct);
-          const db = b.deltaPct == null ? -1 : Math.abs(b.deltaPct);
-          return db - da;
-        })
-        .slice(0, TOP_VOLUMES)
-        .map(v => ({
-          name: v.name,
-          catalog: v.catalog,
-          current: v.current,
-          prior: v.prior,
-          deltaPct: v.deltaPct
-        }))
+      staleTaps,
+      pipelineVolumes
     });
   }
 

--- a/ui/src/app/incidents.service.ts
+++ b/ui/src/app/incidents.service.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+
+export type IncidentKind = 'tap_failure' | 'pipeline_failure' | 'stale' | 'volume';
+
+/** Full lifecycle of a recovery-agent incident. `open` through `verifying`
+ *  are active states; `resolved` / `failed` / `abandoned` are terminal. */
+export type IncidentState =
+  | 'open' | 'diagnosing' | 'proposed' | 'awaiting_approval'
+  | 'executing' | 'verifying'
+  | 'resolved' | 'failed' | 'abandoned';
+
+/** One entry in an incident's timeline — the agent appends a step for every
+ *  phase transition (open → diagnose → propose → gate → execute → verify →
+ *  close). Steps that queued a gated action carry the approval's id. */
+export interface IncidentStep {
+  ts: string;
+  phase: 'open' | 'diagnose' | 'propose' | 'gate' | 'execute' | 'verify' | 'close';
+  summary: string;
+  detail?: string;
+  approvalId?: string;
+}
+
+/** One incident as returned by GET /api/v1/incidents. */
+export interface Incident {
+  id: string;
+  kind: IncidentKind;
+  resourceType: 'tap' | 'pipeline';
+  resource: string;
+  openedAt: string;
+  state: IncidentState;
+  trigger: any;
+  steps: IncidentStep[];
+  classification?: string;
+  proposal?: any;
+  aiCalls: number;
+  actionsTaken: number;
+  awaitingApprovalIds?: string[];
+  closedAt?: string;
+  outcome?: string;
+}
+
+export interface IncidentsPage {
+  enabled: boolean;
+  incidents: Incident[];
+}
+
+// ── Server-side dashboard signals (GET /api/v1/activity/signals) ────────────
+// The same detection the recovery agent runs on the server, exposed so the
+// dashboard's chat context (and optionally its panels) agree with what the
+// agent sees.
+
+export interface SignalFailing {
+  kind: 'tap' | 'pipeline';
+  name: string;
+  catalog?: string;
+  reason: string;
+  timeIso?: string;
+  recovered: boolean;
+  failureCount: number;
+  pipelineToken?: string;
+  relatedTapName?: string;
+}
+
+export interface SignalStaleTap {
+  name: string;
+  catalog?: string;
+  cadenceLabel: string;
+  cadenceMs: number;
+  lastRunIso?: string;
+}
+
+export interface SignalVolume {
+  name: string;
+  catalog?: string;
+  current: number;
+  prior: number;
+  priorRuns: number;
+  deltaPct?: number;
+  anomaly: boolean;
+}
+
+export interface ActivitySignals {
+  windowMs: number;
+  computedAt: string;
+  failing: SignalFailing[];
+  staleTaps: SignalStaleTap[];
+  volumes: SignalVolume[];
+  /** `volumes` filtered to anomalous entries only. */
+  anomalies: SignalVolume[];
+}
+
+/** Shared by the Activity → Incidents section. Same style as ApprovalsService. */
+@Injectable({ providedIn: 'root' })
+export class IncidentsService {
+  private enabled$?: Observable<boolean>;
+
+  constructor(private http: HttpClient) {}
+
+  /** RECOVERY_AGENT flag from /api/v1/version, fetched once per app life. */
+  recoveryEnabled(): Observable<boolean> {
+    if (!this.enabled$) {
+      this.enabled$ = this.http.get<any>('/api/v1/version').pipe(
+        map(v => String(v?.recoveryAgentEnabled) === 'true'),
+        catchError(() => of(false)),
+        shareReplay(1)
+      );
+    }
+    return this.enabled$;
+  }
+
+  /** Newest first. `state` may be "open" (any active state) or a specific one. */
+  list(state?: string, limit?: number): Observable<IncidentsPage> {
+    let p = new HttpParams();
+    if (state) p = p.set('state', state);
+    if (limit) p = p.set('limit', String(limit));
+    return this.http.get<IncidentsPage>('/api/v1/incidents', { params: p });
+  }
+
+  get(id: string): Observable<Incident> {
+    return this.http.get<Incident>('/api/v1/incidents/' + encodeURIComponent(id));
+  }
+
+  /** Close an active incident without further agent action. 409 when the
+   *  incident already reached a terminal state. Admin/editor only. */
+  abandon(id: string): Observable<Incident> {
+    return this.http.post<Incident>('/api/v1/incidents/' + encodeURIComponent(id) + '/abandon', {});
+  }
+
+  /** Server-computed dashboard signals for the given window (24h/7d/30d). */
+  signals(window: '24h' | '7d' | '30d'): Observable<ActivitySignals> {
+    const p = new HttpParams().set('window', window);
+    return this.http.get<ActivitySignals>('/api/v1/activity/signals', { params: p });
+  }
+}

--- a/ui/src/app/mcp/mcp.component.ts
+++ b/ui/src/app/mcp/mcp.component.ts
@@ -61,7 +61,9 @@ export class McpComponent implements OnInit {
   playgroundResult = '';
   paramOptions: Record<string, string[]> = {};  // options for select params
 
-  // Full tool catalog
+  // Full tool catalog.
+  // KEEP IN SYNC with mcp-server/server.py's _base_tools() and the server's
+  // auth/MCPToolRoutes.scala — one entry here per MCP tool (70 as of v1.25).
   toolCatalog: McpTool[] = [
     // --- System ---
     {
@@ -390,6 +392,25 @@ export class McpComponent implements OnInit {
       playgroundEnabled: true
     },
     {
+      name: 'get_dest_types',
+      description: 'Propose real destination column types for a pipeline whose columns landed as text. Types are inferred from the data already loaded, with sample values per column and the offending value named when a column must stay text. Postgres, Snowflake, and Databricks destinations only.',
+      category: 'Pipeline Management',
+      parameters: [
+        { name: 'pipeline', type: 'string', description: 'Pipeline name', required: true, inputType: 'text' }
+      ],
+      playgroundEnabled: true
+    },
+    {
+      name: 'apply_dest_types',
+      description: 'Apply destination column types to an all-string pipeline. REQUIRES explicit user approval first. Landed data is migrated before the config changes; any value that will not cast fails the whole apply with the column named and nothing changed. `fields` must list EVERY destination column with its intended type.',
+      category: 'Pipeline Management',
+      parameters: [
+        { name: 'pipeline', type: 'string', description: 'Pipeline name', required: true, inputType: 'text' },
+        { name: 'fields', type: 'array', description: 'Every destination column as {"name": ..., "type": ...}. Types: string, boolean, int, bigint, float, double, date, timestamp.', required: true, inputType: 'textarea' }
+      ],
+      playgroundEnabled: false
+    },
+    {
       name: 'profile_data',
       description: 'Send data and use AI to generate a comprehensive data profile: summary statistics per column, data quality issues detected, and suggested validation rules. Use the suggested aiRule when building a pipeline\'s dataQuality section.',
       category: 'Pipeline Management',
@@ -705,6 +726,53 @@ export class McpComponent implements OnInit {
       parameters: [
         { name: 'name', type: 'string', description: 'Secret name: anthropic, openai, azure, grok, ollama, or embedding', required: true, inputType: 'text' },
         { name: 'fields', type: 'object', description: 'JSON with endpoint, model, apiKey fields', required: true, inputType: 'textarea' }
+      ],
+      playgroundEnabled: true
+    },
+    // --- Agent Policy ---
+    {
+      name: 'get_agent_policy',
+      description: "Read this instance's agent policy: for each action whether an agent may do it on its own (auto), must wait for a person to approve it (approve), or is refused (deny) — plus the recovery agent's mode and limits. Call before a delete or destination-type migration to know whether it will run or queue. When the policy is disabled, every action is auto.",
+      category: 'Agent Policy',
+      parameters: [],
+      playgroundEnabled: true
+    },
+    {
+      name: 'list_pending_approvals',
+      description: 'List the actions this agent queued for human approval, newest first — id, action, resource, state (pending | approved | rejected | expired | executed | failed), and the decision once made.',
+      category: 'Agent Policy',
+      parameters: [
+        { name: 'state', type: 'string', description: 'Filter by state (pending, approved, rejected, expired, executed, failed). Omit for all.', required: false, inputType: 'text' },
+        { name: 'limit', type: 'integer', description: 'Maximum entries to return (default 100)', required: false, inputType: 'number' }
+      ],
+      playgroundEnabled: true
+    },
+    {
+      name: 'get_approval',
+      description: "Poll one queued approval by the approvalId a mutating tool returned with status pending_approval. Returns pending, executed (with the original call's result), failed, rejected, or expired.",
+      category: 'Agent Policy',
+      parameters: [
+        { name: 'approval_id', type: 'string', description: 'The approvalId returned with pending_approval', required: true, inputType: 'text' }
+      ],
+      playgroundEnabled: true
+    },
+    // --- Incidents ---
+    {
+      name: 'list_incidents',
+      description: "List the platform's recovery-agent incidents, newest first — opened by the platform itself for failed, stale, or anomalous data flows, with kind, resource, state, classification, and a step-by-step narrative. Read-only: only the platform opens incidents.",
+      category: 'Incidents',
+      parameters: [
+        { name: 'state', type: 'string', description: 'Filter: open (any active state) or a specific state name. Omit for all.', required: false, inputType: 'text' },
+        { name: 'limit', type: 'integer', description: 'Maximum incidents to return (default 50)', required: false, inputType: 'number' }
+      ],
+      playgroundEnabled: true
+    },
+    {
+      name: 'get_incident',
+      description: 'Read one recovery-agent incident by id — its trigger, classification, proposal, step-by-step narrative, approvals it waits on, and outcome.',
+      category: 'Incidents',
+      parameters: [
+        { name: 'incident_id', type: 'string', description: 'The incident id (inc_…)', required: true, inputType: 'text' }
       ],
       playgroundEnabled: true
     },

--- a/ui/src/app/ops-chat/ops-chat-context.service.ts
+++ b/ui/src/app/ops-chat/ops-chat-context.service.ts
@@ -7,7 +7,14 @@ import { Injectable } from '@angular/core';
 export interface OpsChatContext {
   window: '24h' | '7d' | '30d';
   failingItems: OpsChatFailing[];
+  /** Sourced from the server's GET /api/v1/activity/signals staleTaps (the
+   *  same detection the recovery agent runs) when the endpoint responds;
+   *  Activity's client-side heuristic is the fallback so the dashboard —
+   *  and this snapshot — never break when it errors. */
   staleTaps: OpsChatStale[];
+  /** Sourced from the signals endpoint's `anomalies` (server-filtered to
+   *  volumes worth reasoning about) when it responds; falls back to the
+   *  client-computed per-pipeline volumes sorted by |deltaPct|. */
   pipelineVolumes: OpsChatVolume[];
 }
 


### PR DESCRIPTION
## What

Phase B of the agent control plane. When a scheduled tap finally fails (retry ladder exhausted), a pipeline job errors, a tap goes stale, or a pipeline's volume swings, the platform opens an **incident**, diagnoses it with the Ops assistant's judgment, and — within the agent policy's recovery mode and limits — repairs and verifies it. **The LLM proposes; deterministic code decides.**

- **Loop** (`ai.datris.incident`): diagnosis runs a headless AgentLoop over the shared `OpsAgentPrompt` with READ-ONLY tools and must end in a JSON proposal (classification / needsHuman / actions). Code then filters actions to script-replace / test / run, pins each to the incident's own resource, caps the count, executes each as **one direct REST call** (one action = one gateable, replayable request — composite MCP tools are deliberately not used to act), verifies via a healthy real run + completed pipeline rollup, and **reverts the tap definition when verification fails**. Cooldowns, one-incident-per-resource, and runtime/AI-call/action limits are all enforced in code.
- **Policy integration**: the policy doc gains `recovery { mode: off | propose | autopilot, limits }` plus per-resource recovery overrides. `PolicyInterceptor` force-queues (propose) or refuses (off) incident-tagged mutations — the runner cannot bypass its own dial. Approvals carry the incident id; the sweep resumes incidents when approvals are decided.
- **Identity & audit**: actions run as an auto-issued `recovery-agent` API key; every call carries `X-Datris-Incident`, making the audit log the incident's ledger.
- **Signals server-side**: `ActivitySignals` ports the dashboard's failures / stale / volume-anomaly logic to the server (`GET /api/v1/activity/signals`) — one definition shared by the UI, the Ops chat context, and the sweep.
- **Surfaces**: incidents REST (list/get/abandon), MCP `list_incidents` / `get_incident` (catalog 70), Activity → Incidents lane with step timelines and approval links, Ops-chat context includes open incidents, optional `INCIDENT_WEBHOOK_URL`, Prometheus counters/durations.
- **Flags**: `RECOVERY_AGENT_ENABLED` (default off; requires `USE_AGENT_POLICY`). With it off — or on with recovery mode `off` — behavior is unchanged.
- Also: MCP Connect tab caught up with the full tool catalog (incl. `get_dest_types`/`apply_dest_types`, missing since v1.22), and CI gained a three-way catalog drift guard (`scripts/check-mcp-tool-catalog.py`).

## Testing

- `sbt test`: 357/357 (new: `IncidentRunnerSpec`, `ActivitySignalsSpec`, `RecoveryPolicySpec`).
- Live E2E on compose, 7 rounds: **autopilot** open→diagnose→script-replace→test→run→verify→resolved with zero approvals; **propose** chained 4 approvals to resolved; **stale sweep** opened+resolved; **volume anomalies** triaged diagnosis-only (including three real ones on dev pipelines, correctly); needs-human honesty; **failed verification reverted the definition**; off-mode denial mid-incident; full audit ledger joined by `incidentId`; MCP reads.
- `ng build` clean; catalog drift guard green (70 = 70 = 70) and negative-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)