### PR TITLE
Provenance on data, lineage, find_data (agent control plane Phase C)

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/api/CatalogFindAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/CatalogFindAPIController.scala
@@ -1,0 +1,81 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.auth.CapabilityCheck
+import ai.datris.model.{DatrisEnvironment, PipelineConfig, TapConfig}
+import ai.datris.util.{CatalogFind, PipelineConfigIO, TapConfigIO}
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Dataset discovery (`find_data`): rank the pipelines this caller may read by
+  * relevance to a query and return location, freshness, provenance handles and
+  * a pre-filled `howToQuery` hint. Discovery only — nothing is executed on the
+  * caller's behalf; the query call is the agent's own, under its own
+  * capabilities. */
+@RestController
+@RequestMapping(Array("/api/v1/catalog"))
+class CatalogFindAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[CatalogFindAPIController])
+    private val gson = new Gson()
+
+    @GetMapping(path = Array("/find"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def find(
+        @RequestParam(name = "query") query: String,
+        @RequestParam(name = "limit", required = false) limit: java.lang.Integer,
+        @RequestParam(name = "ai", required = false) ai: java.lang.Boolean,
+        request: HttpServletRequest
+    ): ResponseEntity[String] = {
+        try {
+            if (query == null || query.trim.isEmpty)
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String]("{\"error\":\"query is required\"}")
+
+            val env = DatrisEnvironment.current
+            val pipelines =
+                try PipelineConfigIO.readAll(env.pipelineTableName)
+                catch { case _: Exception => Nil }
+            val taps =
+                try TapConfigIO.readAll(env.tapTableName)
+                catch { case _: Exception => Nil }
+
+            // Per-item capability filter: a hit is visible only when the key
+            // could read that pipeline (catalog/owner scopes included).
+            val visible = pipelines.filter(p => p != null && CapabilityCheck.grants(request, "pipeline", "read", scopeContext(p)))
+
+            val result = CatalogFind.find(
+                query.trim,
+                if (limit != null) limit.intValue() else CatalogFind.DefaultLimit,
+                ai != null && ai.booleanValue(),
+                visible,
+                taps.filter(t => t != null && CapabilityCheck.grants(request, "tap", "read", tapScopeContext(t)))
+            )
+            new ResponseEntity[String](gson.toJson(result), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error in catalog find: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body[String]("{\"error\":\"" + Option(e.getMessage).getOrElse("").replace("\"", "'") + "\"}")
+        }
+    }
+
+    private def scopeContext(p: PipelineConfig): Map[String, String] = {
+        var ctx = Map.empty[String, String]
+        if (p.catalog != null && p.catalog.nonEmpty) ctx += ("catalog" -> p.catalog)
+        if (p.createdByKeyLabel != null && p.createdByKeyLabel.nonEmpty) ctx += ("owner" -> p.createdByKeyLabel)
+        ctx
+    }
+
+    private def tapScopeContext(t: TapConfig): Map[String, String] = {
+        var ctx = Map.empty[String, String]
+        if (t.catalog != null && t.catalog.nonEmpty) ctx += ("catalog" -> t.catalog)
+        if (t.createdByKeyLabel != null && t.createdByKeyLabel.nonEmpty) ctx += ("owner" -> t.createdByKeyLabel)
+        ctx
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/api/LineageAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/LineageAPIController.scala
@@ -1,0 +1,60 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.LineageService
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Deterministic lineage views built from configuration alone (see
+  * [[LineageService]]). Read-only. Node types: source, tap, pipeline,
+  * dataset, catalog. */
+@RestController
+@RequestMapping(Array("/api/v1/lineage"))
+class LineageAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[LineageAPIController])
+    private val gson = new Gson()
+
+    private val nodeTypes = Set("source", "tap", "pipeline", "dataset", "catalog")
+
+    @GetMapping(path = Array(""), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def wholeGraph(): ResponseEntity[String] = {
+        try {
+            new ResponseEntity[String](gson.toJson(LineageService.graph().toJson), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error building lineage graph: " + Throwables.getStackTraceAsString(e))
+                error500(e)
+        }
+    }
+
+    @GetMapping(path = Array("/{nodeType}/{name}"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def neighborhood(@PathVariable nodeType: String, @PathVariable name: String): ResponseEntity[String] = {
+        try {
+            val t = Option(nodeType).map(_.trim.toLowerCase).getOrElse("")
+            if (!nodeTypes.contains(t))
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body[String]("{\"error\":\"type must be one of source, tap, pipeline, dataset, catalog\"}")
+            val result = LineageService.neighborhood(t, name)
+            if (result == null)
+                ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body[String]("{\"error\":\"no such node: " + t + ":" + Option(name).getOrElse("").replace("\"", "'") + "\"}")
+            else
+                new ResponseEntity[String](gson.toJson(result), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error building lineage neighborhood: " + Throwables.getStackTraceAsString(e))
+                error500(e)
+        }
+    }
+
+    private def error500(e: Exception): ResponseEntity[String] =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body[String]("{\"error\":\"" + Option(e.getMessage).getOrElse("").replace("\"", "'") + "\"}")
+}

--- a/datrisserver/src/main/scala/ai/datris/api/PipelineAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/PipelineAPIController.scala
@@ -128,9 +128,19 @@ class PipelineAPIController {
 
             // Definition-edit write → mints a new immutable version snapshot.
             val existing = PipelineConfigIO.read(DatrisEnvironment.current.pipelineTableName, tagged.name)
+            // Tags/provenance preservation: clients rebuild the body from
+            // scratch, so a body that omits these entirely must not wipe them
+            // on an unrelated edit. An explicit empty list / stamp=false in the
+            // body still clears/disables.
+            val preserved = if (existing != null)
+                tagged.copy(
+                    tags = if (tagged.tags == null) existing.tags else tagged.tags,
+                    provenance = if (tagged.provenance == null) existing.provenance else tagged.provenance
+                )
+            else tagged
             val note = if (changeNote != null && changeNote.nonEmpty) changeNote
             else if (existing != null) "updated" else "created"
-            PipelineConfigIO.writeVersioned(tagged, note, VersionActor.resolve(request))
+            PipelineConfigIO.writeVersioned(preserved, note, VersionActor.resolve(request))
 
             // If the source is a database, initialize the pipeline pull table
             if (modifiedConfig.source.databaseAttributes != null)

--- a/datrisserver/src/main/scala/ai/datris/api/ProvenanceAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/ProvenanceAPIController.scala
@@ -1,0 +1,48 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.ProvenanceResolver
+import com.google.common.base.Throwables
+import com.google.gson.Gson
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** Resolves a stamped `_datris_run_id` back to the run, tap run, script commit,
+  * config version and source that produced it (see [[ProvenanceResolver]]).
+  * Read-only; wrapped by the `get_provenance` MCP tool. */
+@RestController
+@RequestMapping(Array("/api/v1"))
+class ProvenanceAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[ProvenanceAPIController])
+    private val gson = new Gson()
+
+    @GetMapping(path = Array("/provenance"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def provenance(
+        @RequestParam(name = "runId") runId: String,
+        @RequestParam(name = "pipeline", required = false) pipeline: String,
+        @RequestParam(name = "tapRun", required = false) tapRun: String,
+        @RequestParam(name = "configVersion", required = false) configVersion: java.lang.Integer
+    ): ResponseEntity[String] = {
+        try {
+            if (runId == null || runId.trim.isEmpty)
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body[String]("{\"error\":\"runId is required\"}")
+            val resolved = ProvenanceResolver.resolve(
+                if (pipeline != null) pipeline.trim else null,
+                runId.trim,
+                if (tapRun != null) tapRun.trim else null,
+                configVersion
+            )
+            new ResponseEntity[String](gson.toJson(resolved), HttpStatus.OK)
+        } catch {
+            case e: Exception =>
+                logger.error("Error resolving provenance: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body[String]("{\"error\":\"" + Option(e.getMessage).getOrElse("").replace("\"", "'") + "\"}")
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/api/QueryAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/QueryAPIController.scala
@@ -328,6 +328,11 @@ class QueryAPIController {
             val gson = new Gson
             val response = new java.util.LinkedHashMap[String, Any]()
             response.put("answer", answer)
+            // Provenance handles the caller passed through (e.g. find_data
+            // results, _datris_* fields from search hits). Echoed verbatim so
+            // the answer text and its provenance travel together; never fed to
+            // the model.
+            Option(body.get("sources")).foreach(response.put("sources", _))
             new ResponseEntity[String](gson.toJson(response), HttpStatus.OK)
         } catch {
             case e: Exception =>

--- a/datrisserver/src/main/scala/ai/datris/api/TapAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/TapAPIController.scala
@@ -390,7 +390,10 @@ class TapAPIController {
                 tapConfigWithScript.copy(
                     createdAt = existing.createdAt,
                     updatedAt = now,
-                    createdByKeyLabel = existing.createdByKeyLabel
+                    createdByKeyLabel = existing.createdByKeyLabel,
+                    // Tags preservation: a body that omits tags entirely must not
+                    // wipe them on an unrelated edit; an explicit empty list clears.
+                    tags = if (tapConfigWithScript.tags == null) existing.tags else tapConfigWithScript.tags
                 )
             else
                 tapConfigWithScript.copy(

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -177,7 +177,16 @@ object CapabilityRoutes {
 
         // Server-side Activity signals (failures / stale / volume) — derived
         // operational metadata.
-        Route("GET", "/api/v1/activity/signals", "metadata", "read")
+        Route("GET", "/api/v1/activity/signals", "metadata", "read"),
+
+        // Provenance / lineage / discovery (v1.26) — read-only derived
+        // metadata. `/catalog/find` additionally filters hits per item with
+        // the caller's pipeline/tap read scopes; `howToQuery` execution is
+        // still gated at the query call itself.
+        Route("GET", "/api/v1/provenance", "metadata", "read"),
+        Route("GET", "/api/v1/lineage", "metadata", "read"),
+        Route("GET", "/api/v1/lineage/**", "metadata", "read"),
+        Route("GET", "/api/v1/catalog/find", "metadata", "read")
     )
 
     /** Every `resource:action` pair the table grants — the vocabulary the

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -141,7 +141,11 @@ object MCPToolRoutes {
 
         // Recovery-agent incidents (read-only; the platform opens them)
         "list_incidents" -> Mapped("GET", "/api/v1/incidents"),
-        "get_incident" -> Mapped("GET", "/api/v1/incidents/example")
+        "get_incident" -> Mapped("GET", "/api/v1/incidents/example"),
+
+        // Discovery + provenance (read-only)
+        "find_data" -> Mapped("GET", "/api/v1/catalog/find"),
+        "get_provenance" -> Mapped("GET", "/api/v1/provenance")
     )
 
     val allToolNames: Seq[String] = tools.map(_._1)

--- a/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
@@ -101,6 +101,11 @@ class JobRunner(jobContext: JobContext) extends Runnable {
                     jobContextPreprocessed
             }
 
+            // Provenance stamp (opt-in per pipeline): constant per-run fields
+            // appended once, after transformation, so every destination loader
+            // below sees the same data. No-op when provenance.stamp is off.
+            val jobContextStamped = ProvenanceStamper.stamp(jobContextTransform)
+
             // Run all destinations in parallel on the dedicated thread pool
             implicit val ec: ExecutionContext = JobRunner.destinationEC
 
@@ -134,43 +139,43 @@ class JobRunner(jobContext: JobContext) extends Runnable {
 
             val destinationFutures = List(
                 if (config.destination.objectStore != null)
-                    Some(runLoader("SparkObjectStoreLoader")(new SparkObjectStoreLoader(jobContextTransform).process()))
+                    Some(runLoader("SparkObjectStoreLoader")(new SparkObjectStoreLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.database != null && config.destination.database.usePostgres)
-                    Some(runLoader("PostgresLoader")(new PostgresLoader(jobContextTransform).process()))
+                    Some(runLoader("PostgresLoader")(new PostgresLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.database != null && config.destination.database.useMongoDB)
-                    Some(runLoader("MongoDBLoader")(new MongoDBLoader(jobContextTransform).process()))
+                    Some(runLoader("MongoDBLoader")(new MongoDBLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.database != null && config.destination.database.useSnowflake)
-                    Some(runLoader("SnowflakeLoader")(new SnowflakeLoader(jobContextTransform).process()))
+                    Some(runLoader("SnowflakeLoader")(new SnowflakeLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.database != null && config.destination.database.useDatabricks)
-                    Some(runLoader("DatabricksLoader")(new DatabricksLoader(jobContextTransform).process()))
+                    Some(runLoader("DatabricksLoader")(new DatabricksLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.restEndpoint != null)
-                    Some(runLoader("RestEndpointRunner")(new RestEndpointRunner(jobContextTransform, config.destination.restEndpoint).process()))
+                    Some(runLoader("RestEndpointRunner")(new RestEndpointRunner(jobContextStamped, config.destination.restEndpoint).process()))
                 else None,
                 if (config.destination.kafka != null)
-                    Some(runLoader("KafkaLoader")(new KafkaLoader(jobContextTransform).process()))
+                    Some(runLoader("KafkaLoader")(new KafkaLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.activeMQ != null)
-                    Some(runLoader("ActiveMQLoader")(new ActiveMQLoader(jobContextTransform).process()))
+                    Some(runLoader("ActiveMQLoader")(new ActiveMQLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.qdrant != null)
-                    Some(runLoader("QdrantLoader")(new QdrantLoader(jobContextTransform).process()))
+                    Some(runLoader("QdrantLoader")(new QdrantLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.weaviate != null)
-                    Some(runLoader("WeaviateLoader")(new WeaviateLoader(jobContextTransform).process()))
+                    Some(runLoader("WeaviateLoader")(new WeaviateLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.pgvector != null)
-                    Some(runLoader("PGVectorLoader")(new PGVectorLoader(jobContextTransform).process()))
+                    Some(runLoader("PGVectorLoader")(new PGVectorLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.milvus != null)
-                    Some(runLoader("MilvusLoader")(new MilvusLoader(jobContextTransform).process()))
+                    Some(runLoader("MilvusLoader")(new MilvusLoader(jobContextStamped).process()))
                 else None,
                 if (config.destination.chroma != null)
-                    Some(runLoader("ChromaLoader")(new ChromaLoader(jobContextTransform).process()))
+                    Some(runLoader("ChromaLoader")(new ChromaLoader(jobContextStamped).process()))
                 else None
             ).flatten
 

--- a/datrisserver/src/main/scala/ai/datris/controller/StreamNotifier.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/StreamNotifier.scala
@@ -22,7 +22,7 @@ class StreamNotifier {
     private val logger: Logger = LoggerFactory.getLogger(classOf[FileNotifier])
     private val statusUtil = new StatusUtil().init(DatrisEnvironment.current.pipelineStatusTableName, this.getClass.getSimpleName)
 
-    def process(byteArray: Array[Byte], filename: String, pipeline: String, publisherToken: String): JobContext = {
+    def process(byteArray: Array[Byte], filename: String, pipeline: String, publisherToken: String, tapFeed: TapFeedInfo = null): JobContext = {
         logger.info("StreamNotifier processing pipeline: " + pipeline + ", filename: " + filename)
         statusUtil.setFilename("stream: " + pipeline)
 
@@ -35,7 +35,17 @@ class StreamNotifier {
             if (config == null)
                 throw new DatrisException("Pipeline: " + pipeline + " is not configured in the NoSQL database")
 
-            val metadata = PipelineMetadata(pipeline, filename, null, Option(publisherToken).getOrElse(pipelineToken), bulkUpload = false)
+            val metadata = PipelineMetadata(
+                pipeline,
+                filename,
+                null,
+                Option(publisherToken).getOrElse(pipelineToken),
+                bulkUpload = false,
+                tapName = if (tapFeed != null) tapFeed.tapName else null,
+                tapRunTime = if (tapFeed != null) tapFeed.runTime else null,
+                tapScriptSha = if (tapFeed != null) tapFeed.scriptCommitSha else null,
+                tapSource = if (tapFeed != null) tapFeed.source else null
+            )
             val gson = new Gson
             // Must persist metadata before any statusUtil calls so getPipelineName can resolve the pipeline token
             NoSQLDbUtil.setItemNameValue(

--- a/datrisserver/src/main/scala/ai/datris/model/PipelineConfig.scala
+++ b/datrisserver/src/main/scala/ai/datris/model/PipelineConfig.scala
@@ -18,7 +18,18 @@ case class PipelineConfig(
     createdByKeyLabel: String = null,
     // Monotonic definition version; immutable snapshots
     // 1..N live in <env>-pipeline-version. Absent field → 1.
-    version: Int = 1
+    version: Int = 1,
+    // Free-form discovery labels ranked by /catalog/find. java.util.List
+    // because Gson round-trips this document and its EntityVersion snapshots.
+    tags: java.util.List[String] = null,
+    // Opt-in provenance stamping (absent/null ⇒ off). See ProvenanceStamper.
+    provenance: ProvenanceConfig = null
+)
+
+case class ProvenanceConfig @JsonCreator() (
+    @JsonProperty("stamp") stamp: Boolean = false,
+    // Subset of ProvenanceStamper.AllFields to stamp; null/empty ⇒ all.
+    @JsonProperty("fields") fields: java.util.List[String] = null
 )
 
 case class Source(

--- a/datrisserver/src/main/scala/ai/datris/model/PipelineMetadata.scala
+++ b/datrisserver/src/main/scala/ai/datris/model/PipelineMetadata.scala
@@ -10,5 +10,23 @@ case class PipelineMetadata(
     dataFileName: String,
     dataFilePath: String,
     publisherToken: String,
-    bulkUpload: Boolean // If true, the dataFilePath contains the path to the bulk upload files
+    bulkUpload: Boolean, // If true, the dataFilePath contains the path to the bulk upload files
+    // Tap-fed jobs only: identity of the feeding tap run, threaded through so
+    // ProvenanceStamper can name the run without a lookup. Null on direct
+    // uploads, file drops, and archived metadata written before these existed.
+    tapName: String = null,
+    tapRunTime: String = null,
+    tapScriptSha: String = null,
+    tapSource: String = null
+)
+
+/** Carrier for tap-run identity from TapRunner into StreamNotifier, so a
+  * stamped row can say which tap run produced it. `source` is the tap's
+  * declared source (URL host for HTTP taps, `tap:<name>` otherwise) — never
+  * credentials. */
+case class TapFeedInfo(
+    tapName: String,
+    runTime: String,
+    scriptCommitSha: String,
+    source: String
 )

--- a/datrisserver/src/main/scala/ai/datris/model/TapConfig.scala
+++ b/datrisserver/src/main/scala/ai/datris/model/TapConfig.scala
@@ -63,7 +63,10 @@ case class TapConfig(
     // unused). Flat string for the same Gson round-trip reason as scriptStorage.
     scriptKind: String = null,
     // Endpoint POSTed to on each run when scriptKind == "http".
-    endpointUrl: String = null
+    endpointUrl: String = null,
+    // Free-form discovery labels ranked by /catalog/find. java.util.List
+    // because Gson round-trips this document and its EntityVersion snapshots.
+    tags: java.util.List[String] = null
 ) {
 
     /** True when this tap is a user-hosted HTTP endpoint rather than a

--- a/datrisserver/src/main/scala/ai/datris/util/CatalogFind.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/CatalogFind.scala
@@ -62,6 +62,12 @@ object CatalogFind {
         }.sum
     }
 
+    /** Pipeline tags then tap tags, deduplicated — a label shared by both
+      * shows once in the hit. */
+    private[datris] def mergedTags(p: PipelineConfig, tap: Option[TapConfig]): List[String] =
+        (Option(p.tags).map(_.asScala.toList).getOrElse(Nil) ++
+            tap.flatMap(t => Option(t.tags)).map(_.asScala.toList).getOrElse(Nil)).distinct
+
     private def destFieldTokens(p: PipelineConfig): List[String] = {
         if (p.destination == null || p.destination.schemaProperties == null || p.destination.schemaProperties.fields == null) Nil
         else p.destination.schemaProperties.fields.asScala.toList.flatMap(f => tokenize(f.name))
@@ -140,8 +146,7 @@ object CatalogFind {
         o.addProperty("name", p.name)
         c.tap.flatMap(t => Option(t.description)).foreach(o.addProperty("description", _))
         val tags = new JsonArray()
-        if (p.tags != null) p.tags.asScala.foreach(tags.add)
-        c.tap.foreach(t => if (t.tags != null) t.tags.asScala.foreach(tags.add))
+        mergedTags(p, c.tap).foreach(tags.add)
         o.add("tags", tags)
         if (p.catalog != null) o.addProperty("catalog", p.catalog)
         o.addProperty("score", math.round(c.score * 100.0) / 100.0)

--- a/datrisserver/src/main/scala/ai/datris/util/CatalogFind.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/CatalogFind.scala
@@ -1,0 +1,216 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{PipelineConfig, TapConfig}
+import com.google.gson.{Gson, JsonArray, JsonObject, JsonParser}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+/** Dataset discovery for `find_data`: rank the pipelines a caller may see by
+  * lexical match against a natural-language query, and return where each one's
+  * data lives, how fresh it is, and how to query it — without executing
+  * anything on the caller's behalf. The `howToQuery` hint names an EXISTING
+  * tool with pre-filled arguments; the agent still makes that call itself,
+  * under its own capabilities.
+  *
+  * Ranking is deterministic (name, description, tags, catalog, destination
+  * field names, source host). `ai=true` adds a rerank of the top candidates
+  * by the primary AI slot; on any AI failure the lexical order stands.
+  */
+object CatalogFind {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    private[datris] val DefaultLimit = 5
+    private[datris] val MaxLimit = 25
+    private val RerankCandidates = 15
+
+    /** One scored candidate with everything needed to render a hit. */
+    private[datris] case class Candidate(pipeline: PipelineConfig, tap: Option[TapConfig], score: Double)
+
+    private[datris] def tokenize(s: String): List[String] =
+        Option(s).getOrElse("").toLowerCase.split("[^a-z0-9]+").filter(_.length > 1).toList
+
+    /** Deterministic lexical score of one pipeline against the query tokens. */
+    private[datris] def score(queryTokens: List[String], p: PipelineConfig, tap: Option[TapConfig]): Double = {
+        def fieldTokens(s: String): List[String] = tokenize(s)
+        def listTokens(l: java.util.List[String]): List[String] =
+            if (l == null) Nil else l.asScala.toList.flatMap(fieldTokens)
+
+        val weighted: List[(List[String], Double)] = List(
+            fieldTokens(p.name) -> 3.0,
+            listTokens(p.tags) -> 3.0,
+            fieldTokens(p.catalog) -> 2.0,
+            tap.map(t => fieldTokens(t.description)).getOrElse(Nil) -> 2.0,
+            tap.map(t => fieldTokens(t.name)).getOrElse(Nil) -> 1.5,
+            tap.map(t => listTokens(t.tags)).getOrElse(Nil) -> 2.0,
+            destFieldTokens(p) -> 1.0,
+            tap.map(t => fieldTokens(TapRunner.declaredSource(t))).getOrElse(Nil) -> 1.0
+        )
+
+        queryTokens.map { q =>
+            weighted.map { case (tokens, weight) =>
+                if (tokens.contains(q)) weight
+                else if (tokens.exists(t => t.contains(q) || q.contains(t))) weight / 2
+                else 0.0
+            }.max
+        }.sum
+    }
+
+    private def destFieldTokens(p: PipelineConfig): List[String] = {
+        if (p.destination == null || p.destination.schemaProperties == null || p.destination.schemaProperties.fields == null) Nil
+        else p.destination.schemaProperties.fields.asScala.toList.flatMap(f => tokenize(f.name))
+    }
+
+    /** The pre-filled query hint for a dataset. Null for destinations with no
+      * query tool (kafka, activemq, rest). Copy stays neutral — placeholders,
+      * no domain examples. */
+    private[datris] def howToQuery(pipelineName: String, ds: LineageService.DatasetRef): JsonObject = {
+        val coords = ds.coords.toMap
+        def obj(tool: String)(args: (String, Any)*): JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("tool", tool)
+            val a = new JsonObject()
+            args.foreach {
+                case (k, v: String) => if (v != null && v.nonEmpty) a.addProperty(k, v)
+                case (k, v: Int) => a.addProperty(k, v)
+                case _ => ()
+            }
+            o.add("args", a)
+            o
+        }
+        ds.kind match {
+            case "postgres" =>
+                val schema = coords.getOrElse("schema", "public")
+                val table = coords.getOrElse("table", "")
+                obj("query_postgres")("sql" -> ("SELECT * FROM \"" + schema + "\".\"" + table + "\" LIMIT 100"), "limit" -> 100)
+            case "mongodb" => obj("query_mongodb")("collection" -> coords.getOrElse("collection", ""), "limit" -> 20)
+            case "snowflake" => obj("query_snowflake")("pipeline" -> pipelineName)
+            case "databricks" => obj("query_databricks")("pipeline" -> pipelineName)
+            case "objectstore" => obj("query_objectstore")("pipeline" -> pipelineName, "limit" -> 100)
+            case "qdrant" => obj("search_qdrant")("query" -> "<your question>", "collection" -> coords.getOrElse("collection", ""))
+            case "weaviate" => obj("search_weaviate")("query" -> "<your question>", "class_name" -> coords.getOrElse("collection", ""))
+            case "milvus" => obj("search_milvus")("query" -> "<your question>", "collection" -> coords.getOrElse("collection", ""))
+            case "pgvector" =>
+                obj("search_pgvector")(
+                    "query" -> "<your question>",
+                    "table" -> coords.getOrElse("table", ""),
+                    "schema" -> coords.getOrElse("schema", "public")
+                )
+            case "chroma" => obj("search_chroma")("query" -> "<your question>", "collection" -> coords.getOrElse("collection", ""))
+            case _ => null
+        }
+    }
+
+    /** Rank + render. `visible` has already been capability-filtered by the
+      * controller. */
+    def find(query: String, limit: Int, ai: Boolean, visible: List[PipelineConfig], taps: List[TapConfig]): JsonObject = {
+        val cappedLimit = math.max(1, math.min(if (limit <= 0) DefaultLimit else limit, MaxLimit))
+        val queryTokens = tokenize(query)
+        val tapForPipeline: Map[String, TapConfig] =
+            taps.filter(t => t != null && t.targetPipeline != null).map(t => t.targetPipeline -> t).toMap
+
+        val scored = visible
+            .filter(_ != null)
+            .map(p => Candidate(p, tapForPipeline.get(p.name), score(queryTokens, p, tapForPipeline.get(p.name))))
+            .filter(c => queryTokens.isEmpty || c.score > 0)
+            .sortBy(c => (-c.score, c.pipeline.name))
+
+        val ordered =
+            if (ai && scored.size > 1) rerank(query, scored.take(RerankCandidates)) ++ scored.drop(RerankCandidates)
+            else scored
+
+        val out = new JsonObject()
+        val results = new JsonArray()
+        ordered.take(cappedLimit).foreach(c => results.add(renderHit(c, taps)))
+        out.add("results", results)
+        out.addProperty("count", math.min(ordered.size, cappedLimit))
+        out.addProperty("totalMatches", ordered.size)
+        out
+    }
+
+    private def renderHit(c: Candidate, taps: List[TapConfig]): JsonObject = {
+        val p = c.pipeline
+        val o = new JsonObject()
+        o.addProperty("name", p.name)
+        c.tap.flatMap(t => Option(t.description)).foreach(o.addProperty("description", _))
+        val tags = new JsonArray()
+        if (p.tags != null) p.tags.asScala.foreach(tags.add)
+        c.tap.foreach(t => if (t.tags != null) t.tags.asScala.foreach(tags.add))
+        o.add("tags", tags)
+        if (p.catalog != null) o.addProperty("catalog", p.catalog)
+        o.addProperty("score", math.round(c.score * 100.0) / 100.0)
+
+        val freshness = LineageService.freshness(p.name, taps)
+        o.add("freshness", freshness)
+
+        val dsets = LineageService.datasets(p)
+        dsets.headOption.foreach { primary =>
+            o.add("location", primary.toJson)
+            val htq = howToQuery(p.name, primary)
+            if (htq != null) o.add("howToQuery", htq)
+        }
+        if (dsets.size > 1) {
+            val extra = new JsonArray()
+            dsets.tail.foreach { ds =>
+                val e = new JsonObject()
+                e.add("location", ds.toJson)
+                val htq = howToQuery(p.name, ds)
+                if (htq != null) e.add("howToQuery", htq)
+                extra.add(e)
+            }
+            o.add("additionalLocations", extra)
+        }
+
+        val provenance = new JsonObject()
+        if (freshness.has("latestRunId")) provenance.addProperty("latestRunId", freshness.get("latestRunId").getAsString)
+        provenance.addProperty("configVersion", if (p.version > 0) p.version else 1)
+        c.tap.flatMap(t => Option(t.scriptCommitSha)).foreach(provenance.addProperty("scriptSha", _))
+        o.add("provenance", provenance)
+
+        val lineage = new JsonObject()
+        val upstream = new JsonArray()
+        c.tap.foreach(t => upstream.add("tap:" + t.name))
+        lineage.add("upstream", upstream)
+        val downstream = new JsonArray()
+        dsets.foreach(ds => downstream.add(ds.id))
+        lineage.add("downstream", downstream)
+        o.add("lineage", lineage)
+        o
+    }
+
+    /** Optional AI rerank of the lexical top candidates. Best-effort: any
+      * failure (call, parse, unknown names) leaves the lexical order intact. */
+    private def rerank(query: String, candidates: List[Candidate]): List[Candidate] = {
+        try {
+            val gson = new Gson
+            val listing = candidates.map { c =>
+                val desc = c.tap.flatMap(t => Option(t.description)).getOrElse("")
+                val tags = Option(c.pipeline.tags).map(_.asScala.mkString(", ")).getOrElse("")
+                c.pipeline.name + " — " + desc + (if (tags.nonEmpty) " [" + tags + "]" else "")
+            }.mkString("\n")
+            val system = "You rank datasets by relevance to a request. " +
+                "Reply with ONLY a JSON array of dataset names, best match first. Include every listed name exactly once."
+            val user = "Request: " + query + "\n\nDatasets:\n" + listing
+            val response = AIUtil.extractText(AIUtil.callAIWithSystem(system, user))
+            val start = response.indexOf('[')
+            val end = response.lastIndexOf(']')
+            if (start < 0 || end <= start) return candidates
+            val names = JsonParser.parseString(response.substring(start, end + 1)).getAsJsonArray.asScala
+                .map(_.getAsString).toList
+            val byName = candidates.map(c => c.pipeline.name -> c).toMap
+            val reranked = names.flatMap(byName.get)
+            if (reranked.isEmpty) candidates
+            else reranked ++ candidates.filterNot(c => names.contains(c.pipeline.name))
+        } catch {
+            case e: Exception =>
+                logger.debug("CatalogFind: AI rerank failed, keeping lexical order: " + e.getMessage)
+                candidates
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DestTypeInference.scala
@@ -46,6 +46,11 @@ object DestTypeInference {
 
     private val NeverRetyped = Set("_json", "_xml")
 
+    /** Provenance columns (ProvenanceStamper) stay `string`: they are stamped
+      * in-memory per run, so retyping them would desync from the stored config. */
+    private def isProvenanceColumn(name: String): Boolean =
+        name != null && name.toLowerCase.startsWith(ProvenanceStamper.Prefix)
+
     /** Evidence caps for the typing dialog: how many distinct values are shown
       * per column, and how long any shown value can be. */
     private[util] val maxSamples = 5
@@ -174,7 +179,7 @@ object DestTypeInference {
         val fields = names.map { name =>
             val values = lowerRecords.flatMap(_.get(name.toLowerCase)).map(v => if (v == null) null else v.toString)
             val (inferredType, samples, reason) = inferColumnWithEvidence(values)
-            if (NeverRetyped.contains(name.toLowerCase))
+            if (NeverRetyped.contains(name.toLowerCase) || isProvenanceColumn(name))
                 InferredDestField(name, "string", samples, null)
             else
                 InferredDestField(name, inferredType, samples, reason)

--- a/datrisserver/src/main/scala/ai/datris/util/LineageService.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/LineageService.scala
@@ -1,0 +1,255 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model._
+import com.google.gson.{Gson, JsonArray, JsonObject}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+/** Deterministic lineage: the graph Source → Tap → Pipeline → Dataset →
+  * Catalog built purely from stored configuration — no AI, no inference, no
+  * new storage. Freshness per pipeline comes from the status summaries, the
+  * tap staleness classification is shared with [[ActivitySignals]] so the
+  * catalog and the activity dashboard never disagree, and the incremental
+  * cursor comes from [[TapStateIO]].
+  *
+  * Node ids are `type:name` (`dataset` names are destination coordinates,
+  * e.g. `postgres:datris.public.orders`). Column-level lineage and
+  * OpenLineage export are additive on top of this graph, not part of it.
+  */
+object LineageService {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val gson = new Gson()
+
+    private val FreshnessWindowMs = 30L * 86400000L
+    private val MaxRows = 5000
+    private val cacheTtlMs = 60000L
+
+    case class Node(id: String, nodeType: String, name: String, catalog: Option[String] = None) {
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("id", id)
+            o.addProperty("type", nodeType)
+            o.addProperty("name", name)
+            catalog.foreach(o.addProperty("catalog", _))
+            o
+        }
+    }
+
+    case class Edge(from: String, to: String) {
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("from", from)
+            o.addProperty("to", to)
+            o
+        }
+    }
+
+    case class Graph(nodes: List[Node], edges: List[Edge]) {
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            val n = new JsonArray(); nodes.foreach(x => n.add(x.toJson)); o.add("nodes", n)
+            val e = new JsonArray(); edges.foreach(x => e.add(x.toJson)); o.add("edges", e)
+            o
+        }
+    }
+
+    /** One landed dataset: destination kind + its coordinates. */
+    case class DatasetRef(kind: String, coords: List[(String, String)]) {
+        def name: String = kind + ":" + coords.map(_._2).filter(v => v != null && v.nonEmpty).mkString(".")
+        def id: String = "dataset:" + name
+        def toJson: JsonObject = {
+            val o = new JsonObject()
+            o.addProperty("kind", kind)
+            coords.foreach { case (k, v) => if (v != null && v.nonEmpty) o.addProperty(k, v) }
+            o
+        }
+    }
+
+    /** The datasets a pipeline lands into, from its destination section alone. */
+    def datasets(p: PipelineConfig): List[DatasetRef] = {
+        if (p == null || p.destination == null) return Nil
+        val d = p.destination
+        val out = List.newBuilder[DatasetRef]
+        if (d.database != null) {
+            val db = d.database
+            val coords = List("database" -> db.dbName, "schema" -> db.schema, "table" -> db.table)
+            if (db.usePostgres) out += DatasetRef("postgres", coords)
+            if (db.useMongoDB) out += DatasetRef("mongodb", List("database" -> db.dbName, "collection" -> db.table))
+            if (db.useSnowflake) out += DatasetRef("snowflake", coords)
+            if (db.useDatabricks) out += DatasetRef("databricks", coords)
+        }
+        if (d.objectStore != null) {
+            val os = d.objectStore
+            out += DatasetRef(
+                "objectstore",
+                List("bucket" -> Option(os.destinationBucketOverride).getOrElse(""), "prefix" -> Option(os.prefixKey).getOrElse(p.name))
+            )
+        }
+        if (d.kafka != null) out += DatasetRef("kafka", List("topic" -> d.kafka.topic))
+        if (d.activeMQ != null) out += DatasetRef("activemq", List("queue" -> d.activeMQ.queueName))
+        if (d.qdrant != null) out += DatasetRef("qdrant", List("collection" -> d.qdrant.collectionName))
+        if (d.weaviate != null) out += DatasetRef("weaviate", List("collection" -> d.weaviate.className))
+        if (d.pgvector != null)
+            out += DatasetRef("pgvector", List("schema" -> Option(d.pgvector.schemaName).getOrElse("public"), "table" -> d.pgvector.tableName))
+        if (d.milvus != null) out += DatasetRef("milvus", List("collection" -> d.milvus.collectionName))
+        if (d.chroma != null) out += DatasetRef("chroma", List("collection" -> d.chroma.collectionName))
+        out.result()
+    }
+
+    /** Pure graph construction from configs — the unit-testable core. */
+    private[datris] def build(taps: List[TapConfig], pipelines: List[PipelineConfig]): Graph = {
+        val nodes = scala.collection.mutable.LinkedHashMap[String, Node]()
+        val edges = List.newBuilder[Edge]
+
+        def addNode(n: Node): Unit = if (!nodes.contains(n.id)) nodes.put(n.id, n)
+
+        taps.filter(_ != null).foreach { t =>
+            val tapId = "tap:" + t.name
+            addNode(Node(tapId, "tap", t.name, Option(t.catalog)))
+            val source = TapRunner.declaredSource(t)
+            addNode(Node("source:" + source, "source", source))
+            edges += Edge("source:" + source, tapId)
+            if (t.targetPipeline != null && t.targetPipeline.nonEmpty)
+                edges += Edge(tapId, "pipeline:" + t.targetPipeline)
+        }
+
+        pipelines.filter(_ != null).foreach { p =>
+            val pipelineId = "pipeline:" + p.name
+            addNode(Node(pipelineId, "pipeline", p.name, Option(p.catalog)))
+            datasets(p).foreach { ds =>
+                addNode(Node(ds.id, "dataset", ds.name, Option(p.catalog)))
+                edges += Edge(pipelineId, ds.id)
+                if (p.catalog != null && p.catalog.nonEmpty) {
+                    addNode(Node("catalog:" + p.catalog, "catalog", p.catalog))
+                    edges += Edge(ds.id, "catalog:" + p.catalog)
+                }
+            }
+        }
+
+        // Drop edges whose target node doesn't exist (e.g. a tap pointing at a
+        // deleted pipeline) — the UI should not render dangling references.
+        val ids = nodes.keySet
+        Graph(nodes.values.toList, edges.result().distinct.filter(e => ids.contains(e.from) && ids.contains(e.to)))
+    }
+
+    // ------------------------------------------------------------------
+
+    private case class CacheEntry(atMs: Long, graph: Graph, taps: List[TapConfig], pipelines: List[PipelineConfig])
+    private val cache = new java.util.concurrent.ConcurrentHashMap[String, CacheEntry]()
+
+    private def loadCached(): CacheEntry = {
+        val env = DatrisEnvironment.current
+        val now = System.currentTimeMillis()
+        val cached = cache.get(env.environment)
+        if (cached != null && now - cached.atMs < cacheTtlMs) return cached
+        val taps =
+            try TapConfigIO.readAll(env.tapTableName)
+            catch { case _: Exception => Nil }
+        val pipelines =
+            try PipelineConfigIO.readAll(env.pipelineTableName)
+            catch { case _: Exception => Nil }
+        val entry = CacheEntry(now, build(taps, pipelines), taps, pipelines)
+        cache.put(env.environment, entry)
+        entry
+    }
+
+    /** The whole graph (cached ~1 minute). */
+    def graph(): Graph = loadCached().graph
+
+    /** Per-pipeline freshness: last successful landing, its record count, the
+      * incremental cursor when the feeding tap keeps one, and the stale/fresh
+      * classification shared with ActivitySignals. */
+    def freshness(pipelineName: String, taps: List[TapConfig]): JsonObject = {
+        val env = DatrisEnvironment.current
+        val now = System.currentTimeMillis()
+        val o = new JsonObject()
+
+        val summaries: List[PipelineStatusSummaryTable] =
+            try NoSQLDbUtil.getItemsSinceAsJSON(env.pipelineStatusTableName + "-summary", "created_at", now - FreshnessWindowMs, MaxRows).flatMap {
+                    json =>
+                        try Some(gson.fromJson(json, classOf[PipelineStatusSummaryTable]))
+                        catch { case _: Exception => None }
+                }
+            catch { case e: Exception => logger.debug("lineage: summary read failed: " + e.getMessage); Nil }
+
+        val landed = summaries
+            .filter(s =>
+                s.json != null && pipelineName.equals(s.json.pipeline) &&
+                    Option(s.json.status).exists(st => st.equalsIgnoreCase("success") || st.equalsIgnoreCase("warning"))
+            )
+            .sortBy(s => Option(s.created_at).map(_.longValue()).getOrElse(0L))
+
+        val feedingTap = taps.find(t => t != null && pipelineName.equals(t.targetPipeline))
+        val staleNames = ActivitySignals.computeStale(now, taps).map(_.name).toSet
+
+        landed.lastOption match {
+            case Some(last) =>
+                o.addProperty("lastLandedAt", java.time.Instant.ofEpochMilli(last.created_at.longValue()).toString)
+                o.addProperty("recordCount", last.json.recordCount)
+                if (last.json.pipelineToken != null) o.addProperty("latestRunId", last.json.pipelineToken)
+                val state = if (feedingTap.exists(t => staleNames.contains(t.name))) "stale" else "fresh"
+                o.addProperty("state", state)
+            case None =>
+                o.addProperty("state", if (feedingTap.exists(t => staleNames.contains(t.name))) "stale" else "unknown")
+        }
+
+        feedingTap.foreach { t =>
+            try {
+                val st = TapStateIO.read(t.name)
+                if (st != null && st.updatedAt != null) o.addProperty("cursorUpdatedAt", st.updatedAt)
+            } catch { case _: Exception => () }
+        }
+        o
+    }
+
+    /** Neighborhood of one node: the node, everything transitively upstream,
+      * and everything transitively downstream. 404-style null when unknown. */
+    def neighborhood(nodeType: String, name: String): JsonObject = {
+        val entry = loadCached()
+        val g = entry.graph
+        val id = nodeType + ":" + name
+        val node = g.nodes.find(_.id == id).orNull
+        if (node == null) return null
+
+        val forward = g.edges.groupBy(_.from).mapValues(_.map(_.to))
+        val backward = g.edges.groupBy(_.to).mapValues(_.map(_.from))
+
+        def walk(start: String, next: String => List[String]): List[String] = {
+            val seen = scala.collection.mutable.LinkedHashSet[String]()
+            var frontier = next(start)
+            while (frontier.nonEmpty) {
+                val fresh = frontier.filterNot(seen.contains)
+                fresh.foreach(seen.add)
+                frontier = fresh.flatMap(next)
+            }
+            seen.toList
+        }
+
+        val upstream = walk(id, i => backward.getOrElse(i, Nil))
+        val downstream = walk(id, i => forward.getOrElse(i, Nil))
+        val byId = g.nodes.map(n => n.id -> n).toMap
+
+        val o = new JsonObject()
+        o.add("node", node.toJson)
+        val up = new JsonArray(); upstream.flatMap(byId.get).foreach(n => up.add(n.toJson)); o.add("upstream", up)
+        val down = new JsonArray(); downstream.flatMap(byId.get).foreach(n => down.add(n.toJson)); o.add("downstream", down)
+        val relevant = (upstream ++ downstream :+ id).toSet
+        val e = new JsonArray()
+        g.edges.filter(x => relevant.contains(x.from) && relevant.contains(x.to)).foreach(x => e.add(x.toJson))
+        o.add("edges", e)
+
+        // Freshness for the pipeline this node is (or feeds).
+        val pipelineName: Option[String] =
+            if (nodeType == "pipeline") Some(name)
+            else (upstream ++ downstream).find(_.startsWith("pipeline:")).map(_.stripPrefix("pipeline:"))
+        pipelineName.foreach(p => o.add("freshness", freshness(p, entry.taps)))
+        o
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/MilvusSearchUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/MilvusSearchUtil.scala
@@ -61,16 +61,25 @@ object MilvusSearchUtil extends VectorSearchUtility {
             val floatVec: io.milvus.v2.service.vector.request.data.BaseVector = new FloatVec(floatList)
             val vectorData: java.util.List[io.milvus.v2.service.vector.request.data.BaseVector] =
                 java.util.Collections.singletonList(floatVec)
-            val outputFields = java.util.Arrays.asList("text", "chunk_index", "source_pipeline", "filename")
+            val baseFields = List("text", "chunk_index", "source_pipeline", "filename")
 
-            val searchReq = SearchReq.builder()
-                .collectionName(collection)
-                .data(vectorData)
-                .topK(topK)
-                .outputFields(outputFields)
-                .build()
+            def doSearch(fields: List[String]) = {
+                val searchReq = SearchReq.builder()
+                    .collectionName(collection)
+                    .data(vectorData)
+                    .topK(topK)
+                    .outputFields(fields.asJava)
+                    .build()
+                client.search(searchReq)
+            }
 
-            val searchResp = client.search(searchReq)
+            // Echo provenance payload fields (ProvenanceStamper) when present.
+            // Collections created by the loader have dynamic fields enabled so
+            // unknown names are legal; older/foreign collections may reject
+            // them — fall back to the base field list.
+            val searchResp =
+                try doSearch(baseFields ++ ProvenanceStamper.AllFields)
+                catch { case _: Exception => doSearch(baseFields) }
             val results = new java.util.ArrayList[java.util.Map[String, Any]]()
 
             searchResp.getSearchResults.asScala.foreach { resultList =>

--- a/datrisserver/src/main/scala/ai/datris/util/PGVectorLoader.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/PGVectorLoader.scala
@@ -236,6 +236,17 @@ class PGVectorLoader(jobContext: JobContext) {
 
             statusUtil.info("processing", "Ensuring table: " + schemaName + "." + tableName + " with vector dimension: " + dimension)
             stmt.execute(createSql)
+
+            // Additive evolution for metadata columns: a table created before a
+            // metadata key existed (user-added key, or provenance stamping turned
+            // on) must gain the column or the INSERT column list fails.
+            if (pgvectorConfig.metadata != null) {
+                pgvectorConfig.metadata.asScala.keys.foreach { key =>
+                    stmt.execute(
+                        "ALTER TABLE \"" + schemaName + "\".\"" + tableName + "\" ADD COLUMN IF NOT EXISTS \"" + key + "\" TEXT"
+                    )
+                }
+            }
             conn.commit()
         } finally {
             stmt.close()

--- a/datrisserver/src/main/scala/ai/datris/util/ProvenanceResolver.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/ProvenanceResolver.scala
@@ -1,0 +1,190 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import com.google.gson.{Gson, JsonObject}
+import ai.datris.model._
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+
+/** Resolves a stamped `_datris_run_id` back to its origin: run → job status →
+  * tap run log → script commit → pipeline config version → declared source.
+  * Every hop is an existing lookup; this walks them in order and returns one
+  * document. Read-only.
+  */
+object ProvenanceResolver {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    // How far back the tap-log fallback scan looks when the archived metadata
+    // predates the tap-identity fields (pre-v1.26 runs).
+    private val fallbackScanDays = 90
+    private val fallbackScanMax = 5000
+
+    def resolve(pipeline: String, runId: String, tapRunKey: String, configVersion: Integer): JsonObject = {
+        val env = DatrisEnvironment.current
+        val gson = new Gson
+        val out = new JsonObject()
+        out.addProperty("runId", runId)
+
+        // 1. Archived metadata for the run (pipeline name + tap identity).
+        val metadata: PipelineMetadata =
+            NoSQLDbUtil.getItemJSON(env.archivedMetadataTableName, "pipeline_token", runId, "metadata")
+                .map(gson.fromJson(_, classOf[PipelineMetadata]))
+                .orNull
+
+        val pipelineName =
+            if (pipeline != null && pipeline.nonEmpty) pipeline
+            else if (metadata != null) metadata.pipeline
+            else null
+        if (pipelineName != null) out.addProperty("pipeline", pipelineName)
+
+        // 2. Job status rollup for the run.
+        val statusResponse = PipelineStatusUtil.getPipelineStatusWithRollup(runId)
+        val job = new JsonObject()
+        val jobRollup = statusResponse.rollup.jobs.asScala.find(_.pipelineToken == runId)
+        jobRollup.foreach { j =>
+            job.addProperty("status", j.status)
+            job.addProperty("startedAt", j.startedAt)
+            job.addProperty("lastEventAt", j.lastEventAt)
+            if (j.filename != null) job.addProperty("filename", j.filename)
+        }
+        summaryFor(runId).foreach { s =>
+            job.addProperty("recordCount", s.recordCount)
+            if (s.dataType != null) job.addProperty("dataType", s.dataType)
+        }
+        if (job.size() > 0) out.add("job", job)
+
+        // 3. Tap run log: direct key when known (metadata or the stamped
+        //    `_datris_tap_run` value passed in), else a windowed scan matching
+        //    the run's publisherToken (pre-v1.26 metadata).
+        val publisherToken = {
+            val fromEvents = statusResponse.events.asScala.find(e => e.publisherToken != null).map(_.publisherToken)
+            if (metadata != null && metadata.publisherToken != null) metadata.publisherToken
+            else fromEvents.orNull
+        }
+        val directKey =
+            if (tapRunKey != null && tapRunKey.nonEmpty) tapRunKey
+            else if (metadata != null && metadata.tapName != null && metadata.tapRunTime != null)
+                metadata.tapName + "|" + metadata.tapRunTime
+            else null
+
+        val tapRunLog: TapRunLog = {
+            val direct =
+                if (directKey != null)
+                    NoSQLDbUtil.getItemJSON(env.tapLogTableName, "key", directKey, "value")
+                        .map(gson.fromJson(_, classOf[TapRunLog]))
+                        .orNull
+                else null
+            if (direct != null) direct
+            else if (publisherToken != null && publisherToken != runId) findTapRunByPublisher(publisherToken)
+            else null
+        }
+
+        if (tapRunLog != null) {
+            val t = new JsonObject()
+            t.addProperty("tapName", tapRunLog.tapName)
+            t.addProperty("runTime", tapRunLog.runTime)
+            t.addProperty("status", tapRunLog.status)
+            t.addProperty("recordCount", tapRunLog.recordCount)
+            t.addProperty("durationMs", tapRunLog.durationMs)
+            if (tapRunLog.mode != null) t.addProperty("mode", tapRunLog.mode)
+            if (tapRunLog.publisherToken != null) t.addProperty("publisherToken", tapRunLog.publisherToken)
+            if (tapRunLog.scriptCommitSha != null) t.addProperty("scriptCommitSha", tapRunLog.scriptCommitSha)
+            out.add("tapRun", t)
+        }
+
+        // 4. Tap definition + script origin + declared source.
+        val tapName =
+            if (tapRunLog != null) tapRunLog.tapName
+            else if (metadata != null) metadata.tapName
+            else null
+        if (tapName != null) {
+            val tapConfig = TapConfigIO.read(env.tapTableName, tapName)
+            if (tapConfig != null) {
+                val tap = new JsonObject()
+                tap.addProperty("name", tapConfig.name)
+                if (tapConfig.description != null) tap.addProperty("description", tapConfig.description)
+                if (tapConfig.catalog != null) tap.addProperty("catalog", tapConfig.catalog)
+                tap.addProperty("version", if (tapConfig.version > 0) tapConfig.version else 1)
+                val script = new JsonObject()
+                if (tapConfig.scriptStorage != null) script.addProperty("storage", tapConfig.scriptStorage)
+                if (tapConfig.scriptRepoPath != null) script.addProperty("repoPath", tapConfig.scriptRepoPath)
+                val sha =
+                    if (tapRunLog != null && tapRunLog.scriptCommitSha != null) tapRunLog.scriptCommitSha
+                    else tapConfig.scriptCommitSha
+                if (sha != null) script.addProperty("commitSha", sha)
+                if (script.size() > 0) tap.add("script", script)
+                out.add("tap", tap)
+                out.addProperty("source", TapRunner.declaredSource(tapConfig))
+            }
+        }
+        if (!out.has("source") && metadata != null && metadata.tapSource != null)
+            out.addProperty("source", metadata.tapSource)
+
+        // 5. Pipeline config version snapshot. The version at run time comes from
+        //    the stamped `_datris_config_version` (configVersion param); without
+        //    it the current version is reported.
+        if (pipelineName != null) {
+            val current = PipelineConfigIO.read(env.pipelineTableName, pipelineName)
+            val version: Int =
+                if (configVersion != null) configVersion.intValue()
+                else if (current != null && current.version > 0) current.version
+                else 1
+            val cfg = new JsonObject()
+            cfg.addProperty("version", version)
+            cfg.addProperty("versionSource", if (configVersion != null) "stamped" else "current")
+            EntityVersionIO.get(env.pipelineVersionTableName, pipelineName, version).foreach { snapshot =>
+                if (snapshot.createdAt != null) cfg.addProperty("createdAt", snapshot.createdAt)
+                if (snapshot.createdBy != null) cfg.addProperty("createdBy", snapshot.createdBy)
+                if (snapshot.changeNote != null) cfg.addProperty("changeNote", snapshot.changeNote)
+            }
+            out.add("configVersion", cfg)
+        }
+
+        out
+    }
+
+    private def summaryFor(runId: String): Option[PipelineStatusSummary] = {
+        try {
+            val gson = new Gson
+            NoSQLDbUtil
+                .queryJSONItemsByKey(DatrisEnvironment.current.pipelineStatusTableName + "-summary", "pipeline_token", runId)
+                .headOption
+                .map(gson.fromJson(_, classOf[PipelineStatusSummaryTable]).json)
+        } catch {
+            case e: Exception =>
+                logger.debug("ProvenanceResolver: summary lookup failed for " + runId + ": " + e.getMessage)
+                None
+        }
+    }
+
+    /** Fallback for runs whose archived metadata predates the tap-identity
+      * fields: windowed scan over the tap log matching publisherToken. */
+    private def findTapRunByPublisher(publisherToken: String): TapRunLog = {
+        try {
+            val gson = new Gson
+            val since = System.currentTimeMillis() - fallbackScanDays.toLong * 24 * 60 * 60 * 1000
+            NoSQLDbUtil
+                .getItemsSinceAsJSON(DatrisEnvironment.current.tapLogTableName, "created_at", since, fallbackScanMax)
+                .flatMap { json =>
+                    // Rows have shape {"key":..., "value": {...TapRunLog...}, "created_at":...}
+                    try {
+                        val el = com.google.gson.JsonParser.parseString(json)
+                        if (el.isJsonObject && el.getAsJsonObject.has("value"))
+                            Option(gson.fromJson(el.getAsJsonObject.get("value"), classOf[TapRunLog]))
+                        else None
+                    } catch { case _: Exception => None }
+                }
+                .find(log => log != null && log.publisherToken == publisherToken)
+                .orNull
+        } catch {
+            case e: Exception =>
+                logger.debug("ProvenanceResolver: tap-log scan failed: " + e.getMessage)
+                null
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/ProvenanceStamper.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/ProvenanceStamper.scala
@@ -1,0 +1,234 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model._
+import com.google.gson.{Gson, JsonElement, JsonObject, JsonParser}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+
+/** Appends per-run provenance onto a job's data, once, after transformation and
+  * before any destination loader runs — so every destination sees the same
+  * fields without per-loader code. Opt-in per pipeline (`provenance.stamp`).
+  *
+  * All values are constant for the run, so stamping is a cheap append:
+  *  - delimited data: fields appended to `data.header`, every row, and the
+  *    in-memory source AND destination schemas (both, so a pipeline whose
+  *    schemas matched before stamping still takes the loaders' no-projection
+  *    fast path). The stored pipeline definition is never touched — provenance
+  *    columns must not leak into the config document, its version snapshots,
+  *    or the dest-types dialog.
+  *  - JSON rawData: keys injected into each object (array, single object, or
+  *    NDJSON lines). XML is not stamped.
+  *  - unstructured/vector data (rawBytes): keys injected into the in-memory
+  *    vector destination `metadata` maps; the vector loaders already write
+  *    that map onto every chunk.
+  *
+  * Rows are never rewritten retroactively: provenance starts at the first run
+  * after the toggle is turned on.
+  */
+object ProvenanceStamper {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    val RunId = "_datris_run_id"
+    val IngestedAt = "_datris_ingested_at"
+    val ConfigVersion = "_datris_config_version"
+    val TapRun = "_datris_tap_run"
+    val ScriptSha = "_datris_script_sha"
+    val Source = "_datris_source"
+
+    val AllFields: List[String] = List(RunId, IngestedAt, ConfigVersion, TapRun, ScriptSha, Source)
+
+    /** Prefix every stamped field carries; DestTypeInference treats it as
+      * never-retyped so provenance columns cannot break the dest-types flow. */
+    val Prefix = "_datris_"
+
+    def enabled(config: PipelineConfig): Boolean =
+        config != null && config.provenance != null && config.provenance.stamp
+
+    def stamp(ctx: JobContext): JobContext = {
+        if (!enabled(ctx.config)) return ctx
+        try {
+            val values = stampValues(ctx, java.time.Instant.now().toString)
+            if (values.isEmpty) return ctx
+            val stamped =
+                if (ctx.data == null) ctx
+                else if (ctx.data.rows != null && ctx.data.header != null) stampDelimited(ctx, values)
+                else if (ctx.data.rawData != null) stampRaw(ctx, values)
+                else if (ctx.data.rawBytes != null) stampVector(ctx, values)
+                else ctx
+            if ((stamped ne ctx) && ctx.statusUtil != null)
+                ctx.statusUtil.info("processing", "Provenance stamped: " + values.map(_._1).mkString(", "))
+            stamped
+        } catch {
+            // Stamping must never fail a job that would otherwise load. Record
+            // the miss and continue unstamped.
+            case e: Exception =>
+                logger.warn("ProvenanceStamper: stamping failed for pipeline: " + ctx.config.name + " — loading unstamped: " + e.getMessage)
+                if (ctx.statusUtil != null)
+                    ctx.statusUtil.info("processing", "Provenance stamping skipped (error): " + e.getMessage)
+                ctx
+        }
+    }
+
+    /** The (field, value) pairs for this run. Null values are kept (they stamp
+      * as empty/absent) so column order is stable across runs of one pipeline. */
+    private[util] def stampValues(ctx: JobContext, nowIso: String): List[(String, String)] = {
+        val md = ctx.metadata
+        val tapRun =
+            if (md != null && md.tapName != null && md.tapRunTime != null) md.tapName + "|" + md.tapRunTime else null
+        val all = List(
+            RunId -> ctx.pipelineToken,
+            IngestedAt -> nowIso,
+            ConfigVersion -> String.valueOf(if (ctx.config.version > 0) ctx.config.version else 1),
+            TapRun -> tapRun,
+            ScriptSha -> (if (md != null) md.tapScriptSha else null),
+            Source -> (if (md != null) md.tapSource else null)
+        )
+        val selected = Option(ctx.config.provenance.fields).map(_.asScala.toSet).filter(_.nonEmpty)
+        selected match {
+            case Some(s) => all.filter(p => s.contains(p._1))
+            case None => all
+        }
+    }
+
+    private def stampDelimited(ctx: JobContext, values: List[(String, String)]): JobContext = {
+        val data = ctx.data
+        // Idempotence guard: never double-stamp (e.g. a replayed context).
+        if (data.header.exists(_.startsWith(Prefix))) return ctx
+
+        val delimiter =
+            if (ctx.config.source != null && ctx.config.source.fileAttributes != null && ctx.config.source.fileAttributes.csvAttributes != null)
+                ctx.config.source.fileAttributes.csvAttributes.delimiter
+            else ","
+
+        val names = values.map(_._1)
+        val suffix = values.map(v => csvEncode(Option(v._2).getOrElse(""), delimiter)).mkString(delimiter)
+
+        val newHeader = data.header ++ names
+        val newRows = data.rows.map(row => row + delimiter + suffix)
+        val newHeaderWithSchema =
+            if (data.headerWithSchema != null) data.headerWithSchema ++ names.map(n => SchemaField(n, "string"))
+            else data.headerWithSchema
+
+        // Append to BOTH in-memory schemas so loaders that compare them (fast
+        // path) or read them positionally (object store) stay aligned. The
+        // stored config is never written back.
+        val newSource =
+            if (ctx.config.source != null)
+                ctx.config.source.copy(schemaProperties = appendSchemaFields(ctx.config.source.schemaProperties, names))
+            else ctx.config.source
+        val newDestination =
+            if (ctx.config.destination != null)
+                ctx.config.destination.copy(schemaProperties = appendSchemaFields(ctx.config.destination.schemaProperties, names))
+            else ctx.config.destination
+
+        ctx.copy(
+            data = data.copy(header = newHeader, headerWithSchema = newHeaderWithSchema, rows = newRows),
+            config = ctx.config.copy(source = newSource, destination = newDestination)
+        )
+    }
+
+    private[util] def appendSchemaFields(sp: SchemaProperties, names: List[String]): SchemaProperties = {
+        if (sp == null || sp.fields == null) return sp
+        val existing = sp.fields.asScala.map(_.name.toLowerCase).toSet
+        val list = new java.util.ArrayList[SchemaField](sp.fields)
+        names.filterNot(existing.contains).foreach(n => list.add(SchemaField(n, "string")))
+        sp.copy(fields = list)
+    }
+
+    /** Same quoting rule CSVReader applies at ingest. */
+    private[util] def csvEncode(value: String, delimiter: String): String = {
+        if (value.contains(delimiter) || value.contains("\"") || value.contains("\n"))
+            "\"" + value.replace("\"", "\"\"") + "\""
+        else value
+    }
+
+    private def stampRaw(ctx: JobContext, values: List[(String, String)]): JobContext = {
+        // XML documents are not stamped — no safe generic injection point.
+        if (
+            ctx.config.source != null && ctx.config.source.fileAttributes != null &&
+            ctx.config.source.fileAttributes.xmlAttributes != null
+        ) return ctx
+        val injected = injectJson(ctx.data.rawData, values)
+        if (injected == null) ctx
+        else ctx.copy(data = ctx.data.copy(rawData = injected))
+    }
+
+    /** Inject the stamp keys into a JSON payload: array of objects, a single
+      * object, or NDJSON lines. Returns null when the payload is not stampable
+      * (unparseable, primitives, already stamped). */
+    private[util] def injectJson(rawData: String, values: List[(String, String)]): String = {
+        if (rawData == null || rawData.trim.isEmpty) return null
+        val nonNull = values.filter(_._2 != null)
+        if (nonNull.isEmpty) return null
+        val gson = new Gson
+
+        def injectObject(obj: JsonObject): Boolean = {
+            if (obj.has(RunId)) return false
+            nonNull.foreach { case (k, v) => obj.addProperty(k, v) }
+            true
+        }
+
+        try {
+            val el: JsonElement = JsonParser.parseString(rawData)
+            if (el.isJsonArray) {
+                val arr = el.getAsJsonArray
+                var changed = false
+                val it = arr.iterator()
+                while (it.hasNext) {
+                    val e = it.next()
+                    if (e.isJsonObject && injectObject(e.getAsJsonObject)) changed = true
+                }
+                if (changed) gson.toJson(arr) else null
+            } else if (el.isJsonObject) {
+                if (injectObject(el.getAsJsonObject)) gson.toJson(el) else null
+            } else null
+        } catch {
+            case _: Exception =>
+                // NDJSON: one JSON object per line. All lines must parse or we
+                // leave the payload untouched.
+                try {
+                    val lines = rawData.split("\n")
+                    val out = lines.map { line =>
+                        if (line.trim.isEmpty) line
+                        else {
+                            val el = JsonParser.parseString(line)
+                            if (el.isJsonObject) { injectObject(el.getAsJsonObject); gson.toJson(el) }
+                            else line
+                        }
+                    }
+                    out.mkString("\n")
+                } catch {
+                    case _: Exception => null
+                }
+        }
+    }
+
+    private def stampVector(ctx: JobContext, values: List[(String, String)]): JobContext = {
+        val nonNull = values.filter(_._2 != null)
+        if (nonNull.isEmpty) return ctx
+        val dest = ctx.config.destination
+        if (dest == null) return ctx
+
+        def extend(metadata: java.util.Map[String, String]): java.util.Map[String, String] = {
+            val m = new java.util.LinkedHashMap[String, String]()
+            if (metadata != null) m.putAll(metadata)
+            nonNull.foreach { case (k, v) => m.put(k, v) }
+            m
+        }
+
+        val newDest = dest.copy(
+            qdrant = if (dest.qdrant != null) dest.qdrant.copy(metadata = extend(dest.qdrant.metadata)) else null,
+            weaviate = if (dest.weaviate != null) dest.weaviate.copy(metadata = extend(dest.weaviate.metadata)) else null,
+            pgvector = if (dest.pgvector != null) dest.pgvector.copy(metadata = extend(dest.pgvector.metadata)) else null,
+            milvus = if (dest.milvus != null) dest.milvus.copy(metadata = extend(dest.milvus.metadata)) else null,
+            chroma = if (dest.chroma != null) dest.chroma.copy(metadata = extend(dest.chroma.metadata)) else null
+        )
+        ctx.copy(config = ctx.config.copy(destination = newDest))
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/util/TapRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/TapRunner.scala
@@ -5,7 +5,7 @@ Datris
 Copyright (C) 2026 Datris (https://datris.ai)
  */
 
-import ai.datris.model.{DatrisEnvironment, DatrisException, GlobalJobContext, TapConfig, TapDocumentLedger, TapRunLog}
+import ai.datris.model.{DatrisEnvironment, DatrisException, GlobalJobContext, TapConfig, TapDocumentLedger, TapFeedInfo, TapRunLog}
 import ai.datris.controller.{JobRunner, StreamNotifier}
 import com.google.gson.{Gson, JsonParser}
 import org.slf4j.{Logger, LoggerFactory}
@@ -182,7 +182,7 @@ object TapRunner {
                     tapConfig.targetPipeline != null && tapConfig.targetPipeline.nonEmpty
                 ) {
                     feedStarted = true
-                    feedPipeline(tapConfig, result, publisherToken)
+                    feedPipeline(tapConfig, result, publisherToken, TapFeedInfo(tapConfig.name, now, tapConfig.scriptCommitSha, declaredSource(tapConfig)))
                 } else (result.recordCount, new java.util.ArrayList[String]())
 
             if (push) {
@@ -290,9 +290,23 @@ object TapRunner {
         }
     }
 
-    private def feedPipeline(tapConfig: TapConfig, result: TapScriptResult, publisherToken: String): (Int, java.util.List[String]) = {
+    /** The tap's declared source identity for provenance: the endpoint host for
+      * HTTP taps, `tap:<name>` for script taps. Never credentials. */
+    private[util] def declaredSource(tapConfig: TapConfig): String = {
+        if (tapConfig.isHttp && tapConfig.endpointUrl != null) {
+            try {
+                val host = java.net.URI.create(tapConfig.endpointUrl).getHost
+                if (host != null) host else "tap:" + tapConfig.name
+            } catch {
+                case _: Exception => "tap:" + tapConfig.name
+            }
+        } else
+            "tap:" + tapConfig.name
+    }
+
+    private def feedPipeline(tapConfig: TapConfig, result: TapScriptResult, publisherToken: String, tapFeed: TapFeedInfo): (Int, java.util.List[String]) = {
         if (result.dataType == "document") {
-            return feedDocumentPipeline(tapConfig, result, publisherToken)
+            return feedDocumentPipeline(tapConfig, result, publisherToken, tapFeed)
         }
 
         logger.info("TapRunner: feeding " + result.recordCount + " records to pipeline: " + tapConfig.targetPipeline)
@@ -320,7 +334,7 @@ object TapRunner {
             (result.records.getBytes("UTF-8"), "tap-" + tapConfig.name + ".json")
         }
 
-        val jobContext = new StreamNotifier().process(bytes, filename, tapConfig.targetPipeline, publisherToken)
+        val jobContext = new StreamNotifier().process(bytes, filename, tapConfig.targetPipeline, publisherToken, tapFeed)
         GlobalJobContext.addJobContext(jobContext)
         logger.info("TapRunner: submitted job for pipeline: " + tapConfig.targetPipeline + ", token: " + jobContext.pipelineToken)
         val tokens = new java.util.ArrayList[String]()
@@ -345,7 +359,12 @@ object TapRunner {
      * Returns the number of documents actually submitted to the pipeline (skipped docs
      * and failed docs are not counted).
      */
-    private def feedDocumentPipeline(tapConfig: TapConfig, result: TapScriptResult, publisherToken: String): (Int, java.util.List[String]) = {
+    private def feedDocumentPipeline(
+        tapConfig: TapConfig,
+        result: TapScriptResult,
+        publisherToken: String,
+        tapFeed: TapFeedInfo
+    ): (Int, java.util.List[String]) = {
         import scala.collection.JavaConverters._
         logger.info("TapRunner: document tap '" + tapConfig.name + "' returned " + result.recordCount + " documents")
         val tokens = new java.util.ArrayList[String]()
@@ -440,7 +459,7 @@ object TapRunner {
                         )
 
                         try {
-                            val jobContext = new StreamNotifier().process(rawBytes, filename, tapConfig.targetPipeline, publisherToken)
+                            val jobContext = new StreamNotifier().process(rawBytes, filename, tapConfig.targetPipeline, publisherToken, tapFeed)
                             GlobalJobContext.addJobContext(jobContext)
                             tokens.add(jobContext.pipelineToken)
                             TapDocumentLedgerIO.write(

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -33,8 +33,15 @@ class MCPToolRoutesSpec extends AnyFunSuite {
     )
 
     test("catalog has one row per MCP tool, no duplicates") {
-        assert(MCPToolRoutes.allToolNames.size == 70)
+        assert(MCPToolRoutes.allToolNames.size == 72)
         assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
+    }
+
+    test("discovery + provenance routes are capability-mapped as metadata reads") {
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/provenance") == RouteCheck.Require("metadata", "read"))
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/lineage") == RouteCheck.Require("metadata", "read"))
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/lineage/pipeline/example") == RouteCheck.Require("metadata", "read"))
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/catalog/find") == RouteCheck.Require("metadata", "read"))
     }
 
     test("drift guard: every Mapped row resolves in CapabilityRoutes") {

--- a/datrisserver/src/test/scala/ai/datris/util/CatalogFindSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/CatalogFindSpec.scala
@@ -70,6 +70,14 @@ class CatalogFindSpec extends AnyFunSuite {
         assert(CatalogFind.howToQuery("p", ref("activemq", "queue" -> "q")) == null)
     }
 
+    test("a tag shared by pipeline and tap shows once in a hit") {
+        val p = pipeline("orders", tagList = tags("provenance-test", "orders"))
+        val t = tap("orders-export", "orders", "d").copy(tags = tags("provenance-test"))
+        assert(CatalogFind.mergedTags(p, Some(t)) == List("provenance-test", "orders"))
+        assert(CatalogFind.mergedTags(p, None) == List("provenance-test", "orders"))
+        assert(CatalogFind.mergedTags(pipeline("bare"), None) == Nil)
+    }
+
     test("weaviate hint uses class_name, matching the search tool's schema") {
         val w = CatalogFind.howToQuery("p", LineageService.DatasetRef("weaviate", List("collection" -> "Documents")))
         assert(w.get("tool").getAsString == "search_weaviate")

--- a/datrisserver/src/test/scala/ai/datris/util/CatalogFindSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/CatalogFindSpec.scala
@@ -1,0 +1,78 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model._
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+class CatalogFindSpec extends AnyFunSuite {
+
+    private def tags(values: String*): java.util.List[String] =
+        new java.util.ArrayList[String](values.asJava)
+
+    private def pipeline(name: String, catalog: String = null, tagList: java.util.List[String] = null): PipelineConfig =
+        PipelineConfig(name = name, catalog = catalog, tags = tagList)
+
+    private def tap(name: String, target: String, description: String): TapConfig =
+        TapConfig(name = name, description = description, targetPipeline = target)
+
+    test("tokenize lowercases and splits on non-alphanumerics, dropping single chars") {
+        assert(CatalogFind.tokenize("Customer-Orders_2026 landed!") == List("customer", "orders", "2026", "landed"))
+        assert(CatalogFind.tokenize(null) == Nil)
+    }
+
+    test("scoring ranks the better lexical match first, deterministically") {
+        val orders = pipeline("orders", catalog = "commerce", tagList = tags("sales"))
+        val weather = pipeline("weather", catalog = "science")
+        val q = CatalogFind.tokenize("customer orders this week")
+        val sOrders = CatalogFind.score(q, orders, Some(tap("orders-export", "orders", "Daily order export")))
+        val sWeather = CatalogFind.score(q, weather, None)
+        assert(sOrders > sWeather)
+    }
+
+    test("tag matches count toward the score") {
+        val tagged = pipeline("p1", tagList = tags("sales"))
+        val untagged = pipeline("p2")
+        val q = CatalogFind.tokenize("sales")
+        assert(CatalogFind.score(q, tagged, None) > CatalogFind.score(q, untagged, None))
+    }
+
+    test("howToQuery names the existing tool with pre-filled arguments per kind") {
+        def ref(kind: String, coords: (String, String)*) = LineageService.DatasetRef(kind, coords.toList)
+
+        val pg = CatalogFind.howToQuery("p", ref("postgres", "database" -> "datris", "schema" -> "public", "table" -> "orders"))
+        assert(pg.get("tool").getAsString == "query_postgres")
+        assert(pg.getAsJsonObject("args").get("sql").getAsString == "SELECT * FROM \"public\".\"orders\" LIMIT 100")
+
+        val mongo = CatalogFind.howToQuery("p", ref("mongodb", "database" -> "datris", "collection" -> "orders"))
+        assert(mongo.get("tool").getAsString == "query_mongodb")
+        assert(mongo.getAsJsonObject("args").get("collection").getAsString == "orders")
+
+        val sf = CatalogFind.howToQuery("p", ref("snowflake", "table" -> "t"))
+        assert(sf.get("tool").getAsString == "query_snowflake")
+        assert(sf.getAsJsonObject("args").get("pipeline").getAsString == "p")
+
+        val qd = CatalogFind.howToQuery("p", ref("qdrant", "collection" -> "chunks"))
+        assert(qd.get("tool").getAsString == "search_qdrant")
+        assert(qd.getAsJsonObject("args").get("collection").getAsString == "chunks")
+
+        val pgv = CatalogFind.howToQuery("p", ref("pgvector", "schema" -> "public", "table" -> "docs"))
+        assert(pgv.get("tool").getAsString == "search_pgvector")
+        assert(pgv.getAsJsonObject("args").get("table").getAsString == "docs")
+
+        // Destinations without a query tool return no hint.
+        assert(CatalogFind.howToQuery("p", ref("kafka", "topic" -> "events")) == null)
+        assert(CatalogFind.howToQuery("p", ref("activemq", "queue" -> "q")) == null)
+    }
+
+    test("weaviate hint uses class_name, matching the search tool's schema") {
+        val w = CatalogFind.howToQuery("p", LineageService.DatasetRef("weaviate", List("collection" -> "Documents")))
+        assert(w.get("tool").getAsString == "search_weaviate")
+        assert(w.getAsJsonObject("args").get("class_name").getAsString == "Documents")
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/LineageServiceSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/LineageServiceSpec.scala
@@ -1,0 +1,78 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model._
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+class LineageServiceSpec extends AnyFunSuite {
+
+    private def pipeline(name: String, catalog: String = null, dest: Destination): PipelineConfig =
+        PipelineConfig(name = name, catalog = catalog, destination = dest)
+
+    private def tap(name: String, target: String, catalog: String = null): TapConfig =
+        TapConfig(name = name, description = "d", targetPipeline = target, catalog = catalog)
+
+    private val pgDest = Destination(
+        schemaProperties = null,
+        database = Database(dbName = "datris", schema = "public", table = "orders", usePostgres = true)
+    )
+
+    test("graph chains source → tap → pipeline → dataset → catalog") {
+        val g = LineageService.build(List(tap("orders-export", "orders", "commerce")), List(pipeline("orders", "commerce", pgDest)))
+        val ids = g.nodes.map(_.id)
+        assert(ids.contains("source:tap:orders-export"))
+        assert(ids.contains("tap:orders-export"))
+        assert(ids.contains("pipeline:orders"))
+        assert(ids.contains("dataset:postgres:datris.public.orders"))
+        assert(ids.contains("catalog:commerce"))
+        val edges = g.edges.map(e => e.from -> e.to)
+        assert(edges.contains("source:tap:orders-export" -> "tap:orders-export"))
+        assert(edges.contains("tap:orders-export" -> "pipeline:orders"))
+        assert(edges.contains("pipeline:orders" -> "dataset:postgres:datris.public.orders"))
+        assert(edges.contains("dataset:postgres:datris.public.orders" -> "catalog:commerce"))
+    }
+
+    test("a tap pointing at a deleted pipeline leaves no dangling edge") {
+        val g = LineageService.build(List(tap("orphan", "gone")), Nil)
+        assert(g.nodes.map(_.id).contains("tap:orphan"))
+        assert(!g.edges.exists(_.to == "pipeline:gone"))
+    }
+
+    test("datasets derive one ref per destination, with coordinates") {
+        val multi = Destination(
+            database = Database(dbName = "datris", schema = "public", table = "t", usePostgres = true, useMongoDB = true),
+            qdrant = QdrantConfig("chunks", null, null, "emb", "qd"),
+            kafka = Kafka("events", null, null)
+        )
+        val refs = LineageService.datasets(pipeline("p", dest = multi))
+        val kinds = refs.map(_.kind)
+        assert(kinds == List("postgres", "mongodb", "kafka", "qdrant"))
+        val pg = refs.find(_.kind == "postgres").get
+        assert(pg.name == "postgres:datris.public.t")
+        val mongo = refs.find(_.kind == "mongodb").get
+        assert(mongo.coords.toMap.get("collection").contains("t"))
+    }
+
+    test("an HTTP tap's source node is the endpoint host") {
+        val httpTap = TapConfig(
+            name = "prices",
+            description = "d",
+            targetPipeline = "p",
+            scriptKind = "http",
+            endpointUrl = "https://feeds.example.com/v1/prices"
+        )
+        val g = LineageService.build(List(httpTap), List(pipeline("p", dest = pgDest)))
+        assert(g.nodes.map(_.id).contains("source:feeds.example.com"))
+    }
+
+    test("pipelines without a catalog produce no catalog node") {
+        val g = LineageService.build(Nil, List(pipeline("p", catalog = null, dest = pgDest)))
+        assert(!g.nodes.exists(_.nodeType == "catalog"))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/ProvenanceStamperSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/ProvenanceStamperSpec.scala
@@ -1,0 +1,148 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model._
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+class ProvenanceStamperSpec extends AnyFunSuite {
+
+    private def fields(names: String*): java.util.List[SchemaField] =
+        new java.util.ArrayList[SchemaField](names.map(n => SchemaField(n, "string")).asJava)
+
+    private def config(stamp: Boolean, selected: java.util.List[String] = null): PipelineConfig =
+        PipelineConfig(
+            name = "orders",
+            source = Source(
+                schemaProperties = SchemaProperties("db", fields("id", "amount")),
+                fileAttributes = FileAttributes(csvAttributes = CsvAttributes())
+            ),
+            destination = Destination(schemaProperties = SchemaProperties("db", fields("id", "amount"))),
+            version = 7,
+            provenance = if (stamp) ProvenanceConfig(stamp = true, fields = selected) else null
+        )
+
+    private def delimitedCtx(cfg: PipelineConfig, metadata: PipelineMetadata = null): JobContext =
+        JobContext(
+            "run-123",
+            metadata,
+            Data(10L, List("id", "amount"), List(SchemaField("id", "string"), SchemaField("amount", "string")), List("1,5", "2,9"), null),
+            cfg,
+            null,
+            INITIALIZED,
+            null,
+            null
+        )
+
+    private val tapMetadata =
+        PipelineMetadata(
+            "orders",
+            "f.csv",
+            null,
+            "pub-1",
+            bulkUpload = false,
+            tapName = "prices",
+            tapRunTime = "2026-09-02 06:00:00 UTC",
+            tapScriptSha = "a1b2c3d",
+            tapSource = "example-host"
+        )
+
+    test("stamping is a no-op when provenance is absent or off") {
+        val ctx = delimitedCtx(config(stamp = false))
+        assert(ProvenanceStamper.stamp(ctx) eq ctx)
+        val off = delimitedCtx(config(stamp = false).copy(provenance = ProvenanceConfig(stamp = false)))
+        assert(ProvenanceStamper.stamp(off) eq off)
+    }
+
+    test("delimited stamping appends header, rows, and BOTH in-memory schemas in lockstep") {
+        val stamped = ProvenanceStamper.stamp(delimitedCtx(config(stamp = true), tapMetadata))
+        val names = ProvenanceStamper.AllFields
+        assert(stamped.data.header == List("id", "amount") ++ names)
+        assert(stamped.data.headerWithSchema.map(_.name) == List("id", "amount") ++ names)
+        assert(stamped.config.source.schemaProperties.fields.asScala.map(_.name).toList == List("id", "amount") ++ names)
+        assert(stamped.config.destination.schemaProperties.fields.asScala.map(_.name).toList == List("id", "amount") ++ names)
+        // Every row gains exactly the appended columns, same order.
+        val cols = stamped.data.rows.head.split(",", -1)
+        assert(cols.length == 2 + names.size)
+        assert(cols(2) == "run-123") // _datris_run_id
+        assert(cols(4) == "7") // _datris_config_version
+        assert(cols(5) == "prices|2026-09-02 06:00:00 UTC") // _datris_tap_run
+        assert(cols(6) == "a1b2c3d") // _datris_script_sha
+        assert(cols(7) == "example-host") // _datris_source
+        // All rows carry the identical constant suffix.
+        assert(stamped.data.rows.map(_.split(",", -1).drop(2).toList).distinct.size == 1)
+    }
+
+    test("stamping is idempotent — an already-stamped header is left alone") {
+        val once = ProvenanceStamper.stamp(delimitedCtx(config(stamp = true), tapMetadata))
+        val twice = ProvenanceStamper.stamp(once)
+        assert(twice.data.header == once.data.header)
+        assert(twice.data.rows == once.data.rows)
+    }
+
+    test("direct uploads stamp empty tap fields, not nulls that shift columns") {
+        val stamped = ProvenanceStamper.stamp(delimitedCtx(config(stamp = true), metadata = null))
+        val cols = stamped.data.rows.head.split(",", -1)
+        assert(cols.length == 2 + ProvenanceStamper.AllFields.size)
+        assert(cols(5) == "") // _datris_tap_run empty for non-tap jobs
+        assert(cols(6) == "")
+        assert(cols(7) == "")
+    }
+
+    test("provenance.fields selects a subset, order preserved") {
+        val selected = new java.util.ArrayList[String](List(ProvenanceStamper.RunId, ProvenanceStamper.IngestedAt).asJava)
+        val stamped = ProvenanceStamper.stamp(delimitedCtx(config(stamp = true, selected), tapMetadata))
+        assert(stamped.data.header == List("id", "amount", ProvenanceStamper.RunId, ProvenanceStamper.IngestedAt))
+    }
+
+    test("csvEncode applies the ingest quoting rule") {
+        assert(ProvenanceStamper.csvEncode("plain", ",") == "plain")
+        assert(ProvenanceStamper.csvEncode("a,b", ",") == "\"a,b\"")
+        assert(ProvenanceStamper.csvEncode("say \"hi\"", ",") == "\"say \"\"hi\"\"\"")
+        assert(ProvenanceStamper.csvEncode("tap|run", "|") == "\"tap|run\"")
+    }
+
+    test("injectJson stamps arrays, single objects, and NDJSON; leaves primitives alone") {
+        val values = List(ProvenanceStamper.RunId -> "run-123", ProvenanceStamper.ConfigVersion -> "7")
+        val arr = ProvenanceStamper.injectJson("[{\"a\":1},{\"a\":2}]", values)
+        assert(arr != null && arr.contains("run-123"))
+        assert(com.google.gson.JsonParser.parseString(arr).getAsJsonArray.size() == 2)
+
+        val obj = ProvenanceStamper.injectJson("{\"a\":1}", values)
+        assert(obj != null && com.google.gson.JsonParser.parseString(obj).getAsJsonObject.get(ProvenanceStamper.RunId).getAsString == "run-123")
+
+        val ndjson = ProvenanceStamper.injectJson("{\"a\":1}\n{\"a\":2}", values)
+        assert(ndjson != null && ndjson.split("\n").forall(_.contains("run-123")))
+
+        assert(ProvenanceStamper.injectJson("42", values) == null)
+        assert(ProvenanceStamper.injectJson("not json at [all", values) == null)
+    }
+
+    test("vector destinations get provenance injected into their metadata maps") {
+        val meta = new java.util.LinkedHashMap[String, String]()
+        meta.put("team", "x")
+        val cfg = config(stamp = true).copy(
+            destination = Destination(qdrant = QdrantConfig("docs", null, meta, "emb", "qd"))
+        )
+        val ctx = JobContext("run-123", tapMetadata, Data(10L, null, null, null, null, Array[Byte](1, 2)), cfg, null, INITIALIZED, null, null)
+        val stamped = ProvenanceStamper.stamp(ctx)
+        val m = stamped.config.destination.qdrant.metadata
+        assert(m.get("team") == "x") // existing metadata preserved
+        assert(m.get(ProvenanceStamper.RunId) == "run-123")
+        assert(m.get(ProvenanceStamper.TapRun) == "prices|2026-09-02 06:00:00 UTC")
+        // Original config object untouched (stamp copies, never mutates).
+        assert(!cfg.destination.qdrant.metadata.containsKey(ProvenanceStamper.RunId))
+    }
+
+    test("stampValues reports config version 1 for pre-versioning configs") {
+        val ctx = delimitedCtx(config(stamp = true).copy(version = 0), tapMetadata)
+        val values = ProvenanceStamper.stampValues(ctx, "2026-09-02T00:00:00Z").toMap
+        assert(values(ProvenanceStamper.ConfigVersion) == "1")
+        assert(values(ProvenanceStamper.IngestedAt) == "2026-09-02T00:00:00Z")
+    }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,7 +37,8 @@
           {
             "group": "Catalog",
             "pages": [
-              "data-catalog"
+              "data-catalog",
+              "provenance"
             ]
           },
           {

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -85,7 +85,7 @@ Explore the structure of PostgreSQL, MongoDB, and vector databases managed by th
 
 | Tool | Description |
 |------|-------------|
-| `ai_answer` | Answer a question using AI based on provided context (RAG) |
+| `ai_answer` | Answer a question using AI based on provided context (RAG). Accepts an optional `sources` array of provenance handles, echoed back on the response so the answer and its provenance travel together |
 
 ### Taps
 
@@ -140,6 +140,13 @@ Every tool that changes platform state also accepts an optional `reason` — one
 |------|-------------|
 | `list_incidents` | The platform's [recovery-agent incidents](/incidents), newest first — kind, resource, state, classification and narrative. Read-only: only the platform opens incidents |
 | `get_incident` | One incident by id, with its full step-by-step story and any approvals it waits on. When the operator asks about a failure the platform is already working, explain this record instead of re-diagnosing |
+
+### Discovery and provenance
+
+| Tool | Description |
+|------|-------------|
+| `find_data` | Find datasets by meaning: ranks the pipelines the key can read against a natural-language query and returns location, [freshness](/provenance), provenance handles, lineage and a pre-filled `howToQuery` hint naming the existing query/search tool. Discovery only — the query call stays the agent's own |
+| `get_provenance` | Resolve a stamped `_datris_run_id` back to its origin: pipeline run, tap run, script commit, config version and declared source. See [Provenance](/provenance) |
 
 ## Monitoring Active Agents
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -224,12 +224,25 @@ components:
         context:
           type: string
           description: Context text to base the answer on (e.g., retrieved document chunks)
+        sources:
+          type: array
+          items:
+            type: object
+          description: >-
+            Optional provenance handles for the context (e.g. find_data results
+            or _datris_* fields from search hits). Echoed back unchanged on the
+            response; never fed to the model.
 
     AiAnswerResponse:
       type: object
       properties:
         answer:
           type: string
+        sources:
+          type: array
+          items:
+            type: object
+          description: The request's sources array, echoed unchanged
 
     ConfigUploadResponse:
       type: object
@@ -4157,3 +4170,190 @@ paths:
                     type: string
         '500':
           description: Error (including missing key)
+
+  # ── Provenance / Lineage / Discovery (v1.26) ──────────────────────────────
+  /api/v1/provenance:
+    get:
+      tags: [Provenance]
+      summary: Resolve a stamped run id to its origin
+      description: >-
+        Walks a `_datris_run_id` back through the chain run → job status → tap
+        run → script commit → pipeline config version → declared source and
+        returns one document. Pass the row's `_datris_tap_run` and
+        `_datris_config_version` values when available for exact resolution.
+      parameters:
+        - in: query
+          name: runId
+          required: true
+          schema:
+            type: string
+          description: The `_datris_run_id` value (the pipeline run token)
+        - in: query
+          name: pipeline
+          schema:
+            type: string
+          description: Pipeline name, if known
+        - in: query
+          name: tapRun
+          schema:
+            type: string
+          description: The `_datris_tap_run` value, if present
+        - in: query
+          name: configVersion
+          schema:
+            type: integer
+          description: The `_datris_config_version` value, if present
+      responses:
+        '200':
+          description: The resolved provenance chain
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runId:
+                    type: string
+                  pipeline:
+                    type: string
+                  job:
+                    type: object
+                  tapRun:
+                    type: object
+                  tap:
+                    type: object
+                  configVersion:
+                    type: object
+                  source:
+                    type: string
+        '400':
+          description: runId missing
+  /api/v1/lineage:
+    get:
+      tags: [Provenance]
+      summary: The whole lineage graph
+      description: >-
+        The graph Source → Tap → Pipeline → Dataset → Catalog, derived from
+        configuration alone (cached ~1 minute). Node ids are `type:name`.
+      responses:
+        '200':
+          description: Nodes and edges
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                          enum: [source, tap, pipeline, dataset, catalog]
+                        name:
+                          type: string
+                        catalog:
+                          type: string
+                  edges:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        from:
+                          type: string
+                        to:
+                          type: string
+  /api/v1/lineage/{type}/{name}:
+    get:
+      tags: [Provenance]
+      summary: One node's lineage neighborhood
+      description: >-
+        The node, everything transitively upstream and downstream, the edges
+        between them, and freshness for the pipeline the node is (or feeds).
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [source, tap, pipeline, dataset, catalog]
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The neighborhood
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  node:
+                    type: object
+                  upstream:
+                    type: array
+                    items:
+                      type: object
+                  downstream:
+                    type: array
+                    items:
+                      type: object
+                  edges:
+                    type: array
+                    items:
+                      type: object
+                  freshness:
+                    type: object
+        '404':
+          description: No such node
+  /api/v1/catalog/find:
+    get:
+      tags: [Provenance]
+      summary: Find datasets by meaning (discovery, not execution)
+      description: >-
+        Ranks the pipelines the calling key may read against a natural-language
+        query (name, description, tags, catalog, destination field names,
+        source host). Each hit carries location, freshness, provenance handles,
+        lineage and a pre-filled `howToQuery` hint naming an existing
+        query/search tool — the caller still makes that call itself, under its
+        own capabilities.
+      parameters:
+        - in: query
+          name: query
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 5
+            maximum: 25
+        - in: query
+          name: ai
+          schema:
+            type: boolean
+            default: false
+          description: Rerank the top candidates with the primary AI model
+      responses:
+        '200':
+          description: Ranked hits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                  count:
+                    type: integer
+                  totalMatches:
+                    type: integer
+        '400':
+          description: query missing

--- a/docs/pipeline-configuration.mdx
+++ b/docs/pipeline-configuration.mdx
@@ -86,6 +86,8 @@ You don't need to write JSON by hand — once you have the Datris Data Platform 
 | `transformation` | object | No | Data transformation settings |
 | `destination` | object | Yes | One or more output destinations |
 | `catalog` | string | No | Free-form label that groups related pipelines and taps in the [Data Catalog](/data-catalog). Empty or null = Uncataloged. |
+| `tags` | string[] | No | Free-form discovery labels — `find_data` and the catalog search rank over them. See [Provenance, Lineage & Discovery](/provenance). |
+| `provenance` | object | No | `{ "stamp": true }` appends `_datris_*` provenance fields to every row this pipeline lands. Off by default. See [Provenance, Lineage & Discovery](/provenance). |
 
 ### Source
 

--- a/docs/provenance.mdx
+++ b/docs/provenance.mdx
@@ -1,0 +1,88 @@
+---
+title: "Provenance, Lineage & Discovery"
+description: "Trace any landed row back to the run, config version, script commit and source that produced it — and let agents find datasets by meaning."
+---
+
+Every answer an agent gives from Datris data should be traceable. Three features make that real:
+
+- **Provenance stamping** (opt-in per pipeline) writes run identity onto every row, document, message and vector chunk a pipeline lands.
+- **Lineage** shows the chain *Source → Tap → Pipeline → Dataset → Catalog*, derived deterministically from your configuration — no AI, no inference.
+- **`find_data`** lets an agent discover a dataset by meaning, learn where it lives, how fresh it is, and exactly how to query it — without Datris executing anything on its behalf.
+
+## Provenance stamping
+
+Turn it on per pipeline: **Catalog → pipeline → Edit → Destination step → "Stamp provenance on landed data"**, or set it in the config:
+
+```json
+{
+  "name": "orders",
+  "provenance": { "stamp": true }
+}
+```
+
+From the next run on, every row the pipeline lands carries six extra fields:
+
+| Field | Meaning |
+|-------|---------|
+| `_datris_run_id` | The pipeline run that landed this row |
+| `_datris_ingested_at` | When it landed (UTC, ISO-8601) |
+| `_datris_config_version` | The pipeline definition version at run time |
+| `_datris_tap_run` | The tap run that fed it (`tapName\|runTime`; empty for direct uploads) |
+| `_datris_script_sha` | The tap script's commit, for repository-backed taps |
+| `_datris_source` | The tap's declared source — an endpoint host or tap id, never credentials |
+
+How the fields land depends on the destination:
+
+- **PostgreSQL, Snowflake, Databricks** — columns, auto-added as text to existing tables on the first stamped run (the same additive schema evolution new CSV columns already get).
+- **MongoDB and JSON data** — keys on each document. XML data is not stamped.
+- **Object store (CSV/Parquet)** — columns in the written files, from the first stamped run on.
+- **Kafka / ActiveMQ** — fields in each message; consumers that ignore unknown fields are unaffected.
+- **Vector stores** — payload metadata on every chunk, so search results cite the run and source per chunk.
+
+Rows are **never rewritten retroactively**: provenance starts at the first run after the toggle is turned on, and older rows read as null/absent. Stamped columns are always stored as text and are never proposed for retyping by the destination-typing flow.
+
+A subset of fields can be selected with `"provenance": { "stamp": true, "fields": ["_datris_run_id", "_datris_ingested_at"] }`.
+
+## Resolving a stamp
+
+`GET /api/v1/provenance?runId=<_datris_run_id>` (or the `get_provenance` MCP tool) walks the chain and returns one document: the run's job status and record count, the tap run that fed it (with logs metadata and script commit), the pipeline config version snapshot, and the declared source. Pass the row's `_datris_tap_run` and `_datris_config_version` values when you have them for an exact, lookup-only resolution.
+
+## Lineage & freshness
+
+`GET /api/v1/lineage` returns the whole graph; `GET /api/v1/lineage/{type}/{name}` returns one node's neighborhood — everything upstream and downstream of a source, tap, pipeline, dataset, or catalog. The graph is built from configuration alone, on request.
+
+Freshness per pipeline combines the last successful landing, its record count, the incremental sync cursor (when the feeding tap keeps one), and the same stale classification the Ops Activity dashboard uses — the catalog and the dashboard never disagree.
+
+In the UI, a pipeline's detail page shows its upstream tap and source, the datasets it lands in, and the freshness line.
+
+## Tags
+
+Taps and pipelines take free-form `tags` (edit them in the wizards, or via the API). They render in the catalog tables and feed discovery ranking. That is the whole "business concept" layer: explicit, reviewable, boring.
+
+## `find_data` — discovery without execution
+
+The `find_data` MCP tool (or `GET /api/v1/catalog/find?query=…`) ranks the pipelines the calling key can read against a natural-language query — over names, descriptions, tags, catalogs, destination field names and source hosts. Each hit returns:
+
+```json
+{
+  "name": "orders",
+  "description": "Daily order export",
+  "tags": ["sales"],
+  "catalog": "commerce",
+  "freshness": { "state": "fresh", "lastLandedAt": "…", "recordCount": 14223 },
+  "location": { "kind": "postgres", "database": "datris", "schema": "public", "table": "orders" },
+  "howToQuery": { "tool": "query_postgres", "args": { "sql": "SELECT * FROM \"public\".\"orders\" LIMIT 100" } },
+  "provenance": { "latestRunId": "…", "configVersion": 12, "scriptSha": "a1b2c3d" },
+  "lineage": { "upstream": ["tap:orders-export"], "downstream": ["dataset:postgres:datris.public.orders"] }
+}
+```
+
+`howToQuery` names an **existing** tool with pre-filled arguments; the agent still makes that call itself, under its own capabilities. That is deliberate:
+
+1. Capabilities are enforced at the query call — a viewer key can find but not read.
+2. Provenance attaches to the dataset actually queried, not a synthesized result.
+3. The agent's loop stays visible — a wrong hint is a tool error the agent sees and corrects, not a silently wrong answer.
+
+Ranking is deterministic by default; pass `ai=true` for an optional rerank of the top candidates by the primary AI model.
+
+To carry provenance through to an answer, pass the handles to `ai_answer` as `sources` — they are echoed back on the response, alongside the answer text, and never fed to the model.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -2119,6 +2119,11 @@ def _base_tools():
                 "properties": {
                     "query": {"type": "string", "description": "The question to answer"},
                     "context": {"type": "string", "description": "Context text to base the answer on (e.g., retrieved document chunks)"},
+                    "sources": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": "Optional provenance handles for the context (e.g. find_data results or _datris_* fields from search hits). Echoed back unchanged on the response so the answer and its provenance travel together.",
+                    },
                 },
                 "required": ["query", "context"]
             }
@@ -2842,6 +2847,49 @@ def _base_tools():
                 "required": ["incident_id"],
             }
         ),
+        # --- Discovery + provenance (read-only) ---
+        Tool(
+            name="find_data",
+            description=(
+                "Find datasets by meaning: ranks the pipelines your key can read against a natural-language "
+                "query over their names, descriptions, tags, catalogs, destination field names, and source hosts. "
+                "Each hit returns where the data lives, how fresh it is, provenance handles (latest run id, config "
+                "version, script sha), lineage, and a `howToQuery` hint naming the existing query/search tool with "
+                "pre-filled arguments. Discovery only — nothing is executed for you: make the query call yourself, "
+                "then pass its provenance handles to ai_answer as `sources` so the answer carries them."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Natural-language description of the data you need."},
+                    "limit": {"type": "integer", "description": "Maximum results to return (default: 5, max: 25)."},
+                    "ai": {
+                        "type": "boolean",
+                        "description": "Rerank the top candidates with the platform's primary AI model (default: false — ranking is deterministic).",
+                    },
+                },
+                "required": ["query"],
+            }
+        ),
+        Tool(
+            name="get_provenance",
+            description=(
+                "Resolve a stamped `_datris_run_id` value back to its origin: the pipeline run, the tap run that fed "
+                "it, the script commit, the pipeline config version, and the declared source. Use it when rows or "
+                "search results carry `_datris_*` provenance fields (pipelines with provenance stamping enabled). "
+                "Returns one document walking the whole chain."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "run_id": {"type": "string", "description": "The `_datris_run_id` value from the data (the pipeline run token)."},
+                    "pipeline": {"type": "string", "description": "Pipeline name, if known (speeds resolution)."},
+                    "tap_run": {"type": "string", "description": "The `_datris_tap_run` value from the data, if present."},
+                    "config_version": {"type": "integer", "description": "The `_datris_config_version` value from the data, if present."},
+                },
+                "required": ["run_id"],
+            }
+        ),
     ]
 
 
@@ -2925,6 +2973,7 @@ def _dispatch(name: str, args: dict) -> str:
                         "destination": dest_kind,
                         "target": target,
                         "catalog": p.get("catalog"),
+                        "tags": p.get("tags"),
                         "version": p.get("version"),
                     })
                 return json.dumps({"count": len(summary), "names": [s["name"] for s in summary], "pipelines": summary}, indent=2)
@@ -3338,6 +3387,8 @@ def _dispatch(name: str, args: dict) -> str:
     # --- AI ---
     elif name == "ai_answer":
         payload = {"query": args["query"], "context": args["context"]}
+        if args.get("sources"):
+            payload["sources"] = args["sources"]
         return _call("post", "/api/v1/ai/answer", json=payload)
 
     # --- Config ---
@@ -3853,6 +3904,30 @@ def _dispatch(name: str, args: dict) -> str:
         if not incident_id:
             return json.dumps({"error": "incident_id is required"})
         return _call("get", f"/api/v1/incidents/{incident_id}")
+
+    elif name == "find_data":
+        query = str(args.get("query", "")).strip()
+        if not query:
+            return json.dumps({"error": "query is required"})
+        params = {"query": query}
+        if args.get("limit"):
+            params["limit"] = args["limit"]
+        if args.get("ai"):
+            params["ai"] = "true"
+        return _call("get", "/api/v1/catalog/find", params=params)
+
+    elif name == "get_provenance":
+        run_id = str(args.get("run_id", "")).strip()
+        if not run_id:
+            return json.dumps({"error": "run_id is required"})
+        params = {"runId": run_id}
+        if args.get("pipeline"):
+            params["pipeline"] = args["pipeline"]
+        if args.get("tap_run"):
+            params["tapRun"] = args["tap_run"]
+        if args.get("config_version"):
+            params["configVersion"] = args["config_version"]
+        return _call("get", "/api/v1/provenance", params=params)
 
     else:
         return json.dumps({"error": f"Unknown tool: {name}"})

--- a/ui/src/app/lineage.service.ts
+++ b/ui/src/app/lineage.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+/** Deterministic lineage views (v1.26): the config-derived graph
+ *  Source → Tap → Pipeline → Dataset → Catalog, plus per-pipeline freshness.
+ *  Server logic lives in LineageService (Scala); this is a thin typed client. */
+
+export interface LineageNode {
+  id: string;
+  type: 'source' | 'tap' | 'pipeline' | 'dataset' | 'catalog';
+  name: string;
+  catalog?: string;
+}
+
+export interface LineageEdge {
+  from: string;
+  to: string;
+}
+
+export interface LineageGraph {
+  nodes: LineageNode[];
+  edges: LineageEdge[];
+}
+
+export interface LineageFreshness {
+  state: 'fresh' | 'stale' | 'unknown';
+  lastLandedAt?: string;
+  recordCount?: number;
+  latestRunId?: string;
+  cursorUpdatedAt?: string;
+}
+
+export interface LineageNeighborhood {
+  node: LineageNode;
+  upstream: LineageNode[];
+  downstream: LineageNode[];
+  edges: LineageEdge[];
+  freshness?: LineageFreshness;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LineageService {
+  constructor(private http: HttpClient) { }
+
+  graph(): Observable<LineageGraph> {
+    return this.http.get<LineageGraph>('/api/v1/lineage');
+  }
+
+  neighborhood(type: string, name: string): Observable<LineageNeighborhood> {
+    return this.http.get<LineageNeighborhood>(
+      '/api/v1/lineage/' + encodeURIComponent(type) + '/' + encodeURIComponent(name)
+    );
+  }
+}

--- a/ui/src/app/mcp.service.ts
+++ b/ui/src/app/mcp.service.ts
@@ -334,6 +334,32 @@ export class McpService {
           map((data: any) => ({ secret: params['name'], fields: Object.keys(data || {}).filter(k => k !== '_type') }))
         );
 
+      // Incidents (playground cases were missing when the v1.25 catalog
+      // entries shipped with playgroundEnabled: true)
+      case 'list_incidents': {
+        let ip = new HttpParams();
+        if (params['state']) ip = ip.set('state', params['state']);
+        if (params['limit']) ip = ip.set('limit', params['limit']);
+        return this.http.get<any>('/api/v1/incidents', { params: ip });
+      }
+      case 'get_incident':
+        return this.http.get<any>('/api/v1/incidents/' + encodeURIComponent(params['incident_id']));
+
+      // Discovery & Provenance
+      case 'find_data': {
+        let fp = new HttpParams().set('query', params['query']);
+        if (params['limit']) fp = fp.set('limit', params['limit']);
+        if (params['ai']) fp = fp.set('ai', 'true');
+        return this.http.get<any>('/api/v1/catalog/find', { params: fp });
+      }
+      case 'get_provenance': {
+        let pp = new HttpParams().set('runId', params['run_id']);
+        if (params['pipeline']) pp = pp.set('pipeline', params['pipeline']);
+        if (params['tap_run']) pp = pp.set('tapRun', params['tap_run']);
+        if (params['config_version']) pp = pp.set('configVersion', params['config_version']);
+        return this.http.get<any>('/api/v1/provenance', { params: pp });
+      }
+
       default:
         throw new Error('Unknown tool: ' + toolName);
     }

--- a/ui/src/app/mcp/mcp.component.ts
+++ b/ui/src/app/mcp/mcp.component.ts
@@ -63,7 +63,7 @@ export class McpComponent implements OnInit {
 
   // Full tool catalog.
   // KEEP IN SYNC with mcp-server/server.py's _base_tools() and the server's
-  // auth/MCPToolRoutes.scala — one entry here per MCP tool (70 as of v1.25).
+  // auth/MCPToolRoutes.scala — one entry here per MCP tool (72 as of v1.26).
   toolCatalog: McpTool[] = [
     // --- System ---
     {
@@ -773,6 +773,29 @@ export class McpComponent implements OnInit {
       category: 'Incidents',
       parameters: [
         { name: 'incident_id', type: 'string', description: 'The incident id (inc_…)', required: true, inputType: 'text' }
+      ],
+      playgroundEnabled: true
+    },
+    {
+      name: 'find_data',
+      description: 'Find datasets by meaning: ranks the pipelines your key can read against a natural-language query and returns location, freshness, provenance handles, lineage, and a pre-filled howToQuery hint. Discovery only — the query call stays yours to make.',
+      category: 'Discovery & Provenance',
+      parameters: [
+        { name: 'query', type: 'string', description: 'Natural-language description of the data you need', required: true, inputType: 'text' },
+        { name: 'limit', type: 'integer', description: 'Maximum results (default 5, max 25)', required: false, inputType: 'number' },
+        { name: 'ai', type: 'boolean', description: 'Rerank top candidates with the primary AI model (default false)', required: false, inputType: 'text' }
+      ],
+      playgroundEnabled: true
+    },
+    {
+      name: 'get_provenance',
+      description: 'Resolve a stamped _datris_run_id back to its origin: the pipeline run, the tap run that fed it, the script commit, the config version, and the declared source.',
+      category: 'Discovery & Provenance',
+      parameters: [
+        { name: 'run_id', type: 'string', description: 'The _datris_run_id value from the data', required: true, inputType: 'text' },
+        { name: 'pipeline', type: 'string', description: 'Pipeline name, if known', required: false, inputType: 'text' },
+        { name: 'tap_run', type: 'string', description: 'The _datris_tap_run value, if present', required: false, inputType: 'text' },
+        { name: 'config_version', type: 'integer', description: 'The _datris_config_version value, if present', required: false, inputType: 'number' }
       ],
       playgroundEnabled: true
     },

--- a/ui/src/app/pipeline-create/pipeline-create.component.html
+++ b/ui/src/app/pipeline-create/pipeline-create.component.html
@@ -59,6 +59,12 @@
         </div>
       </div>
 
+      <div class="form-row">
+        <label class="form-label">Tags (optional)</label>
+        <input class="form-input" [(ngModel)]="tagsInput" placeholder="comma-separated, e.g. sales, daily">
+        <p class="form-hint">Discovery labels — find_data and the catalog search rank over them.</p>
+      </div>
+
       <!-- Source toggle -->
       <div class="source-toggle" *ngIf="!isEditMode">
         <button class="toggle-btn" [class.active]="pipelineSource === 'file'" (click)="pipelineSource = 'file'; onPipelineSourceChange()">
@@ -784,6 +790,14 @@
           </div>
         </div>
       </ng-container>
+
+      <div class="form-row">
+        <label class="checkbox-row">
+          <input type="checkbox" [(ngModel)]="provenanceStamp">
+          <span>Stamp provenance on landed data</span>
+        </label>
+        <p class="form-hint">Appends _datris_run_id, _datris_ingested_at, _datris_config_version, _datris_tap_run, _datris_script_sha and _datris_source to every row this pipeline lands, so any record can be traced back to the run, config version, script commit and source that produced it. Existing rows are never rewritten — provenance starts with the first run after this is turned on.</p>
+      </div>
     </div>
 
     <!-- Error -->

--- a/ui/src/app/pipeline-create/pipeline-create.component.ts
+++ b/ui/src/app/pipeline-create/pipeline-create.component.ts
@@ -29,6 +29,8 @@ export class PipelineCreateComponent implements OnInit {
   // Step 1 — Basics + Source
   pipelineName = '';
   catalog = '';
+  tagsInput = '';
+  provenanceStamp = false;
   availableCatalogs: string[] = [];
   showNewCatalog = false;
   newCatalogName = '';
@@ -225,6 +227,8 @@ export class PipelineCreateComponent implements OnInit {
   loadFromConfig(config: any): void {
     this.pipelineName = config.name || '';
     this.catalog = config.catalog || '';
+    this.tagsInput = (config.tags || []).join(', ');
+    this.provenanceStamp = !!config.provenance?.stamp;
     this.sampleFileDetected = true; // skip sample file prompt
 
     // Detect source type
@@ -1167,6 +1171,11 @@ export class PipelineCreateComponent implements OnInit {
 
     // Set catalog on the pipeline config
     config.catalog = this.catalog || null;
+
+    // Tags + provenance. Emit explicit values (the wizard hydrates both in
+    // edit mode, so an empty tags list here is a deliberate clear).
+    config.tags = this.tagsInput.split(',').map(t => t.trim()).filter(t => t.length > 0);
+    config.provenance = { stamp: this.provenanceStamp };
 
     this.pipelineService.createPipeline(config).subscribe({
       next: () => {

--- a/ui/src/app/pipeline-view/pipeline-view.component.css
+++ b/ui/src/app/pipeline-view/pipeline-view.component.css
@@ -232,3 +232,56 @@
 .banner-btn:hover {
   background: rgba(217, 164, 65, 0.15);
 }
+
+/* Lineage & freshness panel (v1.26) */
+.lineage-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.lineage-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.lineage-label {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  min-width: 72px;
+}
+.lineage-detail {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.fresh-chip {
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+.fresh-chip.fresh { color: var(--accent-green); border-color: var(--accent-green); }
+.fresh-chip.stale { color: var(--accent-red); border-color: var(--accent-red); }
+.lineage-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  padding: 3px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  text-decoration: none;
+  background: var(--bg-primary);
+}
+.lineage-chip .material-icons { font-size: 15px; color: var(--text-muted); }
+.lineage-chip.tap:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }

--- a/ui/src/app/pipeline-view/pipeline-view.component.html
+++ b/ui/src/app/pipeline-view/pipeline-view.component.html
@@ -46,6 +46,33 @@
     <button class="banner-btn" *ngIf="auth.canWrite()" (click)="showDestTypes = true">Set types…</button>
   </div>
 
+  <!-- Lineage & freshness (v1.26): config-derived neighborhood + last landing. -->
+  <div class="lineage-panel" *ngIf="lineage">
+    <div class="lineage-row" *ngIf="lineage.freshness as f">
+      <span class="lineage-label">Freshness</span>
+      <span class="fresh-chip" [class.fresh]="f.state === 'fresh'" [class.stale]="f.state === 'stale'">{{ f.state }}</span>
+      <span class="lineage-detail" *ngIf="f.lastLandedAt">last landed {{ f.lastLandedAt }}<ng-container *ngIf="f.recordCount != null"> · {{ f.recordCount }} records</ng-container></span>
+      <span class="lineage-detail" *ngIf="f.cursorUpdatedAt"> · cursor {{ f.cursorUpdatedAt }}</span>
+    </div>
+    <div class="lineage-row" *ngIf="upstreamNodes().length > 0">
+      <span class="lineage-label">Upstream</span>
+      <ng-container *ngFor="let n of upstreamNodes()">
+        <a *ngIf="n.type === 'tap'" class="lineage-chip tap" [routerLink]="['/taps', n.name, 'edit']">
+          <span class="material-icons">water_drop</span>{{ n.name }}
+        </a>
+        <span *ngIf="n.type === 'source'" class="lineage-chip source">
+          <span class="material-icons">public</span>{{ n.name }}
+        </span>
+      </ng-container>
+    </div>
+    <div class="lineage-row" *ngIf="downstreamNodes().length > 0">
+      <span class="lineage-label">Lands in</span>
+      <span class="lineage-chip dataset" *ngFor="let n of downstreamNodes()">
+        <span class="material-icons">storage</span>{{ n.name }}
+      </span>
+    </div>
+  </div>
+
   <div class="config-container" *ngIf="configJson">
     <pre class="config-json" [innerText]="configJson"></pre>
   </div>

--- a/ui/src/app/pipeline-view/pipeline-view.component.ts
+++ b/ui/src/app/pipeline-view/pipeline-view.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { PipelineService } from '../pipeline.service';
 import { AuthService } from '../auth.service';
 import { isAllTextDestination } from '../shared/dest-types';
+import { LineageService, LineageNeighborhood } from '../lineage.service';
 
 @Component({
     selector: 'app-pipeline-view',
@@ -19,14 +20,34 @@ export class PipelineViewComponent implements OnInit, OnDestroy {
   confirmDelete = false;
   deleteLoading = false;
   showDestTypes = false;
+  lineage: LineageNeighborhood | null = null;
   private refreshInterval: any = null;
 
-  constructor(private route: ActivatedRoute, private router: Router, private pipelineService: PipelineService, public auth: AuthService) { }
+  constructor(private route: ActivatedRoute, private router: Router, private pipelineService: PipelineService,
+              private lineageService: LineageService, public auth: AuthService) { }
 
   ngOnInit(): void {
     this.name = this.route.snapshot.paramMap.get('name') || '';
     this.loadPipeline();
+    this.loadLineage();
     this.refreshInterval = setInterval(() => this.loadPipeline(), 3000);
+  }
+
+  /** Loaded once — the server caches the graph ~1 minute anyway. Fail-soft:
+   *  no lineage panel when the endpoint is unavailable. */
+  private loadLineage(): void {
+    this.lineageService.neighborhood('pipeline', this.name).subscribe({
+      next: (n) => this.lineage = n,
+      error: () => this.lineage = null
+    });
+  }
+
+  upstreamNodes(): any[] {
+    return (this.lineage?.upstream || []).filter(n => n.type === 'tap' || n.type === 'source');
+  }
+
+  downstreamNodes(): any[] {
+    return (this.lineage?.downstream || []).filter(n => n.type === 'dataset');
   }
 
   ngOnDestroy(): void {

--- a/ui/src/app/pipelines/pipelines.component.css
+++ b/ui/src/app/pipelines/pipelines.component.css
@@ -817,3 +817,9 @@ tbody tr:last-child td {
   outline: none;
   box-sizing: border-box;
 }
+
+.del-opt:disabled {
+  opacity: 0.6;
+  cursor: default;
+  pointer-events: none;
+}

--- a/ui/src/app/pipelines/pipelines.component.html
+++ b/ui/src/app/pipelines/pipelines.component.html
@@ -58,7 +58,7 @@
           <th>Details</th>
           <th>Connection</th>
           <th>Type</th>
-          <th></th>
+          <th>Tags</th>
           <th></th>
           <th></th>
         </tr>
@@ -94,7 +94,10 @@
             <span class="embed-type-badge" *ngIf="getSourceType(ds)">{{ getSourceType(ds).toUpperCase() }}</span>
             <span class="embed-muted" *ngIf="!getSourceType(ds)">—</span>
           </td>
-          <td></td>
+          <td class="embed-tags-cell">
+            <span class="embed-tag" *ngFor="let t of (ds.tags || [])" [title]="t">{{ t }}</span>
+            <span class="embed-muted" *ngIf="!ds.tags || ds.tags.length === 0">—</span>
+          </td>
           <td></td>
           <td class="embed-actions-cell">
             <!-- Normal action row. Hidden while the delete confirm is up so the

--- a/ui/src/app/pipelines/pipelines.component.html
+++ b/ui/src/app/pipelines/pipelines.component.html
@@ -122,13 +122,13 @@
             </ng-container>
             <span class="delete-menu embed-delete-confirm"
                   *ngIf="auth.canWrite() && deleteTarget === ds.name" (click)="$event.stopPropagation()">
-              <button class="del-opt del-all" (click)="confirmDelete($event, true)" title="Delete config and data">
-                <span class="material-icons">delete_forever</span> Config &amp; Data
+              <button class="del-opt del-all" (click)="confirmDelete($event, true)" [disabled]="deleting === ds.name" title="Delete config and data">
+                <span class="material-icons">{{ deleting === ds.name && deletingMode === 'all' ? 'hourglass_empty' : 'delete_forever' }}</span> {{ deleting === ds.name && deletingMode === 'all' ? 'Deleting...' : 'Config &amp; Data' }}
               </button>
-              <button class="del-opt del-data" (click)="confirmDelete($event, false)" title="Delete data only">
-                <span class="material-icons">cleaning_services</span> Data Only
+              <button class="del-opt del-data" (click)="confirmDelete($event, false)" [disabled]="deleting === ds.name" title="Delete data only">
+                <span class="material-icons">{{ deleting === ds.name && deletingMode === 'data' ? 'hourglass_empty' : 'cleaning_services' }}</span> {{ deleting === ds.name && deletingMode === 'data' ? 'Deleting...' : 'Data Only' }}
               </button>
-              <button class="del-opt del-cancel" (click)="cancelDelete($event)" title="Cancel">
+              <button class="del-opt del-cancel" (click)="cancelDelete($event)" [disabled]="deleting === ds.name" title="Cancel">
                 <span class="material-icons">close</span>
               </button>
             </span>
@@ -179,13 +179,13 @@
             <button class="action-btn edit-btn" (click)="editPipeline($event, ds.name)" title="Edit pipeline" *ngIf="auth.canWrite()"><span class="material-icons">edit</span></button>
             <button class="action-btn delete-btn" (click)="promptDelete($event, ds.name)" title="Delete pipeline" *ngIf="auth.canWrite() && deleteTarget !== ds.name"><span class="material-icons">delete</span></button>
             <div class="delete-menu" *ngIf="auth.canWrite() && deleteTarget === ds.name" (click)="$event.stopPropagation()">
-              <button class="del-opt del-all" (click)="confirmDelete($event, true)" title="Delete config and data">
-                <span class="material-icons">delete_forever</span> Config & Data
+              <button class="del-opt del-all" (click)="confirmDelete($event, true)" [disabled]="deleting === ds.name" title="Delete config and data">
+                <span class="material-icons">{{ deleting === ds.name && deletingMode === 'all' ? 'hourglass_empty' : 'delete_forever' }}</span> {{ deleting === ds.name && deletingMode === 'all' ? 'Deleting...' : 'Config & Data' }}
               </button>
-              <button class="del-opt del-data" (click)="confirmDelete($event, false)" title="Delete data only">
-                <span class="material-icons">cleaning_services</span> Data Only
+              <button class="del-opt del-data" (click)="confirmDelete($event, false)" [disabled]="deleting === ds.name" title="Delete data only">
+                <span class="material-icons">{{ deleting === ds.name && deletingMode === 'data' ? 'hourglass_empty' : 'cleaning_services' }}</span> {{ deleting === ds.name && deletingMode === 'data' ? 'Deleting...' : 'Data Only' }}
               </button>
-              <button class="del-opt del-cancel" (click)="cancelDelete($event)" title="Cancel">
+              <button class="del-opt del-cancel" (click)="cancelDelete($event)" [disabled]="deleting === ds.name" title="Cancel">
                 <span class="material-icons">close</span>
               </button>
             </div>

--- a/ui/src/app/pipelines/pipelines.component.ts
+++ b/ui/src/app/pipelines/pipelines.component.ts
@@ -66,9 +66,9 @@ export class PipelinesComponent implements OnInit, OnDestroy {
     this.loadTaps();
     this.refreshInterval = setInterval(() => {
       // Pause auto-refresh during any row-level interaction a re-render would
-      // destroy: an inline name edit, an open move-to-catalog menu, or an
-      // in-flight column-resize drag.
-      if (this.editingName || this.moveMenuOpen || isColumnDragActive()) return;
+      // destroy: an inline name edit, an open move-to-catalog menu, a pending
+      // or in-flight delete, or an in-flight column-resize drag.
+      if (this.editingName || this.moveMenuOpen || this.deleteTarget || isColumnDragActive()) return;
       this.loadPipelines();
       this.loadTaps();
     }, 5000);
@@ -246,6 +246,10 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   }
 
   deleteTarget = '';
+  // Name + mode of the delete in flight — dropping a table / deleting config
+  // and data can take seconds, so the confirm widget shows progress and locks.
+  deleting = '';
+  deletingMode: 'all' | 'data' | '' = '';
 
   promptDelete(event: Event, name: string): void {
     event.stopPropagation();
@@ -254,6 +258,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
 
   cancelDelete(event: Event): void {
     event.stopPropagation();
+    if (this.deleting) { return; }
     this.deleteTarget = '';
   }
 
@@ -272,16 +277,20 @@ export class PipelinesComponent implements OnInit, OnDestroy {
 
   confirmDelete(event: Event, deleteConfig: boolean): void {
     event.stopPropagation();
+    if (this.deleting) { return; }
     const name = this.deleteTarget;
+    this.deleting = name;
+    this.deletingMode = deleteConfig ? 'all' : 'data';
+    const done = () => { this.deleting = ''; this.deletingMode = ''; this.deleteTarget = ''; };
     if (deleteConfig) {
       this.pipelineService.deletePipeline(name).subscribe({
-        next: () => { this.deleteTarget = ''; this.loadPipelines(); },
-        error: (err) => { alert('Failed to delete: ' + (err.error || err.message)); this.deleteTarget = ''; }
+        next: () => { done(); this.loadPipelines(); },
+        error: (err) => { alert('Failed to delete: ' + (err.error || err.message)); done(); }
       });
     } else {
       this.pipelineService.deletePipelineData(name).subscribe({
-        next: () => { this.deleteTarget = ''; },
-        error: (err) => { alert('Failed to delete data: ' + (err.error || err.message)); this.deleteTarget = ''; }
+        next: () => done(),
+        error: (err) => { alert('Failed to delete data: ' + (err.error || err.message)); done(); }
       });
     }
   }

--- a/ui/src/app/tap-create/tap-create.component.html
+++ b/ui/src/app/tap-create/tap-create.component.html
@@ -155,6 +155,12 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label class="form-label">Tags (optional)</label>
+        <input class="form-input" [(ngModel)]="tagsInput" placeholder="comma-separated, e.g. sales, daily">
+        <p class="form-hint">Discovery labels — find_data and the catalog search rank over them.</p>
+      </div>
+
       <div class="form-group" *ngIf="!bringYourOwnCode && !isHttpTap">
         <label class="form-label">
           <span class="material-icons brainstorm-icon">auto_awesome</span>

--- a/ui/src/app/tap-create/tap-create.component.ts
+++ b/ui/src/app/tap-create/tap-create.component.ts
@@ -26,6 +26,7 @@ export class TapCreateComponent implements OnInit, OnDestroy {
   tapType: 'structured' | 'document' = 'structured';
   secretName = '';
   catalog = '';
+  tagsInput = '';
   availableCatalogs: string[] = [];
   showNewCatalog = false;
   newCatalogName = '';
@@ -250,6 +251,7 @@ export class TapCreateComponent implements OnInit, OnDestroy {
           this.scriptMissing = tap.scriptMissing === true;
           this.secretName = tap.secretName || '';
           this.catalog = tap.catalog || '';
+          this.tagsInput = (tap.tags || []).join(', ');
           this.targetPipeline = tap.targetPipeline || '';
           this.tapType = (tap.tapType === 'document') ? 'document' : 'structured';
           this.scriptStorage = tap.scriptStorage || '';
@@ -1170,6 +1172,10 @@ export class TapCreateComponent implements OnInit, OnDestroy {
     return this.testRecords.slice(0, 100);
   }
 
+  parseTags(): string[] {
+    return this.tagsInput.split(',').map(t => t.trim()).filter(t => t.length > 0);
+  }
+
   save(): void {
     this.saving = true;
     this.error = '';
@@ -1189,7 +1195,8 @@ export class TapCreateComponent implements OnInit, OnDestroy {
             lastTestRunDataType: this.testDataType || null,
             lastTestRunColumns: this.testColumns.length > 0 ? this.testColumns : null,
             lastTestRunRecordCount: this.testRecordCount || 0,
-            catalog: this.catalog || null
+            catalog: this.catalog || null,
+            tags: this.parseTags()
           }
         : {
             name: this.tapName.trim(),
@@ -1207,7 +1214,8 @@ export class TapCreateComponent implements OnInit, OnDestroy {
             lastTestRunDataType: this.testDataType || null,
             lastTestRunColumns: this.testColumns.length > 0 ? this.testColumns : null,
             lastTestRunRecordCount: this.testRecordCount || 0,
-            catalog: this.catalog || null
+            catalog: this.catalog || null,
+            tags: this.parseTags()
           };
 
       this.tapService.createOrUpdateTap(config).subscribe({

--- a/ui/src/app/taps/taps.component.css
+++ b/ui/src/app/taps/taps.component.css
@@ -1136,3 +1136,9 @@ tbody tr:last-child td {
   font-style: italic;
   color: var(--text-muted);
 }
+
+.del-opt:disabled {
+  opacity: 0.6;
+  cursor: default;
+  pointer-events: none;
+}

--- a/ui/src/app/taps/taps.component.html
+++ b/ui/src/app/taps/taps.component.html
@@ -150,10 +150,10 @@
             </ng-container>
             <span class="delete-confirm embed-delete-confirm"
                   *ngIf="auth.canWrite() && deleteTarget === tap.name" (click)="$event.stopPropagation()">
-              <button class="del-opt del-yes" (click)="confirmDelete($event)" title="Confirm delete">
-                <span class="material-icons">delete_forever</span> Delete
+              <button class="del-opt del-yes" (click)="confirmDelete($event)" [disabled]="deleting === tap.name" title="Confirm delete">
+                <span class="material-icons">{{ deleting === tap.name ? 'hourglass_empty' : 'delete_forever' }}</span> {{ deleting === tap.name ? 'Deleting...' : 'Delete' }}
               </button>
-              <button class="del-opt del-cancel" (click)="cancelDelete($event)" title="Cancel">
+              <button class="del-opt del-cancel" (click)="cancelDelete($event)" [disabled]="deleting === tap.name" title="Cancel">
                 <span class="material-icons">close</span>
               </button>
             </span>
@@ -258,10 +258,10 @@
               <span class="material-icons">delete</span>
             </button>
             <div class="delete-confirm" *ngIf="auth.canWrite() && deleteTarget === tap.name" (click)="$event.stopPropagation()">
-              <button class="del-opt del-yes" (click)="confirmDelete($event)">
-                <span class="material-icons">delete_forever</span> Delete
+              <button class="del-opt del-yes" (click)="confirmDelete($event)" [disabled]="deleting === tap.name">
+                <span class="material-icons">{{ deleting === tap.name ? 'hourglass_empty' : 'delete_forever' }}</span> {{ deleting === tap.name ? 'Deleting...' : 'Delete' }}
               </button>
-              <button class="del-opt del-cancel" (click)="cancelDelete($event)">
+              <button class="del-opt del-cancel" (click)="cancelDelete($event)" [disabled]="deleting === tap.name">
                 <span class="material-icons">close</span>
               </button>
             </div>

--- a/ui/src/app/taps/taps.component.html
+++ b/ui/src/app/taps/taps.component.html
@@ -70,7 +70,7 @@
           <th>Name</th>
           <th>Details</th>
           <th>Connection</th>
-          <th></th>
+          <th>Tags</th>
           <th>Schedule</th>
           <th>Last Run</th>
           <th></th>
@@ -102,7 +102,10 @@
             <span *ngIf="tap.targetPipeline" class="embed-connection" [title]="tap.targetPipeline">→ {{ tap.targetPipeline }}</span>
             <span *ngIf="!tap.targetPipeline" class="embed-muted">—</span>
           </td>
-          <td></td>
+          <td class="embed-tags-cell">
+            <span class="embed-tag" *ngFor="let t of (tap.tags || [])" [title]="t">{{ t }}</span>
+            <span class="embed-muted" *ngIf="!tap.tags || tap.tags.length === 0">—</span>
+          </td>
           <td>
             <span class="embed-cron" *ngIf="tap.cronExpression" [title]="tap.cronExpression">{{ tap.cronExpression }}</span>
             <span class="embed-muted" *ngIf="!tap.cronExpression">—</span>

--- a/ui/src/app/taps/taps.component.ts
+++ b/ui/src/app/taps/taps.component.ts
@@ -41,6 +41,10 @@ export class TapsComponent implements OnInit, OnDestroy {
   private refreshInterval: any;
 
   deleteTarget = '';
+  // Name of the tap whose delete is in flight — server-side cleanup (script
+  // store, ledger, staged objects) can take seconds, so the confirm widget
+  // shows progress and locks instead of sitting idle.
+  deleting = '';
   deleteCatalogTarget = '';
   runCatalogTarget = '';
   runningTap = '';
@@ -536,15 +540,18 @@ export class TapsComponent implements OnInit, OnDestroy {
 
   cancelDelete(event: Event): void {
     event.stopPropagation();
+    if (this.deleting) { return; }
     this.deleteTarget = '';
   }
 
   confirmDelete(event: Event): void {
     event.stopPropagation();
+    if (this.deleting) { return; }
     const name = this.deleteTarget;
+    this.deleting = name;
     this.tapService.deleteTap(name).subscribe({
-      next: () => { this.deleteTarget = ''; this.loadTaps(); },
-      error: (err) => { alert('Failed to delete: ' + (err.error || err.message)); this.deleteTarget = ''; }
+      next: () => { this.deleting = ''; this.deleteTarget = ''; this.loadTaps(); },
+      error: (err) => { alert('Failed to delete: ' + (err.error || err.message)); this.deleting = ''; this.deleteTarget = ''; }
     });
   }
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -315,3 +315,20 @@ tr:hover .embed-name-edit-btn { opacity: 1; }
 .catalog-list .catalog-card:has(.embed-move-menu) {
   overflow: visible;
 }
+
+/* Tags chips in the catalog embed tables (v1.26) */
+.embed-tags-cell { white-space: normal; }
+.embed-tag {
+  display: inline-block;
+  font-size: 11px;
+  padding: 1px 7px;
+  margin: 1px 2px 1px 0;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Phase C of the agent-control-plane roadmap: any row Datris lands can say which run, config version, script commit and source produced it — and an agent can discover a dataset by meaning without the platform executing anything on its behalf.

## Provenance stamping (opt-in per pipeline)
- `provenance.stamp` on the pipeline config (default off). A `ProvenanceStamper` runs once per job, after transformation and before every destination loader, appending `_datris_run_id`, `_datris_ingested_at`, `_datris_config_version`, `_datris_tap_run`, `_datris_script_sha`, `_datris_source`.
- Delimited data: appended to the header, every row, and both in-memory schemas (schemas that matched before stamping keep the loaders' no-projection fast path); the stored definition is never touched. SQL destinations gain the columns via the existing Level-1 additive evolution. JSON data: keys injected per document (Mongo included; XML not stamped). Vector stores: injected via the destination metadata maps; PGVector gains `ADD COLUMN IF NOT EXISTS` for metadata columns and Milvus search echoes the fields.
- Tap-run identity (`tapName|runTime`, script commit sha, source host) threads from TapRunner through `PipelineMetadata`, so stamps are exact — no lookups on the hot path.
- `GET /api/v1/provenance` + `get_provenance` MCP tool resolve a stamped run id back through run → job status → tap run → script commit → config version snapshot → declared source.

## Deterministic lineage + freshness
- `LineageService` builds Source → Tap → Pipeline → Dataset → Catalog from configuration alone (no AI, cached ~1 min). `GET /api/v1/lineage` and `/api/v1/lineage/{type}/{name}`.
- Freshness = last successful landing + record count + incremental cursor, with the stale classification shared with ActivitySignals so the catalog and the Activity dashboard never disagree.
- `tags` on taps and pipelines (wizard inputs, chips in the catalog tables, preserved on partial updates); pipeline detail page gets a lineage + freshness panel.

## find_data (discovery, not execution)
- `GET /api/v1/catalog/find` + `find_data` MCP tool: capability-scoped, deterministic lexical ranking (optional `ai=true` rerank), returning location, freshness, provenance handles, lineage, and a pre-filled `howToQuery` naming the existing query/search tool. The agent still makes the query call itself, under its own capabilities.
- `ai_answer` accepts an optional `sources` array, echoed back verbatim (never fed to the model) so answers and their provenance travel together.

## Also in this PR
- Catalog tables show an in-flight "Deleting…" state for tap/pipeline deletes (and the pipelines table pauses auto-refresh while a delete confirm is up).
- MCP playground gains the two new tools plus the missing v1.25 incidents cases; `list_pipelines` surfaces tags.

## Verification
- Server tests 378/378 (21 new across ProvenanceStamperSpec, LineageServiceSpec, CatalogFindSpec, MCPToolRoutesSpec); MCP catalog drift guard green at 72 tools; `ng build` clean.
- Live E2E on a full local rebuild, all green: stamping on a Postgres pipeline with pre-existing rows (columns auto-added, old rows NULL, new rows stamped), tap-fed chain with a real GitHub commit sha, `get_provenance` via both stamped-hint and runId-only paths, `find_data` → `howToQuery` → `query_postgres` round trip, lineage neighborhood, `ai_answer` sources echo.

Everything is additive and off by default: `provenance.stamp=false` on every existing pipeline, lineage/find are read-only views, `tags` default empty. No compose changes, no new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)