### PR TITLE
Claude Fable 5.1 support: recommended aiPrimary model, Bedrock seed default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,7 @@ OPENAI_API_KEY=
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_REGION=us-east-1
-# BEDROCK_MODEL=anthropic.claude-fable-5
+# BEDROCK_MODEL=anthropic.claude-fable-5-1
 
 # Grok (xAI) path: ai-primary and codegen use Grok through xAI's OpenAI-compatible
 # API. XAI_API_KEY comes from console.x.ai. Embeddings default to the bundled

--- a/datrisserver/src/test/scala/ai/datris/util/aiutil/AIProvidersSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/aiutil/AIProvidersSpec.scala
@@ -14,7 +14,9 @@ class AIProvidersSpec extends AnyFunSuite {
     test("adaptive-only Anthropic models reject sampling params") {
         val rejecting = List(
             "claude-fable-5",
+            "claude-fable-5-1",
             "claude-mythos-5",
+            "claude-mythos-5-1",
             "claude-opus-4-7",
             "claude-opus-4-8",
             "claude-opus-5",

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -947,7 +947,7 @@ configs:
           seed_if_absent secret/oss/ai-primary \
             provider="bedrock" \
             endpoint="" \
-            model="$${BEDROCK_MODEL:-anthropic.claude-fable-5}" \
+            model="$${BEDROCK_MODEL:-anthropic.claude-fable-5-1}" \
             apiKey=""
           seed_if_absent secret/oss/codegen \
             provider="bedrock" \

--- a/docker/vault-init.sh
+++ b/docker/vault-init.sh
@@ -139,7 +139,7 @@ else
     seed_if_absent secret/oss/ai-primary \
       provider="bedrock" \
       endpoint="" \
-      model="${BEDROCK_MODEL:-anthropic.claude-fable-5}" \
+      model="${BEDROCK_MODEL:-anthropic.claude-fable-5-1}" \
       apiKey=""
     seed_if_absent secret/oss/codegen \
       provider="bedrock" \

--- a/docs/ai-configuration.mdx
+++ b/docs/ai-configuration.mdx
@@ -158,12 +158,12 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 # Optional model override (default shown):
-# BEDROCK_MODEL=anthropic.claude-fable-5
+# BEDROCK_MODEL=anthropic.claude-fable-5-1
 ```
 
 | Slot | Provider | Endpoint | Model |
 |------|----------|----------|-------|
-| `oss/ai-primary` | bedrock | *(blank — derived from region)* | `BEDROCK_MODEL` or `anthropic.claude-fable-5` |
+| `oss/ai-primary` | bedrock | *(blank — derived from region)* | `BEDROCK_MODEL` or `anthropic.claude-fable-5-1` |
 | `oss/codegen` | bedrock | *(blank — derived from region)* | `CODEGEN_MODEL` or `anthropic.claude-opus-5` |
 | `oss/embedding` | tei | `http://tei:80/v1/embeddings` | `BAAI/bge-m3` |
 
@@ -171,11 +171,11 @@ Notes:
 
 - **Model ids** are Bedrock's `anthropic.`-prefixed forms (e.g. `anthropic.claude-opus-5`). Models that aren't on-demand invokable in your region are addressed by their **cross-region inference profile** id (e.g. `us.anthropic.claude-...`). The Configuration UI discovers the invokable list live from your account when its IAM policy allows it.
 - **Enable model access first.** Models must be enabled for your account in the AWS Bedrock console — a model can appear in listings and still fail with `AccessDeniedException` on the first call until access is granted.
-- **Claude Fable 5 needs a one-time data-retention opt-in.** Fable 5 (and Mythos 5) require Bedrock's `provider_data_share` retention mode — prompts/completions are shared with Anthropic and retained up to 30 days for trust and safety (not used for training; other Claude models are unaffected by the setting). Without it, calls fail with "data retention mode 'default' is not available for this model". Opt in once per account: `PUT /data-retention` with `{"mode": "provider_data_share"}` on the Bedrock control plane (IAM action `bedrock:PutAccountDataRetention`) — see AWS's Bedrock "Data retention" documentation. There is no console UI for this setting at the time of writing.
+- **Claude Fable 5 / 5.1 need a one-time data-retention opt-in.** Fable 5 and 5.1 (and Mythos 5 / 5.1) require Bedrock's `provider_data_share` retention mode — prompts/completions are shared with Anthropic and retained up to 30 days for trust and safety (not used for training; other Claude models are unaffected by the setting). Without it, calls fail with "data retention mode 'default' is not available for this model". Opt in once per account: `PUT /data-retention` with `{"mode": "provider_data_share"}` on the Bedrock control plane (IAM action `bedrock:PutAccountDataRetention`) — see AWS's Bedrock "Data retention" documentation. There is no console UI for this setting at the time of writing.
 - **Minimal IAM policy:** `bedrock:InvokeModel` on the models you use, plus `bedrock:ListFoundationModels` and `bedrock:ListInferenceProfiles` for the UI's live model dropdown (optional — without them the UI shows a standard list).
 - **Endpoint stays blank** in the slot secrets; the invoke URL is derived from the region and model. Set an explicit endpoint only for VPC endpoints or GovCloud.
 - **Embeddings and web search are not available on Bedrock** — embeddings default to the bundled bge-m3 service (or pair with OpenAI/Azure), and web search stays on Anthropic/OpenAI.
-- Extended thinking works the same as on the direct Anthropic provider, including Claude Fable 5's always-on thinking.
+- Extended thinking works the same as on the direct Anthropic provider, including the always-on thinking of Claude Fable 5 and 5.1.
 
 ### Grok (xAI) path
 

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -255,7 +255,7 @@ These `.env` variables tune what gets seeded. They apply on the **first boot onl
 | `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` | — | Entra ID service principal for keyless Azure OpenAI auth (no API key stored anywhere). Single-tenant only; the Configuration tab's Azure credentials section is the equivalent UI path. On Azure compute, leave all auth unset to use the server's managed identity. |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | — | AWS credentials for the Bedrock path (`AI_PROVIDER=bedrock`). Optional — leave unset to use the server's IAM role / default credential chain. Never selects Bedrock by itself. |
 | `AWS_REGION` | — | AWS region for the Bedrock path (e.g. `us-east-1`). |
-| `BEDROCK_MODEL` | `anthropic.claude-fable-5` | Invokable Bedrock model id seeded into `oss/ai-primary` on the Bedrock path. |
+| `BEDROCK_MODEL` | `anthropic.claude-fable-5-1` | Invokable Bedrock model id seeded into `oss/ai-primary` on the Bedrock path. |
 | `XAI_API_KEY` | — | Grok (xAI) API key from console.x.ai, for the Grok path (`AI_PROVIDER=grok`, or auto-picked when it's the sole key). |
 | `GROK_MODEL` | `grok-4.6` | Grok model seeded into `oss/ai-primary` on the Grok path. |
 | `CODEGEN_MODEL` | `claude-opus-5` or `gpt-5.5` | Model seeded into `oss/codegen` (Anthropic and OpenAI defaults; the Azure path defaults to `AZURE_OPENAI_MODEL`; the Bedrock path defaults to `anthropic.claude-opus-5`; the Grok path defaults to `grok-4.6`). |

--- a/ui/src/app/model-catalog.service.ts
+++ b/ui/src/app/model-catalog.service.ts
@@ -26,7 +26,8 @@ const FETCH_TIMEOUT_MS = 5000;
 const FALLBACK: ModelCatalog = {
   aiPrimary: {
     anthropic: [
-      { value: 'claude-fable-5', label: 'Claude Fable 5 (recommended)', recommended: true },
+      { value: 'claude-fable-5-1', label: 'Claude Fable 5.1 (recommended)', recommended: true },
+      { value: 'claude-fable-5', label: 'Claude Fable 5' },
       { value: 'claude-opus-5', label: 'Claude Opus 5' },
       { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
       { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
@@ -46,7 +47,8 @@ const FALLBACK: ModelCatalog = {
     // when AWS credentials are saved, the UI swaps this for live discovery
     // (only models the account/region can actually invoke).
     bedrock: [
-      { value: 'anthropic.claude-fable-5', label: 'Claude Fable 5 (recommended)', recommended: true },
+      { value: 'anthropic.claude-fable-5-1', label: 'Claude Fable 5.1 (recommended)', recommended: true },
+      { value: 'anthropic.claude-fable-5', label: 'Claude Fable 5' },
       { value: 'anthropic.claude-opus-5', label: 'Claude Opus 5' },
       { value: 'anthropic.claude-sonnet-5', label: 'Claude Sonnet 5' },
       { value: 'anthropic.claude-opus-4-8', label: 'Claude Opus 4.8' },
@@ -64,6 +66,7 @@ const FALLBACK: ModelCatalog = {
       { value: 'claude-opus-5', label: 'Claude Opus 5 (recommended)', recommended: true },
       { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
       { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
+      { value: 'claude-fable-5-1', label: 'Claude Fable 5.1' },
       { value: 'claude-fable-5', label: 'Claude Fable 5' },
       { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
       { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
@@ -81,6 +84,7 @@ const FALLBACK: ModelCatalog = {
     ],
     bedrock: [
       { value: 'anthropic.claude-opus-5', label: 'Claude Opus 5 (recommended)', recommended: true },
+      { value: 'anthropic.claude-fable-5-1', label: 'Claude Fable 5.1' },
       { value: 'anthropic.claude-fable-5', label: 'Claude Fable 5' },
       { value: 'anthropic.claude-opus-4-8', label: 'Claude Opus 4.8' },
       { value: 'anthropic.claude-sonnet-5', label: 'Claude Sonnet 5' },


### PR DESCRIPTION
Adds support for Claude Fable 5.1 (`claude-fable-5-1`, released 2026-09-01) and makes it the recommended AI Provider (aiPrimary) model. All other model recommendations are unchanged — CodeGen stays Claude Opus 5.

## Changes

- **UI fallback catalog** (`ui/src/app/model-catalog.service.ts`): Fable 5.1 recommended for aiPrimary (Anthropic + Bedrock), added as a plain option for CodeGen. Mirrors the canonical catalog at docs.datris.ai/models.json (already live via datris.ai PR #1).
- **vault-init.sh**: fresh-install Bedrock ai-primary seed is now `anthropic.claude-fable-5-1`. Existing vaults are unaffected (`seed_if_absent` never overwrites). The direct-Anthropic seed deliberately stays `claude-opus-5` per the documented 2026-07-14 decision.
- **`.env.example` + docs**: `BEDROCK_MODEL` examples/defaults updated; the Bedrock data-retention opt-in note now covers Fable 5.1.
- **`docker-compose.standalone.yml`**: regenerated (embeds vault-init.sh).
- **AIProvidersSpec**: `claude-fable-5-1` / `claude-mythos-5-1` added to the `rejectsSamplingParams` regression list.

## No server code change

`rejectsSamplingParams` matches the `fable` substring, so Fable 5.1 gets correct sampling-param handling automatically; the thinking-form ladder and token-limit logic self-adapt.

## Test plan

- `sbt "testOnly ai.datris.util.aiutil.AIProvidersSpec"` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)