### PR TITLE
Bump fast-uri to 3.1.7 for SSRF/host-confusion advisories

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9423,9 +9423,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the 4 open high-severity Dependabot alerts (#258–#261), all in **fast-uri** — a transitive dependency of the Angular build tooling (`@angular-devkit` → `ajv` → `fast-uri`):

- GHSA-5jgf-p345-68v8 — host confusion via skipped IDN canonicalization
- GHSA-f65p-4m7j-42xc — SSRF via malformed IPv6 normalization
- GHSA-fph4-wmhf-6fwf — SSRF via repeated hostname percent-decoding
- GHSA-jqff-g426-hqxp — host confusion via percent-encoded scheme normalization

All patched in 3.1.6; `npm update fast-uri` resolved to **3.1.7**. Lockfile-only change (3 lines), dev-time dependency — not shipped in the runtime bundle.

## Test plan

- `npm run build` in `ui/` — succeeds (only the pre-existing CSS budget warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)