### PR TITLE
Pin mcp SDK <2 in pyproject.toml, matching requirements.txt

### DIFF
--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp[cli]",
+    # Same pin as requirements.txt: mcp 2.x removed the Server.list_resources/
+    # list_tools decorator API this server is written against.
+    "mcp[cli]>=1.28,<2",
     "requests",
     "click",
     "httpx",


### PR DESCRIPTION
Found while triaging Dependabot #74 (closed — mcp 2.x removed the low-level `Server.list_resources`/`list_tools` decorator API that `server.py` is written against, so the `<2` pin in requirements.txt is deliberate).

The gap: that pin only covered the Docker/requirements.txt path. `pyproject.toml` shipped an unconstrained `"mcp[cli]"`, so **`pip install datris-mcp-server` from PyPI currently resolves mcp 2.x and the server breaks at startup**. This aligns pyproject with requirements.txt (`mcp[cli]>=1.28,<2`) and documents why.

Worth cutting into the next PyPI release so fresh installs stop breaking. SDK 2.x adoption remains a deliberate migration to plan separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)