### PR TITLE
docs: accuracy audit of docs.datris.ai against v1.28.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,7 +181,7 @@ OPENAI_API_KEY=
 # Flip USE_USER_AUTH=true to enable username/password login + admin gating
 # on the Configuration tab. USE_API_KEYS=true enables per-tenant API-key
 # gating on the REST/MCP API. MULTI_TENANT=true switches to per-tenant
-# database isolation (intended for hosted/managed deployments).
+# database isolation (advanced; requires USE_API_KEYS=true).
 # See https://docs.datris.ai/user-auth for the full setup walkthrough.
 # USE_USER_AUTH=false
 # USE_API_KEYS=false
@@ -224,9 +224,16 @@ OPENAI_API_KEY=
 #   private, loopback, or link-local addresses. Off by default so a tap can't be
 #   pointed at cloud metadata or internal services; enable only if your endpoints
 #   legitimately live on an internal network.
+# DATRIS_ENV=production makes pipeline loads refuse external Postgres hosts whose
+#   JDBC URL lacks sslmode=require (bundled/local Postgres is exempt).
+#   DATRIS_ALLOW_PLAINTEXT_DB=true is the opt-out (starts, logs a warning).
+# TAP_MAX_OUTPUT_MB caps a single tap script's output; the run fails fast above it.
 # SESSION_COOKIE_SECURE=true
 # MINIO_WEBHOOK_TOKEN=change-me-to-a-long-random-string
 # DATRIS_ALLOW_PRIVATE_EGRESS=false
+# DATRIS_ENV=production
+# DATRIS_ALLOW_PLAINTEXT_DB=false
+# TAP_MAX_OUTPUT_MB=100
 
 # API keys for accessing Datris (REST API or via the bundled MCP server) are
 # managed in the Configuration UI's Secrets tab — entries in `oss/api-keys`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Agents ask Datris for data. Datris finds it, acquires it, validates it, lands it
 
 Your agents already acquire, validate, and load data. Without a control plane, they do it badly. Datris puts that work behind one governed surface:
 
-- **One MCP door** — 63 capabilities behind a single MCP server. Claude, Cursor, and any MCP-compatible agent learn one interface instead of 63 integrations
+- **One MCP door** — 73 capabilities behind a single MCP server. Claude, Cursor, and any MCP-compatible agent learn one interface instead of 73 integrations
 - **Vault-brokered credentials** — the agent references a secret by name and never holds a key; agent-written code runs in an isolated container with no keys inside
 - **Every run recorded** — job state, row counts, and provenance for every run; every generated script versioned in git
 - **Durable state** — pipelines and sync bookmarks live in the platform, not the chat, so regenerating a script never loses its place
@@ -115,7 +115,7 @@ Source (File Upload / MinIO Event / Database Pull / Kafka)
 
 | Feature | Description |
 |---------|-------------|
-| **MCP Server** | 63 tools for AI agents — pipeline CRUD, upload, query, search, profiling, taps |
+| **MCP Server** | 73 tools for AI agents — pipeline CRUD, upload, query, search, profiling, taps |
 | **AI Data Quality** | Plain English validation rules — AI generates and runs a validation script |
 | **AI Transformation** | Plain English transformations — AI generates and runs a transformation script |
 | **AI Schema Generation** | Upload a file, get a complete pipeline config |

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -330,6 +330,15 @@ services:
       # on a new scope policy and you want a trial run before flipping on.
       # Legacy `*:*` keys are unaffected either way.
       CAPABILITY_ENFORCEMENT: "${CAPABILITY_ENFORCEMENT:-enforce}"
+      # Hardening switches (see docs → Configuration Reference). DATRIS_ENV=production
+      # requires TLS on external Postgres destinations; DATRIS_ALLOW_PLAINTEXT_DB
+      # is the opt-out. DATRIS_ALLOW_PRIVATE_EGRESS lets HTTP taps / REST
+      # endpoints reach private or loopback addresses (off by default).
+      DATRIS_ENV: "${DATRIS_ENV:-}"
+      DATRIS_ALLOW_PLAINTEXT_DB: "${DATRIS_ALLOW_PLAINTEXT_DB:-false}"
+      DATRIS_ALLOW_PRIVATE_EGRESS: "${DATRIS_ALLOW_PRIVATE_EGRESS:-false}"
+      # Cap on a single tap script's output (MB); the server fails fast above it.
+      TAPMAXOUTPUTMB: "${TAP_MAX_OUTPUT_MB:-100}"
       # Operator-override fallback model when Anthropic Opus is sustained-
       # overloaded; read by AgentLoop.sonnetFallbackFor() at runtime.
       ANTHROPIC_OVERLOAD_FALLBACK_MODEL: "${ANTHROPIC_OVERLOAD_FALLBACK_MODEL:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,15 @@ services:
       # on a new scope policy and you want a trial run before flipping on.
       # Legacy `*:*` keys are unaffected either way.
       CAPABILITY_ENFORCEMENT: "${CAPABILITY_ENFORCEMENT:-enforce}"
+      # Hardening switches (see docs → Configuration Reference). DATRIS_ENV=production
+      # requires TLS on external Postgres destinations; DATRIS_ALLOW_PLAINTEXT_DB
+      # is the opt-out. DATRIS_ALLOW_PRIVATE_EGRESS lets HTTP taps / REST
+      # endpoints reach private or loopback addresses (off by default).
+      DATRIS_ENV: "${DATRIS_ENV:-}"
+      DATRIS_ALLOW_PLAINTEXT_DB: "${DATRIS_ALLOW_PLAINTEXT_DB:-false}"
+      DATRIS_ALLOW_PRIVATE_EGRESS: "${DATRIS_ALLOW_PRIVATE_EGRESS:-false}"
+      # Cap on a single tap script's output (MB); the server fails fast above it.
+      TAPMAXOUTPUTMB: "${TAP_MAX_OUTPUT_MB:-100}"
       # Operator-override fallback model when Anthropic Opus is sustained-
       # overloaded; read by AgentLoop.sonnetFallbackFor() at runtime.
       ANTHROPIC_OVERLOAD_FALLBACK_MODEL: "${ANTHROPIC_OVERLOAD_FALLBACK_MODEL:-}"

--- a/docs/agent-policy.mdx
+++ b/docs/agent-policy.mdx
@@ -31,7 +31,7 @@ Off by default — existing installs are unchanged until you opt in.
    docker compose up -d --force-recreate datris
    ```
 
-3. Open **Configuration → Agent Policy** (admins only when user authentication is on). Set the actions you care about, or click **Use recommended** for a starting point that pauses deletes, job kills and destination-type migrations and refuses secret and connection changes.
+3. Open **Configuration → Agent Policy** (admins only when user authentication is on). Set the actions you care about, or click **Use recommended** for a starting point that pauses deletes, job kills and destination-type migrations and refuses secret, code-repository and platform-configuration writes (`secret:write`, `code-repo:write`, `config:write`).
 
 The policy applies within a few seconds of saving; no restart.
 

--- a/docs/ai-configuration.mdx
+++ b/docs/ai-configuration.mdx
@@ -32,7 +32,7 @@ ai:
 
 | Slot | Purpose | Used by |
 |------|---------|---------|
-| `aiPrimary` | General AI tasks | Schema generation, error explanation, brainstorm chat, profiling, header validation, CRON generation, AI Q&A |
+| `aiPrimary` | General AI tasks | Error explanation, brainstorm chat, profiling, header validation, CRON generation, AI Q&A |
 | `codegen` | Code-generation tasks | Tap scripts, `aiRule`, `aiTransformation`, JSON Schema / XSD generation, natural-language → SQL |
 | `embedding` | Vector embeddings | Vector destinations (Qdrant, Weaviate, Milvus, Chroma, pgvector), semantic search |
 | `webSearch` | Live web lookup (optional) | Tap script generation and tap diagnosis when the model needs current API documentation |
@@ -47,9 +47,9 @@ Each Vault secret carries its full configuration inline:
 | `apiKey` | No (not used by ollama or bedrock) | Inline provider API key. The [shared API key store](#shared-api-key-store) is checked first and takes precedence when set. Bedrock authenticates with AWS credentials instead — see the [Bedrock path](#amazon-bedrock-path) |
 | `version` | Optional | API version (Anthropic uses `2023-06-01`) |
 
-The resolver reads each secret at the configured path and uses whatever it finds inside — there is no path derivation from a YAML `provider` field. This means the three slots can independently use different providers (e.g. Anthropic for `aiPrimary`, Ollama for `codegen`, OpenAI for `embedding`).
+The resolver reads each secret at the configured path and uses whatever it finds inside — there is no path derivation from a YAML `provider` field. This means the four slots can independently use different providers (e.g. Anthropic for `aiPrimary`, Ollama for `codegen`, OpenAI for `embedding`).
 
-**All three slots support Ollama** — you can run the entire platform on local models with no API keys. The Configuration UI offers Ollama as a provider choice for every section, with a free-text model input since Ollama supports hundreds of community models.
+**All three seeded slots (`aiPrimary`, `codegen`, `embedding`) support Ollama** — you can run the entire platform on local models with no API keys. The Configuration UI offers Ollama as a provider choice for every section, with a free-text model input since Ollama supports hundreds of community models.
 
 ### Shared API Key Store
 
@@ -72,7 +72,7 @@ Azure compute, workload identity, or `az login`.
 
 ## Quick Start with `.env`
 
-On first boot, `docker/vault-init.sh` seeds all three Vault secrets automatically based on which API key you put in `.env` (see [How Configuration Persists](#how-configuration-persists) — after the first boot, the Configuration tab is the source of truth). Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, the `AZURE_OPENAI_*` trio, `XAI_API_KEY` (see the [Grok path](#grok-xai-path)), or `AI_PROVIDER=bedrock` (see the [Bedrock path](#amazon-bedrock-path)):
+On first boot, `docker/vault-init.sh` seeds the `ai-primary`, `codegen`, and `embedding` Vault secrets automatically (the optional `web-search` slot is not seeded — configure it from the Configuration tab) based on which API key you put in `.env` (see [How Configuration Persists](#how-configuration-persists) — after the first boot, the Configuration tab is the source of truth). Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, the `AZURE_OPENAI_*` trio, `XAI_API_KEY` (see the [Grok path](#grok-xai-path)), or `AI_PROVIDER=bedrock` (see the [Bedrock path](#amazon-bedrock-path)):
 
 ```bash
 # .env
@@ -225,7 +225,7 @@ You can run all three slots on a local Ollama instance — no cloud API keys nee
 
 If you only need local **chat** but want to keep the bundled embedding service (TEI), leave `oss/embedding` pointed at `http://tei:80/v1/embeddings` with `model="BAAI/bge-m3"` and only switch the AI Primary and CodeGen slots to Ollama.
 
-The Configuration UI makes this easy — select **Ollama (if optional service enabled)** as the provider, type your model name, and the endpoint defaults to `ollama:11434`. No API key is required.
+The Configuration UI makes this easy — select **Ollama (if optional service enabled)** as the provider and type your model name. For the AI Primary and CodeGen slots the endpoint defaults to `http://host.docker.internal:11434/v1/chat/completions` (edit it to `http://ollama:11434/v1/chat/completions` for the bundled service); for the Embedding slot it defaults to `http://ollama:11434/v1/embeddings`. No API key is required.
 
 ### Optional model overrides
 
@@ -236,6 +236,7 @@ ANTHROPIC_MODEL=claude-opus-5
 OPENAI_MODEL=gpt-5.5
 GROK_MODEL=grok-4.6
 CODEGEN_MODEL=claude-opus-5   # or gpt-5.5 if using OpenAI, grok-4.6 for Grok
+ANTHROPIC_OVERLOAD_FALLBACK_MODEL=claude-sonnet-4-6   # used for the current request when an Anthropic Opus call stays overloaded after retries
 ```
 
 ### Mix-and-match: Anthropic chat + OpenAI embeddings
@@ -398,19 +399,19 @@ In multi-tenant deployments (`multiTenant: "true"` in `application.yaml`) each t
 | Embedding | `{env}/embedding` | `oss/embedding` |
 | Web Search | `{env}/web-search` | `oss/web-search` |
 
-(`{env}` is the tenant's environment name, e.g. `trial-acme`.)
+(`{env}` is the tenant's environment name, e.g. `acme`.)
 
 A per-tenant secret takes effect on the next AI call — no restart needed. The override is independent for each slot: a tenant can override just AI Primary, just CodeGen, just Embedding, or any combination.
 
 ### Setting your key from the UI
 
-Trial users (and any multi-tenant tenant) can manage all three slots from the platform UI. The Configuration page is organized into sub-tabs:
+Any tenant can manage all three slots from the platform UI. The Configuration page is organized into sub-tabs:
 
 - **AI Providers** — AI Primary, CodeGen, and Embedding provider + model selectors, plus a shared API Keys panel on the right (backed by the `{env}/ai-keys` secret — see [Shared API Key Store](#shared-api-key-store)). This is where you enter your provider API keys and pick models.
 - **Secrets** — operator-facing platform credentials (Vault-backed). Admin-only when user-auth is on.
 - **Users** — user accounts and roles. Visible when `USE_USER_AUTH=true`.
 - **API-Keys** — issue and revoke scoped credentials for the CLI, MCP agents, and other programmatic clients. Visible when `USE_API_KEYS=true`. See [API Keys](/api-keys).
-- **Environment** — tenant name, version, trial/hosted flags, and a status block showing which AI slots are using Datris-managed defaults vs your own keys.
+- **Data Sources**, **Code Repository**, **Audit Log**, **Agent Policy** — additional operator sub-tabs (see their respective pages).
 
 Some sub-tabs are role- and flag-gated — see the [API Keys matrix](/api-keys#supported-configurations) for the full visibility rules.
 
@@ -421,7 +422,7 @@ To set your AI keys:
 3. For Anthropic/OpenAI/Azure/Grok, enter your API key in the right-hand panel and pick a model from the dropdown. For Azure, also enter your resource endpoint and type your deployment name as the model. For Amazon Bedrock, enter your AWS credentials and region in the right-hand panel (or leave the keys blank to use the server's IAM role) — the model dropdown then lists what your account can actually invoke. For Ollama, type the model name directly — no API key needed.
 4. Click **Save Configuration**. Changes take effect immediately — no restart required.
 
-To revert to defaults, click **Reset to Datris-managed**. This deletes all three per-tenant secrets and falls the tenant back to the global defaults.
+To fall a tenant back to the global `oss/*` defaults, delete its per-tenant secrets in Vault (see below).
 
 ### Setting tenant secrets directly in Vault
 
@@ -430,7 +431,7 @@ For operators provisioning tenants programmatically:
 ```bash
 docker compose exec -e VAULT_ADDR=http://vault:8200 \
   -e VAULT_TOKEN="$(docker compose exec -T datris cat /vault-token/token)" vault \
-  vault kv put secret/trial-acme/ai-primary \
+  vault kv put secret/acme/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \
   model="claude-opus-5" \
@@ -442,4 +443,4 @@ Same shape for `{env}/codegen` and `{env}/embedding`.
 
 ## Misconfiguration
 
-The platform fails fast at startup if any required slot is missing or malformed. There is no silent fallback. The `aiPrimary` slot is always required when `ai.enabled: true`; `codegen` and `embedding` are required if you use features that depend on them (which is most features for codegen, and only vector destinations for embedding).
+The platform fails fast at startup if the `aiPrimary` slot is missing or malformed — it is always required when `ai.enabled: true`. The `codegen` slot is optional: when its secret is absent, code-generation tasks fall back to `aiPrimary`. The `embedding` slot is read per request and is only required by features that depend on it (vector destinations and semantic search).

--- a/docs/ai-error-explanation.mdx
+++ b/docs/ai-error-explanation.mdx
@@ -1,9 +1,9 @@
 ---
 title: "AI Error Explanation"
-description: "AI-powered error explanations"
+description: "AI-powered error explanations, surfaced as an AI Suggested Fix"
 ---
 
-When a pipeline job fails, the AI automatically analyzes the error and provides a plain-English explanation of the root cause and suggested fix. This appears as a separate status entry after the error, making it easy to diagnose issues without reading stack traces.
+When a pipeline job fails, the AI automatically analyzes the error and provides a plain-English explanation of the root cause and suggested fix. The result — labelled **AI Suggested Fix** in the job status — appears as a separate status entry after the error, making it easy to diagnose issues without reading stack traces.
 
 ## How it works
 
@@ -12,9 +12,9 @@ When any pipeline stage (data quality, transformation, destination loading) thro
 1. The error is logged to status as usual
 2. The error message and pipeline configuration are sent to the AI model
 3. The AI returns a concise explanation of what went wrong and how to fix it
-4. The explanation is written as a separate status entry (`AI Explanation: ...`) and logged to the pipeline logs
+4. The explanation is written as a separate status entry (`AI Suggested Fix: ...`, with `Diagnosis:` and `Suggested fix:` lines) and logged to the pipeline logs
 
-If the AI call itself fails (rate limit, timeout, etc.), the explanation is silently skipped — it never causes a secondary failure.
+If the AI call itself fails (rate limit, timeout, etc.), the explanation is skipped with a server log warning — it never causes a secondary failure.
 
 ## Example
 
@@ -22,18 +22,19 @@ If the AI call itself fails (rate limit, timeout, etc.), the explanation is sile
 ```
 Process completed, error: Aborting processing this pipeline, 3 error(s) were found
 while performing data quality rules:
-Data quality AI failure, row: 2, reason: high (7.50) is less than low (8.01)
-Data quality AI failure, row: 3, reason: volume is negative (-500)
-Data quality AI failure, row: 4, reason: close and adj_close exceed $1,000,000
+Data quality CodeGen failure, row: 2, reason: high (7.50) is less than low (8.01)
+Data quality CodeGen failure, row: 3, reason: volume is negative (-500)
+Data quality CodeGen failure, row: 4, reason: close and adj_close exceed $1,000,000
 ```
 
-**AI Explanation status (separate entry):**
+**AI Suggested Fix status (separate entry):**
 ```
-AI Explanation: Three rows in the source data violate the data quality rules:
-row 2 has a high value lower than low (likely a column swap or data entry error),
-row 3 contains a negative volume, and row 4 has close and adj_close values exceeding
-$1,000,000. Fix: Correct the upstream source data or add a pre-processing
-transformation step to sanitize these issues before the data quality check runs.
+AI Suggested Fix: Three source rows violate the price/volume rules; fix the upstream data.
+Diagnosis: Row 2 has a high value lower than low (likely a column swap or data entry
+error), row 3 contains a negative volume, and row 4 has close and adj_close values
+exceeding $1,000,000.
+Suggested fix: Correct the upstream source data or add a pre-processing transformation
+step to sanitize these issues before the data quality check runs.
 ```
 
 ## Configuration

--- a/docs/api-keys.mdx
+++ b/docs/api-keys.mdx
@@ -5,7 +5,7 @@ description: "Enable API-key authentication for the UI, CLI, MCP clients, and an
 
 By default, the Datris OSS install accepts unauthenticated requests on the REST and MCP APIs — fine for laptop development, wrong for any shared or hosted setup. Turn on API-key authentication and every caller (the UI, the CLI, agent MCP clients) must present a key that the platform recognizes.
 
-This page covers single-tenant deployments. Multi-tenant setups use the same flag and a different mapping mechanism — see [user-auth](/user-auth) and the Configuration → Tenants screen.
+This page covers single-tenant deployments. Multi-tenant setups (`MULTI_TENANT=true`) use the same flag and a different mapping mechanism — see [Multi-tenant](#multi-tenant) below.
 
 ## What it does
 
@@ -142,7 +142,7 @@ When user-auth is on, logged-in browser sessions are first-class identities too:
 
 ## Multi-tenant
 
-`MULTI_TENANT=true` switches the model: a single `api-key-mappings` secret maps `keyValue → tenantEnv`, and every tenant carries its own per-environment data. The UI key flow above is single-tenant only; see the Configuration → Tenants documentation for the multi-tenant equivalent.
+`MULTI_TENANT=true` switches the model: a single `api-key-mappings` secret maps `keyValue → tenantEnv`, and every tenant carries its own per-environment data. The UI key flow above is single-tenant only; in multi-tenant mode the mappings are managed directly in the `api-key-mappings` Vault secret.
 
 ## See also
 

--- a/docs/api-reference/ingestion-api.mdx
+++ b/docs/api-reference/ingestion-api.mdx
@@ -20,7 +20,7 @@ Content-Type: multipart/form-data
 | `publishertoken` | form-data | No | Publisher identifier for tracking |
 
 **Behavior:**
-- **Compressed files** (`.zip`, `.gz`, `.tar`, `.jar`): Staged to MinIO raw bucket for asynchronous processing
+- **Compressed files** (`.zip`, `.gz`, `.tar`, `.jar`): Extracted in-process. For a CSV pipeline with several files in the archive, the files are concatenated (headers on files 2+ skipped) and submitted as one batch job; otherwise each extracted file is submitted as its own job
 - **Uncompressed files**: Processed immediately in-memory
 - **Schema evolution**: If a CSV file contains new columns not in the pipeline schema, they are automatically added (as `string` type) and the destination table is altered. See [Schema Evolution](/schemas#schema-evolution).
 
@@ -37,7 +37,7 @@ curl -X POST http://localhost:8080/api/v1/pipeline/upload \
 pt-abc12345-6789-...
 ```
 
-For compressed files, the response is `200 OK` with no body. The file is processed asynchronously when the pipeline detects it in the raw bucket.
+For compressed files, the response is `200 OK` with the single pipeline token of the batch job (CSV batch mode, or a single-file archive), or the plain-text summary `N file(s) submitted` when each extracted file was submitted as its own job.
 
 ---
 

--- a/docs/api-reference/metadata-api.mdx
+++ b/docs/api-reference/metadata-api.mdx
@@ -25,7 +25,7 @@ GET /api/v1/metadata/postgres/schemas
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `database` | query | `datris` | Database name |
+| `database` | query | configured Postgres database | Database name. Defaults to the configured Postgres database (`postgres.database`, which is `datris` on a default install) |
 
 Returns a JSON array of schema names. System schemas (`information_schema`, `pg_catalog`, `pg_toast`) are excluded.
 
@@ -39,7 +39,7 @@ GET /api/v1/metadata/postgres/tables
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `database` | query | `datris` | Database name |
+| `database` | query | configured Postgres database | Database name. Defaults to the configured Postgres database (`postgres.database`, which is `datris` on a default install) |
 | `schema` | query | `public` | Schema name |
 | `vectorOnly` | query | `false` | If `true`, return only pgvector tables (tables with an `embedding` column) |
 
@@ -55,7 +55,7 @@ GET /api/v1/metadata/postgres/columns
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `database` | query | `datris` | Database name |
+| `database` | query | configured Postgres database | Database name. Defaults to the configured Postgres database (`postgres.database`, which is `datris` on a default install) |
 | `schema` | query | `public` | Schema name |
 | `table` | query | (required) | Table name |
 

--- a/docs/api-reference/pipeline-api.mdx
+++ b/docs/api-reference/pipeline-api.mdx
@@ -49,6 +49,11 @@ Content-Type: application/json
 
 **Body:** Full PipelineConfig JSON (see [Pipeline Configuration](/pipeline-configuration)).
 
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `changeNote` | query | No | Note recorded on the saved pipeline version |
+
 **Example:**
 ```bash
 curl -X POST http://localhost:8080/api/v1/pipeline \
@@ -123,4 +128,4 @@ If `useApiKeys` is enabled, all requests must include the `x-api-key` header:
 curl -H "x-api-key: your-api-key" http://localhost:8080/api/v1/pipelines
 ```
 
-API keys are stored in Vault under the secret specified by `secrets.apiKeysSecretName`.
+API keys are stored in Vault under `{environment}/api-keys` (`oss/api-keys` on a default install). `secrets.apiKeysSecretName` in `application.yaml` tells the validator where to read them and should point at that same path — the Keys UI and multi-tenant resolution always write to `{environment}/api-keys`.

--- a/docs/api-reference/query-api.mdx
+++ b/docs/api-reference/query-api.mdx
@@ -74,6 +74,7 @@ POST /api/v1/query/mongodb
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `collection` | string | Yes | | MongoDB collection name |
+| `database` | string | No | configured MongoDB database | MongoDB database name to query |
 | `filter` | object | No | `{}` | MongoDB query filter |
 | `projection` | object | No | all fields | Fields to include/exclude |
 | `limit` | integer | No | 20 | Maximum documents to return. Pass `-1` for unlimited (tap scripts use this to read every document). Omit for the preview default of 20; any positive value is honored with no cap. |

--- a/docs/api-reference/schema-generation-api.mdx
+++ b/docs/api-reference/schema-generation-api.mdx
@@ -195,7 +195,7 @@ The Vault secret keys:
 
 | Key | Description |
 |-----|-------------|
-| `provider` | `anthropic`, `openai`, or `ollama` |
+| `provider` | `anthropic`, `openai`, `azure`, `bedrock`, `grok`, or `ollama` |
 | `endpoint` | The AI provider API URL |
 | `model` | The model name to use |
 | `apiKey` | The API key for authentication (omit for local Ollama) |
@@ -211,6 +211,9 @@ The pipeline reads the secret at startup. If `ai.enabled: true` and the codegen 
 |----------|-----------------|-------------|
 | Anthropic Claude | `anthropic` | `x-api-key` + `anthropic-version: 2023-06-01` |
 | OpenAI | `openai` | `Authorization: Bearer` |
+| Azure OpenAI | `azure` | API key or Entra ID (keyless) |
+| Amazon Bedrock | `bedrock` | AWS credentials |
+| Grok (xAI) | `grok` | `Authorization: Bearer` |
 | Ollama (local) | `ollama` | none |
 
 Any other value for `provider` will cause startup to fail with an unsupported provider error.

--- a/docs/api-reference/secrets-api.mdx
+++ b/docs/api-reference/secrets-api.mdx
@@ -13,6 +13,10 @@ GET /api/v1/secrets
 
 Returns a JSON array of secret names for the current environment.
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `type` | query | No | Filter by the secret's `_type` tag (e.g. `tap`). `platform` returns every secret *not* tagged `_type=tap`. |
+
 ### Example
 
 ```bash
@@ -37,7 +41,7 @@ GET /api/v1/secrets/{name}
 |-----------|------|-------------|
 | `name` | path | Secret name |
 
-Sensitive fields (`password`, `apiKey`, `secretKey`, `token`, `secret`) are always masked as `••••••••`. Non-sensitive fields show their actual values.
+Sensitive fields are always masked as `••••••••`: any field whose name (case-insensitive, ignoring `_`/`-`) contains `password`, `passwd`, `pwd`, `secret`, `token`, `key`, `credential`, `signature`, `bearer`, or `private` — e.g. `apiKey`, `secretKey`, `accessKey`. Non-sensitive fields show their actual values.
 
 ### Example
 

--- a/docs/api-reference/status-api.mdx
+++ b/docs/api-reference/status-api.mdx
@@ -233,13 +233,21 @@ Each status entry (`PipelineStatus`) contains:
 | Process | Description |
 |---------|-------------|
 | `FileNotifier` | File intake from MinIO bucket |
-| `StreamNotifier` | Direct upload intake |
+| `StreamNotifier` | Direct upload intake (also tap-fed and Kafka-fed jobs) |
+| `FileUploadAPIController` | Upload request handling before the job is created |
 | `DataQuality` | Data quality validation |
 | `Transformation` | Data transformation |
 | `JobRunner` | Destination orchestration |
 | `PostgresLoader` | PostgreSQL loading |
+| `SnowflakeLoader` | Snowflake loading |
+| `DatabricksLoader` | Databricks loading |
 | `MongoDBLoader` | MongoDB loading |
 | `SparkObjectStoreLoader` | Object store writing |
 | `KafkaLoader` | Kafka producing |
 | `ActiveMQLoader` | ActiveMQ queue writing |
-| `RestEndpointRunner` | REST endpoint posting |
+| `RestEndpointRunner` | REST endpoint posting (preprocessor and REST destination) |
+| `PGVectorLoader` | pgvector loading |
+| `QdrantLoader` | Qdrant loading |
+| `WeaviateLoader` | Weaviate loading |
+| `MilvusLoader` | Milvus loading |
+| `ChromaLoader` | Chroma loading |

--- a/docs/api-reference/taps-api.mdx
+++ b/docs/api-reference/taps-api.mdx
@@ -180,9 +180,12 @@ Uses AI to generate a Python `fetch()` script from a plain-English description. 
 {
   "script": "import requests\n\ndef fetch():\n    ...",
   "packages": ["yfinance"],
-  "scriptPath": "tap-scripts/stock-prices-tap_a1b2c3d4.py"
+  "scriptPath": "tap-scripts/stock-prices-tap_a1b2c3d4.py",
+  "injectedPrompts": ["rate-limits"]
 }
 ```
+
+`injectedPrompts` lists the names of the [tap prompt fragments](#tap-prompt-fragments) that were injected into the generation prompt (empty when none matched).
 
 ## Fix Script (AI Diagnosis)
 
@@ -371,9 +374,16 @@ Executes a saved tap. Optionally sends data to the configured pipeline.
 ```json
 {
   "name": "stock-prices-tap",
-  "mode": "run"
+  "mode": "run",
+  "params": {"since": "2026-05-01"}
 }
 ```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | (required) | Tap name |
+| `mode` | string | `"test"` | `"run"` feeds records into `targetPipeline`; `"test"` executes the script and returns sample results without persisting |
+| `params` | object | `{}` | Optional per-run parameters exposed to the script as environment variables (nested values JSON-encoded) |
 
 **Response:**
 ```json
@@ -388,10 +398,13 @@ Executes a saved tap. Optionally sends data to the configured pipeline.
   "pipelineTokens": ["a1b2c3d4-..."],
   "recordCount": 503,
   "dataType": "csv",
+  "columns": ["ticker", "date", "open", "high", "low", "close", "volume"],
   "logs": "...",
   "error": null
 }
 ```
+
+`columns` lists the column names the script produced (normalized for `dataType: "csv"`, see [Test Tap](#test-tap)); it is `null` when the run produced no records.
 
 **`mode=run` does not return the records themselves** — the data is in transit to `targetPipeline`, and the agent / caller should verify completion via `get_pipeline_status`, not read from the response body. `recordCount` summarizes how many records were submitted. To preview what a script produces, call the same endpoint with `mode=test`, which returns up to 20 sample rows in a `records` array (with `recordsTruncated: true` set when the script produced more than that).
 
@@ -454,10 +467,23 @@ Returns the last 50 run log entries for a tap, sorted by most recent first.
     "logs": "Retrieved 503 tickers...",
     "error": null,
     "mode": "test",
-    "durationMs": 45000
+    "durationMs": 45000,
+    "publisherToken": null,
+    "aiSummary": null,
+    "aiDiagnosis": null,
+    "aiSuggestion": null,
+    "scriptCommitSha": null,
+    "pipelineRollup": null
   }
 ]
 ```
+
+| Field | Description |
+|---|---|
+| `publisherToken` | Set on `mode=run` entries that fed a pipeline; groups the ingestion jobs the run submitted |
+| `aiSummary`, `aiDiagnosis`, `aiSuggestion` | AI fix suggestion filled in after a scheduled run exhausts its automatic retries; `aiSummary` is the one-line headline, the other two carry the full explanation |
+| `scriptCommitSha` | Repo-backed taps only — the commit the run's script was read at; `null` for MinIO-stored scripts |
+| `pipelineRollup` | Downstream pipeline job rollup (same shape as `rollup` in the [Status API](/api-reference/status-api)) for runs that have a `publisherToken`; `null` otherwise |
 
 ## Document Ledger
 

--- a/docs/api-reference/version-api.mdx
+++ b/docs/api-reference/version-api.mdx
@@ -19,14 +19,18 @@ curl http://localhost:8080/api/v1/version
 **Response:** `200 OK`
 ```json
 {
-  "version": "1.6.3",
+  "version": "1.28.0",
   "environment": "oss",
   "multiTenant": "false",
   "hosted": "false",
   "useUserAuth": "false",
   "useApiKeys": "false",
+  "useAuditLog": "false",
+  "useAgentPolicy": "false",
+  "recoveryAgentEnabled": "false",
   "postgresDatabase": "datris",
-  "mongodbDatabase": "datris"
+  "mongodbDatabase": "datris",
+  "useTapRunner": "false"
 }
 ```
 
@@ -38,5 +42,9 @@ curl http://localhost:8080/api/v1/version
 | `hosted` | Whether this is a managed/hosted deployment |
 | `useUserAuth` | Whether user authentication is enabled |
 | `useApiKeys` | Whether API key authentication is enabled |
+| `useAuditLog` | Whether the audit log is enabled |
+| `useAgentPolicy` | Whether agent policy enforcement is enabled |
+| `recoveryAgentEnabled` | Whether the recovery agent is enabled |
+| `useTapRunner` | Whether tap scripts run in the separate tap-runner service |
 | `postgresDatabase` | Canonical Postgres database name. User-facing; UI reads this as authoritative and doesn't let users edit it. |
 | `mongodbDatabase` | Canonical MongoDB database name (user-facing). In multi-tenant mode this is the tenant environment name; in single-tenant it comes from `mongodb.database` in application.yaml. Distinct from the internal platform database (`mongodb.internalDatabase`, default `oss`) which holds pipeline/tap configs and run state and is never surfaced in the UI. |

--- a/docs/assistant.mdx
+++ b/docs/assistant.mdx
@@ -120,8 +120,8 @@ seems to be "hanging" mid-run, it's waiting between polls on purpose.
 
 | Provider | Streaming text | Tool cards | Reasoning block |
 |----------|---------------|------------|-----------------|
-| Anthropic Claude 4.x | ✅ | ✅ | Full chain-of-thought (extended thinking) |
-| OpenAI GPT-5 | ✅ | ✅ | Reasoning summary |
+| Anthropic Claude (Opus 5, Fable 5.1) | ✅ | ✅ | Full chain-of-thought (extended thinking) |
+| OpenAI GPT-5.x | ✅ | ✅ | Reasoning summary |
 | Azure OpenAI | ✅ | ✅ | None (reasoning happens server-side but isn't surfaced) |
 | Claude via Amazon Bedrock | ✅ | ✅ | Full thinking blocks (same as direct Anthropic; responses arrive at the end of each turn rather than streaming) |
 | Grok (xAI) | ✅ | ✅ | None (reasoning happens server-side but isn't surfaced) |
@@ -129,17 +129,18 @@ seems to be "hanging" mid-run, it's waiting between polls on purpose.
 
 Set `ai.extendedThinking: "false"` in `application.yaml` to disable the
 reasoning block platform-wide. Default is on. Extended thinking adds roughly
-$0.05/turn and 2–8s of latency on Opus 4.x — cheap insurance for transparency
+$0.05/turn and 2–8s of latency on Opus — cheap insurance for transparency
 on an agent that's writing production-bound config.
 
 ## Configuration
 
-The Assistant uses your tenant's **codegen** AI config (the same one that
-powers tap script generation, AI data quality, and AI transformations). On
-Anthropic tenants the default is Opus 4.x; on OpenAI tenants it's GPT-5.
+The Assistant uses your tenant's **AI primary** config (the chat slot). Tap
+script generation, AI data quality, and AI transformations use the separate
+**codegen** slot. On a fresh install the Anthropic default is Claude Opus 5
+(`claude-opus-5`) for both slots; the OpenAI default is `gpt-5.5`.
 
 There is no per-tenant Assistant configuration to manage beyond what you
-already have for codegen. See [AI Configuration](/ai-configuration) for the
+already have for AI primary. See [AI Configuration](/ai-configuration) for the
 underlying AI primary / codegen / web search / embedding settings.
 
 ### Authentication
@@ -172,9 +173,10 @@ the full capability model.
 - **50 iterations per turn.** The agent loop is hard-capped to bound cost. If
   the agent runs out of iterations, it stops and asks you to send a follow-up
   message to continue.
-- **No conversation history.** v1 is session-only — refreshing the tab clears
-  the conversation. Persistence is on the roadmap.
-- **16K output tokens per LLM call.** Sufficient for thinking + reasoning +
+- **No server-side conversation history.** The transcript lives in the
+  browser tab's session storage — it survives a refresh but is gone once the
+  tab is closed. Durable persistence is on the roadmap.
+- **32K output tokens per LLM call.** Sufficient for thinking + reasoning +
   tool selection on every public model we support.
 
 ## How it relates to other tabs
@@ -183,8 +185,9 @@ the full capability model.
   you want to understand what each tool does.
 - **Agent Monitor (pop-out)** — read-only activity monitor of *external* MCP
   clients (Claude Desktop, Cursor, scripts) calling your server. Opens in its
-  own browser window via the pop-out icon on the MCP tab so you can keep an
-  eye on Connections and the Activity Log while you work elsewhere. The
+  own browser window via the pop-out icon (open-in-new) in the Agent Monitor
+  header under **MCP → Activity**, so you can keep an eye on Connections and
+  the Activity Log while you work elsewhere. The
   Assistant is the in-product counterpart — same tools, different surface.
 - **Catalog tab** — anything the Assistant creates (taps and pipelines) lands
   here, grouped by catalog. The "→ Open tap" / "→ Open pipeline" links at the

--- a/docs/audit-log.mdx
+++ b/docs/audit-log.mdx
@@ -72,6 +72,7 @@ Writes, runs, deletes, logins, key and user management, and every denied request
 | `security` | any denied request — insufficient role, missing capability, expired session, and a non-`ui` key attempting to act on behalf of a user |
 | `system` | server start and stop |
 | `audit` | CSV export of the audit log itself |
+| `mcp` | Clearing the Agent Monitor activity log |
 
 Each entry also carries the outcome (`success`, `failure`, `denied`), the HTTP status, how long the request took, the caller's IP address (first hop of `X-Forwarded-For` when the UI sits behind a proxy) and user agent, and the name of the resource touched.
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -123,17 +123,17 @@ description: "Release history for Datris"
 <Update label="v1.20.0" description="August 24, 2026">
   **Opt-in Postgres TLS enforcement.**
 
-  - Set `DATRIS_ENV=production` and the platform refuses to start when its Postgres connection points at an external host without TLS (`sslmode=require` or stricter). Opt out with `DATRIS_ALLOW_PLAINTEXT_DB=true`. The bundled in-network Postgres is exempt; existing deployments are unaffected unless the flag is set. Plaintext connections to external databases now log a startup warning either way.
+  - Deployments marked as production now refuse to start when the platform's Postgres connection points at an external host without TLS (`sslmode=require` or stricter), with an explicit opt-out for deployments that intentionally use plaintext. The bundled in-network Postgres is exempt; existing deployments are unaffected unless production mode is enabled. Plaintext connections to external databases now log a startup warning either way.
 
   **Observability: Prometheus metrics and structured logs.**
 
-  - New `/actuator/prometheus` endpoint for Prometheus scraping, reachable only from inside the deployment's network (the bundled edge proxy blocks it publicly).
+  - Prometheus metrics are now exposed for scraping, reachable only from inside the deployment's network (the bundled edge proxy blocks them publicly). See [Audit Log](/audit-log) for the metrics endpoint.
   - Production deployments emit one JSON log line per event for SIEM / log-aggregator ingestion; development logs stay human-readable.
 
   **Tap isolation on by default for docker compose.**
 
-  - `docker-compose.yml` / `docker-compose.standalone.yml` / `deploy/docker-compose.prod.yml` now default `USE_TAP_RUNNER=true`. `scripts/install.sh` and `docker/vault-init.sh` mint `TAP_RUNNER_TOKEN` on first boot (including upgrades whose token was missing or `changeme`). The server fails fast if isolation is on and the token is still empty/`changeme` — a minted token is accepted.
-  - `sbt` / IDE (no sidecar) stays in-process and logs a warning. Isolated taps still cannot open direct connections to internal DB / object store / Vault — they return records; this is existing behavior, called out because compose now isolates by default.
+  - All bundled Docker Compose configurations now default to `USE_TAP_RUNNER=true`. The runner token is minted automatically on first boot (including upgrades where it was missing or still the placeholder value). The server fails fast if isolation is on and no valid token exists — a minted token is accepted.
+  - Running the server outside Compose (no runner sidecar) stays in-process and logs a warning. Isolated taps still cannot open direct connections to internal DB / object store / Vault — they return records; this is existing behavior, called out because compose now isolates by default.
   - Set `USE_TAP_RUNNER=false` to keep in-process on compose. No host allowlist in this change.
 </Update>
 
@@ -176,7 +176,7 @@ description: "Release history for Datris"
 
   - A broad security pass across authentication, authorization, credential handling, and input validation, plus updated bundled dependencies for published advisories. A standard upgrade needs no configuration changes.
   - **Initial admin login** (when user login is enabled): the first admin password is now generated and printed once to the server logs — `docker compose logs datris`, sign in, and change it.
-  - **Taps calling internal addresses** are blocked by default; set `DATRIS_ALLOW_PRIVATE_EGRESS=true` if an endpoint legitimately runs on an internal network.
+  - **Taps calling internal addresses** are blocked by default, with an opt-out for endpoints that legitimately run on an internal network (see the [Tap Execution & Isolation](/tap-execution-isolation) guide).
   - **Bundled Vault** uses a unique per-install token; for manual `vault` commands read it with `docker compose exec -T datris cat /vault-token/token`.
   - **Fix:** the default Docker Compose config pulls the published images again (a recent change had it building from source).
   - Standard upgrade: `docker compose pull && docker compose up -d`.
@@ -507,7 +507,7 @@ description: "Release history for Datris"
   - **New Ops chat side panel.** A collapsible chat lives on the right side of Ops → Activity. The assistant has the current failures, stale taps, and volume anomalies in mind — ask "why did `X` fail?" and it pulls the root cause; ask it to re-run a tap and it runs and reports the outcome. The panel stays mounted as you switch between Activity and Ingestion, so the conversation survives the tab change.
   - **"Ask" buttons on failure and volume rows.** Click "Ask" next to a row to seed the chat with a row-specific question so you don't have to retype the tap or pipeline name.
   - **Successes are expandable like Failures.** Click any row in the Successes pane to see the same event trail (begin → processing → end) you get from the Failures pane. Only one row across either pane is open at a time so the layout stays compact.
-  - **Claude Opus 4.8 is the new recommended CodeGen model.** New installs seed Opus 4.8 as the codegen default. Existing tenants can pick it from the model dropdown in Configuration. The older Opus versions remain selectable for anyone who wants to pin a specific version.
+  - **Claude Opus 4.8 is the new recommended CodeGen model.** New installs seed Opus 4.8 as the codegen default. Existing installs can pick it from the model dropdown in Configuration. The older Opus versions remain selectable for anyone who wants to pin a specific version.
 
   **Upgrading:** `docker compose pull && docker compose up -d --force-recreate datris ui mcp-server`. No data migration needed. The CLI: `brew upgrade datris`.
 </Update>
@@ -608,8 +608,8 @@ description: "Release history for Datris"
 
   - **Assistant: keep typing without clicking.** After you send a question, the cursor stays in the composer — so as soon as the agent finishes (or even while it's still working), you can type your next prompt without reaching for the mouse.
   - **AI Configuration: provider switches no longer wipe your overrides.** Switching the primary AI, codegen, or embedding provider used to clear the saved provider/model/endpoint on the next page load, so you had to re-pick them every time. Your selections now persist correctly through a provider switch (you still re-enter the API key when changing providers — that's intentional).
-  - **Connect Your Agent: paste-and-go for local.** The MCP tab's generated config no longer asks for an API key for the default local setup — paste the snippet into your agent and it just works. A key is still required when you point the snippet at a hosted, trial, or dedicated instance.
-  - **Trial signup and dedicated upgrade move fully to the website.** The corresponding agent tools have been removed — users finish those flows in a browser anyway. The Getting Started tab has also been refreshed to point at the Assistant for the common onboarding path.
+  - **Connect Your Agent: paste-and-go for local.** The MCP tab's generated config no longer asks for an API key for the default local setup — paste the snippet into your agent and it just works. A key is still required when you point the snippet at a remote instance.
+  - **Hosted trial provisioning tools removed from the agent toolset** (hosted platform since retired). The Getting Started tab has also been refreshed to point at the Assistant for the common onboarding path.
 
   **Upgrading:** `docker compose pull && docker compose up -d`. No data migration needed. The CLI: `brew upgrade datris`.
 </Update>
@@ -626,7 +626,7 @@ description: "Release history for Datris"
   - **MCP transport upgraded — both protocols at once.** The bundled MCP server now serves the streamable-HTTP transport alongside the existing SSE transport on the same port, so the in-product Assistant and external agents connect to one running process. No configuration change needed.
   - **Discovery tab is hidden in this release.** The Assistant supersedes the Discovery tab for the common path.
 
-  **Upgrading:** `docker compose pull && docker compose up -d`. No data migration needed. The CLI: `brew upgrade datris`. The Assistant uses your existing codegen AI configuration — on Anthropic tenants you'll see full chain-of-thought reasoning streamed inline; on OpenAI you'll see reasoning summaries instead.
+  **Upgrading:** `docker compose pull && docker compose up -d`. No data migration needed. The CLI: `brew upgrade datris`. The Assistant uses your existing codegen AI configuration — with Anthropic you'll see full chain-of-thought reasoning streamed inline; on OpenAI you'll see reasoning summaries instead.
 </Update>
 
 <Update label="v1.6.21" description="May 11, 2026">
@@ -634,7 +634,7 @@ description: "Release history for Datris"
 
   - **AI tap workflows can consult the live web.** When enabled in Configuration → AI Providers, tap brainstorm, dataset discovery, tap diagnosis, and tap auto-fix look up current API documentation, free-tier limits, current package names, and recent deprecation notices before recommending sources or generating fixes. Pick your web-search provider independently of AI Primary — the platform uses each provider's native search tool and routes accordingly. First-pass tap script generation stays fast and uses the model's training data only. See [AI Configuration](/ai-configuration) for setup.
   - **AI Configuration changes survive Docker restarts.** Saving from the Configuration UI now mirrors the relevant keys back to your `.env` file so changes aren't lost when the local Vault container restarts. Provider switches also clear any stale credential preserved from the prior provider, so a wrong-provider key can't silently 401 the next call.
-  - **Cleaner MCP authentication.** The bundled MCP server is now a transparent forwarder — each connecting agent provides its own API key per session and the MCP server passes it through to the Datris REST API on every tool call. The Configuration → Connect Your Agent panel generates the new configuration snippet automatically; paste your key from the Configuration UI into your agent's MCP config. Existing trial and managed-service users see no change in behavior.
+  - **Cleaner MCP authentication.** The bundled MCP server is now a transparent forwarder — each connecting agent provides its own API key per session and the MCP server passes it through to the Datris REST API on every tool call. The Configuration → Connect Your Agent panel generates the new configuration snippet automatically; paste your key from the Configuration UI into your agent's MCP config. Existing remote-instance setups see no change in behavior.
   - **Tap brainstorm asks about sources first.** When you describe data without naming where to fetch it from, the AI now lists 3-5 candidate sources (with free vs paid and key-required info) before drilling into parameters — instead of asking for filtering details up front.
   - **Tap script generation is more resilient.** The platform now validates that a generated script actually defines a `fetch()` function before storing it, and the JSON extractor handles model responses that contain narrative braces without falling back to the raw-text path.
 
@@ -663,7 +663,7 @@ description: "Release history for Datris"
 <Update label="v1.6.18" description="May 5, 2026">
   **User authentication, roles, and an admin-only Configuration tab.**
 
-  - **Optional username/password login.** Datris can now require a login before any tab is reachable. Three roles ship out of the box — **admin** (full access), **editor** (read + edit pipelines, taps, secrets), and **viewer** (read-only). Off by default, so existing single-tenant installs are unaffected. See the new [User Authentication](/user-auth) doc to enable it.
+  - **Optional username/password login.** Datris can now require a login before any tab is reachable. Three roles ship out of the box — **admin** (full access), **editor** (read + edit pipelines, taps, secrets), and **viewer** (read-only). Off by default, so existing installs are unaffected. See the new [User Authentication](/user-auth) doc to enable it.
   - **Configuration is admin-only.** When auth is on, only admins see the Configuration tab (Secrets, AI Providers, Taps, Users, Environment). Editors and viewers continue to use everything else.
   - **New Users sub-tab.** Admins can add, remove, and reassign roles. A built-in 16-character password generator with a reveal toggle makes handing out credentials painless. The last admin can't be deleted.
   - **Self-service password change.** Users can change their own password from the top-right user menu.
@@ -749,7 +749,7 @@ description: "Release history for Datris"
   - **Scheduled taps no longer need a manual kickoff.** Taps saved with a cron schedule now fire on their next scheduled time automatically. Previously, a newly saved scheduled tap would wait indefinitely until you ran it once by hand.
   - **Self-diagnosing tap scripts.** If a tap's generated script goes missing from object storage, the Edit Tap page now shows an amber banner explaining the state and pointing you to Regenerate, instead of a cryptic mid-run "key does not exist" error. Test Tap surfaces the same state with actionable wording.
   - **Agents can manage their own tap secrets.** Via MCP, agents can now create and delete the secrets their taps need (API keys, tokens). Scope is strictly tap-owned — agents cannot create, overwrite, or delete human-owned Platform secrets (DB creds, AI keys, vector-store creds).
-  - **Secrets page split into Platform and Taps sub-tabs.** Platform lists the built-in Datris secret slots; Taps lists agent-authored tap secrets. Creating a secret from the Taps sub-tab auto-tags it so it stays agent-editable, and Tap secrets are fully manageable on trial tenants.
+  - **Secrets page split into Platform and Taps sub-tabs.** Platform lists the built-in Datris secret slots; Taps lists agent-authored tap secrets. Creating a secret from the Taps sub-tab auto-tags it so it stays agent-editable.
   - **Honest Test Tap banner.** The run-result banner on Test Tap now reflects what actually happened on the server — "sent to pipeline" only when the run was truly persisted, otherwise "not persisted" with the reason — rather than whatever the pre-request checkbox said.
   - **BYO-code taps can declare pip dependencies.** If you paste your own fetch script into Create Tap, you can now list the Python packages it needs. Previously only AI-generated taps could declare dependencies.
   - **Example agent refactored onto taps.** The bundled market-macro-agent example now drives ingestion through taps instead of ad-hoc fetch scripts, demonstrating the full agent-native tap flow (provisioning, secrets, publisher-token watching).
@@ -758,7 +758,7 @@ description: "Release history for Datris"
 <Update label="v1.6.10" description="April 21, 2026">
   **Tap prompt fragments, post-run script review, BYO code, and Configuration page reorg.**
 
-  - **Tap prompt fragments (new).** A new Configuration → Taps sub-tab lets you save reusable, per-tenant context snippets — things like API conventions, required headers, rate limits, and preferred libraries for a given source. When the key or any of its aliases appears in a Create Tap description, brainstorm, auto-fix, optimize, or Discovery chat, the fragment's content is automatically added to the system prompt. Includes an AI Suggest button, a Load Examples catalog (AWS, Polygon, Stripe, SEC EDGAR), JSON import/export, and an "Extra context applied" chip row in the tap wizard showing which fragments hit.
+  - **Tap prompt fragments (new).** A new Configuration → Taps sub-tab lets you save reusable context snippets — things like API conventions, required headers, rate limits, and preferred libraries for a given source. When the key or any of its aliases appears in a Create Tap description, brainstorm, auto-fix, optimize, or Discovery chat, the fragment's content is automatically added to the system prompt. Includes an AI Suggest button, a Load Examples catalog (AWS, Polygon, Stripe, SEC EDGAR), JSON import/export, and an "Extra context applied" chip row in the tap wizard showing which fragments hit.
   - **Post-run script review.** After a tap's first successful test, the AI now scans the captured stderr/stdout for signals that the *script* should change — rate-limit or burst warnings, deprecation hints, pagination cues, schema drift, auth warnings — and regenerates the script if needed. On a rewrite the wizard auto-retests; the performance optimizer runs only when the logs are clean. The optimizer's prompt was also tightened so rate-limit markers push it toward throttling instead of more concurrency.
   - **I Have My Own Code (new).** A third Tap Type on the Create Tap wizard lets you paste a fetch() script directly instead of having AI generate one. Step 1 switches to a code textarea with a Use My Code button; after upload the button flips to Re-upload My Code and Step 2 gates on the text matching what's on disk, so edits force a fresh upload before running the test.
   - **Configuration page reorganized into three sub-tabs** — Environment, AI Providers, and Taps — with a prominent "Highly recommended: Anthropic with the latest coding model" tip on the CodeGen Provider section.
@@ -801,13 +801,13 @@ description: "Release history for Datris"
 <Update label="v1.6.5" description="April 17, 2026">
   - New AI models from OpenAI and Anthropic now appear in the Configuration dropdowns automatically, without a Datris upgrade.
   - **Claude Opus 4.7** is the recommended Anthropic model for CodeGen (tap script generation, AI data quality rules, AI transformations, JSON Schema / XSD generation, and natural-language → SQL).
-  - New trial signups are seeded with the latest recommended models by default.
+  - Fresh instances are seeded with the latest recommended models by default.
 </Update>
 
 <Update label="v1.6.4" description="April 16, 2026">
   **Two-pass AI tap optimization and Data Catalog UX.**
 
-  - **AI optimize pass.** After a tap script passes its initial test, the platform sends it back to the LLM for a performance rewrite and re-tests. Auto-reverts on regression (>=20% slower) or failure. New `POST /api/v1/tap/optimize` endpoint; `/tap/test` now returns `durationMs`.
+  - **AI optimize pass.** After a tap script passes its initial test, the platform sends it back to the LLM for a performance rewrite and re-tests. Auto-reverts on regression (>=20% slower) or failure. Also available through the API; tap test results now report run duration.
   - **Discovery wizard.** Auto-optimize per tap with before/after timing banner, per-row stop button, on-demand AI fix panel for failed items, chat auto-scroll, and re-shown Discover Datasets button after new messages.
   - **Create Tap.** Configurable test sample size (defaults to 20 records).
   - **Data Catalog.** Kebab menu on Uncataloged items with Edit, Delete, and Move to Catalog (with name-clash detection).
@@ -816,10 +816,10 @@ description: "Release history for Datris"
 <Update label="v1.6.3" description="April 15, 2026">
   **Database lockdown, tap script hardening, Create Tap UX.**
 
-  - **Server-controlled database name.** UI no longer edits the Postgres or MongoDB database name — `/api/v1/version` returns `postgresDatabase` and `mongodbDatabase` and the UI submits them unchanged.
+  - **Server-controlled database name.** The UI no longer edits the Postgres or MongoDB database name — the server reports the configured names and the UI submits them unchanged.
   - **MongoDB internal vs user split.** `mongodb.database` (user-facing, default `datris`) holds pipeline data; `mongodb.internalDatabase` (default `oss`) holds platform state. Existing installs keep `oss` for platform state; new user pipelines land in `datris`.
-  - **Unlimited reads for tap scripts.** `limit: -1` on `/api/v1/query/mongodb` and `/api/v1/query/postgres` returns every matching row. Preview defaults (20 Mongo / 100 Postgres) are unchanged for UI/MCP callers.
-  - **Tap test sampling.** New "Limit test sample to 20 records" checkbox in Create Tap step 2 injects `DATRIS_TAP_TEST_LIMIT=20` into the script. Cron and manual runs read everything.
+  - **Unlimited reads for tap scripts.** Tap scripts can now request every matching row from the MongoDB and Postgres query APIs instead of a capped preview. Preview defaults (20 Mongo / 100 Postgres) are unchanged for UI/MCP callers.
+  - **Tap test sampling.** New "Limit test sample to 20 records" checkbox in Create Tap step 2 caps how much a test run reads. Cron and manual runs read everything.
   - **Codegen + diagnosis hardening.** Generated scripts treat platform response shapes as contractual (no shape-probing, no candidate-key iteration). Diagnosis quotes the actual traceback and respects in-script guards.
   - **Create Tap UX.** Ask button, auto-apply diagnosis (capped at 2 attempts), Stop Test, copy-to-clipboard, scrollable-JSON test results, destination collision check on Generate Pipeline, full destination shown on step 5.
   - **Data Catalog.** One-click delete of the Uncataloged group; per-item trash icon on taps and pipelines inside every catalog.
@@ -829,23 +829,23 @@ description: "Release history for Datris"
   **Input sanitization hardening and minor UI polish.**
 
   - Pipeline creation sanitizes destination identifiers before writing the config — Postgres `dbName`/`schema`/`table`, MongoDB `dbName`/`table`, Kafka `topic`, ActiveMQ `queueName`, vector `collectionName`/`tableName`/`schemaName`, and the DQ schema name.
-  - Four duplicated `sanitizeName` helpers consolidated into `ui/src/app/shared/sanitize.ts` (`sanitizeLabel` and `sanitizeIdentifier`).
+  - Name sanitization is now applied consistently across the UI, so labels and identifiers are cleaned the same way everywhere.
 </Update>
 
 <Update label="v1.6.1" description="April 14, 2026">
-  **Discovery wizard, Data Catalog, and trial BYO AI keys.**
+  **Discovery wizard, Data Catalog, and bring-your-own AI keys.**
 
-  - **Discovery wizard.** Six-step AI-guided onboarding that turns "yfinance daily prices for the S&P 500" into running taps and pipelines. New endpoints `POST /api/v1/discover` and `POST /api/v1/discover/build`, plus `discover_source` MCP tool.
+  - **Discovery wizard.** Six-step AI-guided onboarding that turns "yfinance daily prices for the S&P 500" into running taps and pipelines. Available from the UI, the API, and the new `discover_source` MCP tool.
   - **Data Catalog.** Group related taps and pipelines into named catalogs. New Data Catalog tab with expandable contents and an Uncataloged group.
   - **Per-pipeline DQ + transformation editor.** Inline editor inside the pipeline view.
-  - **Trial BYO keys.** Trial tenants supply their own Anthropic or OpenAI key at signup; keys land in the tenant's Vault path and override the shared Datris-managed key on the next AI call.
+  - **Bring-your-own AI keys.** Hosted trial signups could supply their own Anthropic or OpenAI key, which took effect on the next AI call (hosted platform since retired).
 </Update>
 
 <Update label="v1.6.0" description="April 11, 2026">
-  **Dedicated instance support and hosted platform improvements.**
+  **Hosted platform release.**
 
-  - **Hosted-aware Configuration UI.** Hides Ollama for AI Primary/CodeGen on hosted, locks embedding to bundled Ollama `bge-m3` when the provider is Anthropic, and hides the advanced toggle.
-  - Improved multi-user session handling on shared instances.
+  - Hosted dedicated-instance provisioning and hosted-aware Configuration UI (since retired).
+  - Improved multi-user session handling.
 </Update>
 
 <Update label="v1.5.9" description="April 11, 2026">
@@ -864,10 +864,9 @@ description: "Release history for Datris"
 </Update>
 
 <Update label="v1.5.7" description="April 9, 2026">
-  **Trial-instance hardening and Configuration tab polish.**
+  **Hosted trial hardening.**
 
-  - Trial codegen now defaults to `claude-haiku-4-5-20251001` instead of Opus 4.6, dramatically lowering per-trial cost. Self-hosted customers continue to recommend Opus for codegen on their own keys.
-  - Trial banner copy and link styling refinements on the Configuration tab.
+  - Hosted trial cost tuning and Configuration tab polish (since retired). Self-hosted installs continue to recommend Opus for codegen on their own keys.
 </Update>
 
 <Update label="v1.5.6" description="April 8, 2026">
@@ -875,17 +874,17 @@ description: "Release history for Datris"
 
   - `ai.aiSecretName` and `ai.provider` are replaced by three top-level slots — `ai.aiPrimary.secretName`, `ai.codegen.secretName`, `ai.embedding.secretName`.
   - Each Vault secret is self-describing (`provider`, `endpoint`, `model`, `apiKey`, optionally `version`). No path derivation from YAML.
-  - v1.5.x deployments must update `application.yaml` and re-seed Vault on upgrade.
+  - v1.5.x deployments must update their server configuration and re-seed Vault on upgrade.
 </Update>
 
 <Update label="v1.5.5" description="April 8, 2026">
-  **Onboarding, tap scheduling UX, and trial BYO key path.**
+  **Onboarding and tap scheduling UX.**
 
   - **Getting Started tab** as the new first-run landing page; Docs ↗ top-nav link.
   - Inline cron editor on the Taps page: preset buttons, AI prompt field ("Every weekday at 4pm"), Quartz field validation, human-readable description.
   - Truncate-before-run toggle in the tap wizard (sets `truncateBeforeWrite: true` on the generated destination).
-  - Configuration tab for trial users with BYO Anthropic/OpenAI key banner and "Datris-managed (default)" vs "Your own {provider} key" status.
-  - **Fix:** `TapScheduler` honors the configured `dateTimezone` from `application.yaml`.
+  - Hosted trial bring-your-own AI key banner on the Configuration tab (since retired).
+  - **Fix:** scheduled taps now honor the configured date timezone.
 </Update>
 
 <Update label="v1.5.4" description="April 7, 2026">
@@ -893,7 +892,7 @@ description: "Release history for Datris"
 
   - 4-step tap creation wizard (Describe → Edit & Test → Schedule → Review) with brainstorm chat and proactive env-var suggestions.
   - AI script generation with JSON-parse retry and raw-script fallback; AI diagnosis with explicit (a)/(b)/(c) options; "Apply Diagnosis" rewrites the script in place.
-  - Tap secrets stored in Vault tagged `_type=tap`; run history via `TapRunLog` and `GET /tap/logs`.
+  - Tap secrets stored in Vault and tagged as tap-owned; per-run history is retained and viewable.
   - CRON scheduling (Quartz format), AI-generated from natural language.
   - JSON-to-CSV pipeline feed (union of keys) with column-name normalization via spell-out table (`%` → `percent`, `#` → `num`, `&` → `and`, …).
   - Pipelines page shows the feeding tap; pipeline wizard has "Create from Tap".
@@ -903,36 +902,33 @@ description: "Release history for Datris"
   **Schema Evolution.**
 
   - Additive evolution: new CSV columns are auto-added as `string`, `schemaVersion` increments, and `ALTER TABLE` runs on Postgres.
-  - Dropped columns are excluded from the `COPY` command so Postgres defaults them to `NULL` (previously failed on typed columns).
+  - Dropped columns are left out of the Postgres load so they default to `NULL` (previously failed on typed columns).
   - Missing key fields raise a clear error.
-  - Shared `DataUtil.evolveSchema()` now used by both `StreamNotifier` and `FileNotifier`.
-  - Query endpoints use `serializeNulls()` so `NULL` columns appear in results.
+  - Schema evolution now behaves identically for streamed and file-based ingestion.
+  - Query results now include `NULL` columns.
 </Update>
 
 <Update label="v1.5.2" description="April 3, 2026">
-  **Remote MCP endpoint and managed service support.**
+  **Remote MCP endpoint.**
 
-  - Per-session API key forwarding on the MCP server (header or `api_key` query param); `REQUIRE_API_KEY=true` rejects unauthenticated SSE/streamable-HTTP connections.
-  - New MCP tools for managed service: `signup_trial`, `upgrade_to_dedicated`, `check_upgrade_status`.
-  - Remote SSE registry entry for `https://mcp.trial.datris.ai/sse`.
-  - Website APIs accept `x-api-key` alternative to cookie JWT; `/api/provision/agent-trial` combines signup + provisioning with rate limiting.
+  - Per-session API key forwarding on the MCP server, with an option to reject unauthenticated remote connections.
+  - Hosted trial signup and dedicated-upgrade agent tools and remote registry entry (since retired).
 </Update>
 
 <Update label="v1.5.1" description="April 3, 2026">
-  - Pipeline creation wizard hides PostgreSQL and MongoDB database name fields on trial instances — auto-populated from the environment or defaults to `datris`.
+  - Hosted trial instances: pipeline wizard auto-populated database names (since retired).
 </Update>
 
 <Update label="v1.5.0" description="April 2, 2026">
-  **Multi-tenant hosting on a shared instance.**
+  **Shared-instance hosting.**
 
-  - Per-tenant PostgreSQL databases (auto-created on first use) and per-tenant MongoDB databases scoped via the connection string environment name.
-  - Tenant-scoped metadata and query endpoints; new `TenantInterceptor` sets `DatrisEnvironment.current` per request based on API key.
+  - Hosted multi-tenant isolation on a shared instance (since retired).
   - Vector DB secret isolation across Qdrant, Weaviate, Milvus, Chroma, pgvector.
   - Batch upload for compressed files (`.zip`, `.gz`, `.tar`, `.jar`) processes contents inline — no MinIO webhook dependency.
 </Update>
 
 <Update label="v1.4.4" description="March 30, 2026">
-  - Default AI provider changed to Anthropic (Claude Sonnet 4.6). Customers can still switch to OpenAI or Ollama via `application.yaml`.
+  - Default AI provider changed to Anthropic (Claude Sonnet 4.6). Customers can still switch to OpenAI or Ollama in configuration.
   - Generated Python scripts for DQ and transformation are logged in full to the server logs for debugging.
 </Update>
 
@@ -960,7 +956,7 @@ description: "Release history for Datris"
   - `aiRule` replaces the prior AI DQ approach: the LLM generates a self-contained Python validation script from a plain-English instruction, which runs locally. Cost drops from $25–40/file to ~$0.003/rule.
   - `aiTransformation` uses the same CodeGen approach.
   - Works for CSV, JSON, and XML.
-  - **Removed:** `columnRules` (regex), JavaScript row rules, REST endpoint row rules, `AIDataQualityUtil`. JavaScript row functions and REST transformations removed from UI and CLI.
+  - **Removed:** `columnRules` (regex), JavaScript row rules, REST endpoint row rules, and the legacy AI data-quality path. JavaScript row functions and REST transformations removed from UI and CLI.
 </Update>
 
 <Update label="v1.3.0" description="March 26, 2026">

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -22,17 +22,13 @@ export MCP_SERVER_URL=http://localhost:3000/sse    # default
 
 ### Authentication
 
-When the Datris platform has [`USE_API_KEYS=true`](/api-keys), every CLI command must present an API key. Set it as an environment variable:
+The CLI does not set an `x-api-key` header itself. When `USE_API_KEYS=false` (the OSS default) no key is needed. When [`USE_API_KEYS=true`](/api-keys), pass the key on the MCP URL's query string, which the MCP server accepts as an alternative to the header:
 
 ```bash
-export DATRIS_API_KEY=<your key>
+export MCP_SERVER_URL="http://localhost:3000/sse?api_key=<your key>"
 ```
 
-The CLI sends it as `x-api-key` on every MCP request, which the MCP server forwards to the REST API.
-
-Issue a key dedicated to the CLI from the UI: **Configuration → API-Keys → Issue new key** with a label like `cli` and the capability scope you want (e.g. `read-only` template for an analyst CLI, `ops` for a deploy runner). The value is shown once at issue time — set it as `DATRIS_API_KEY` in your shell. Each label is a distinct caller identity in the request logs and can be revoked independently. See [API Keys](/api-keys) for the full pattern.
-
-When `USE_API_KEYS=false` (the OSS default), the CLI works without any key — the env var is ignored.
+Issue a key dedicated to the CLI from the UI: **Configuration → API-Keys → Issue new key**. See [API Keys](/api-keys) for the full pattern.
 
 ## JSON Output
 
@@ -148,7 +144,7 @@ datris query "SELECT symbol, close FROM public.trades WHERE close > 100" --limit
 
 | Option | Description |
 |--------|-------------|
-| `--limit` | Max rows returned (default: 100, max: 1000) |
+| `--limit` | Max rows returned (default: 100; pass `-1` for no limit) |
 | `--json` | Return raw JSON |
 
 ---
@@ -163,9 +159,9 @@ datris search "What is the return policy?" --store pgvector --collection support
 
 | Option | Description |
 |--------|-------------|
-| `--store` | Vector store: `qdrant`, `weaviate`, `milvus`, `chroma`, `pgvector` (default: `pgvector`) |
-| `--collection` | Collection/table name (required) |
-| `--top-k` | Number of results (default: 5) |
+| `--store`, `-s` | Vector store: `qdrant`, `weaviate`, `milvus`, `chroma`, `pgvector` (default: `pgvector`) |
+| `--collection`, `-c` | Collection/table name (required) |
+| `--top-k`, `-k` | Number of results (default: 5) |
 | `--json` | Return raw JSON |
 
 ---
@@ -295,7 +291,7 @@ datris taps
 Create a tap. The `instruction` argument (a plain-English description) is optional — provide it to have AI generate the fetch script, or omit it and supply your own script with `--script` (or create a config-only tap with neither).
 
 ```bash
-datris tap create ["<instruction>"] --pipeline <name> [--name <tap-name>] [--script <file>] [--cron "<expression>"] [--type structured|document]
+datris tap create ["<instruction>"] --pipeline <name> [--name <tap-name>] [--script <file>] [--cron "<expression>"] [--type structured|document] [--kind python|http --endpoint-url <url>]
 ```
 
 | Argument | Description |
@@ -310,6 +306,8 @@ datris tap create ["<instruction>"] --pipeline <name> [--name <tap-name>] [--scr
 | `--secret` | Vault secret name for credentials injected as env vars |
 | `--script` | Path to a Python script file with a `fetch()` function (skips AI generation) |
 | `--type` | `structured` (default) returns rows of records; `document` returns `{uri, filename, content}` dicts destined for a vector-store pipeline. See [Document Taps](/taps#document-taps) |
+| `--kind` | Tap implementation kind: `python` (default) runs a script on the platform; `http` calls a user-hosted endpoint speaking the tap HTTP contract (no instruction or `--script`) |
+| `--endpoint-url` | For `--kind http`: absolute http(s) URL Datris POSTs the run context to on each run (required with `--kind http`) |
 | `--json` | Return raw JSON |
 
 **Examples:**
@@ -397,7 +395,7 @@ datris tap logs <name>
 Update a tap's configuration without regenerating its script. Specify at least one option.
 
 ```bash
-datris tap update <name> [--enabled | --disabled] [--cron "<expression>"] [--pipeline <name>] [--description "<text>"]
+datris tap update <name> [--enabled | --disabled] [--cron "<expression>"] [--pipeline <name>] [--description "<text>"] [--endpoint-url <url>]
 ```
 
 | Option | Description |
@@ -406,6 +404,7 @@ datris tap update <name> [--enabled | --disabled] [--cron "<expression>"] [--pip
 | `--cron` | CRON expression for scheduling (Quartz format) |
 | `--pipeline`, `-p` | Target pipeline name |
 | `--description`, `-d` | New description |
+| `--endpoint-url` | New endpoint URL (HTTP taps only) |
 | `--json` | Return raw JSON |
 
 ---

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -60,6 +60,7 @@ Do **not** use `docker compose restart` to apply an `.env` change. `restart` reu
 | `schedule.findJobsToStart` | `5000` | Interval to check for queued jobs (ms) |
 | `schedule.checkDatabaseSourceQueries` | `30000` | Interval to check for database pulls (ms) |
 | `schedule.checkTapSchedules` | `30000` | Interval to check for taps with CRON schedules due to run (ms) |
+| `schedule.incidentSweep` | `300000` | Recovery-agent sweep interval (ms): resumes approved actions and raises stale/volume signals |
 
 ### Pipeline
 
@@ -71,6 +72,10 @@ Do **not** use `docker compose restart` to apply an `.env` change. `restart` reu
 | `sendPipelineNotifications` | `true` | Enable pipeline event notifications |
 | `ttlFileNotifierQueueMessages` | `60` | Days to retain processed message IDs for deduplication |
 | `tapScriptTimeoutSeconds` | `300` | Maximum tap script execution time in seconds |
+| `versionCap` | `50` | Definition versions retained per tap / pipeline before older snapshots (and their pinned scripts) are pruned |
+| `cron.retry.enabled` | `true` | Automatically retry failed scheduled (CRON) tap runs that fed nothing downstream |
+| `cron.retry.cap` | `3` | Maximum automatic retries per failed scheduled tap run |
+| `cron.retry.backoffMinutes` | `5,15` | Comma-separated backoff ladder (minutes) between automatic retries; the last value repeats |
 | `tapMaxOutputMB` | `100` | Hard cap on a tap script's stdout output, in megabytes. Runs that exceed the cap fail fast with an actionable error (the agent is told to chunk the source range smaller via `run_tap` `params`) before the JSON is parsed — preventing the whole batch from buffering in JVM heap and OOM-killing the server. Override per deployment with the `TAP_MAX_OUTPUT_MB` env var. |
 
 ### Authentication
@@ -81,8 +86,11 @@ Two independent flags control access. Set them together — see [the supported m
 |---------|---------|-------------|
 | `USE_USER_AUTH` | `false` | Require login for the UI; gate Configuration and Users tabs to `admin`. See [User Authentication](/user-auth) |
 | `USE_API_KEYS` | `false` | Require `x-api-key` on every REST and MCP request. Maps to `useApiKeys` above |
-| `MULTI_TENANT` | `false` | Per-tenant database isolation; routes requests by API-key value. Hosted/managed deployments only |
+| `MULTI_TENANT` | `false` | Advanced: per-tenant database isolation. Requires `USE_API_KEYS=true`; each request is routed to the tenant environment its API key belongs to |
 | `CAPABILITY_ENFORCEMENT` | `enforce` | Default: scoped keys missing the required capability get HTTP 403. Override to `log-only` to emit `would-deny` log lines without rejecting — useful only when iterating on a new scope policy and you want a trial run before flipping enforcement on. Legacy `*:*` keys are unaffected either way |
+| `DATRIS_ALLOW_PRIVATE_EGRESS` | `false` | HTTP taps and REST endpoint destinations refuse loopback, link-local, private, and cloud-metadata addresses. Set `true` only if your endpoints legitimately live on an internal network. See [Tap Execution & Isolation](/tap-execution-isolation#always-on-protections). |
+| `DATRIS_ENV` | _(unset)_ | Set to `production` to require TLS (`sslmode=require` or stricter) on pipeline loads to external Postgres hosts. The bundled and local Postgres services are exempt. |
+| `DATRIS_ALLOW_PLAINTEXT_DB` | `false` | Opt-out for the `DATRIS_ENV=production` TLS check: the load proceeds and a warning is logged. |
 | `USE_AUDIT_LOG` | `false` | Record who created, changed, ran, or deleted what — readable by admins under Configuration → Audit Log and mirrored to the server log. Restart to change. See [Audit Log](/audit-log) |
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries in the config store; `0` keeps them forever. Maps to `auditLog.retentionDays` |
 | `AUDIT_LOG_READS` | `false` | Also record reads — queries, searches, listings, metadata. Off by default because they dwarf the write trail. Maps to `auditLog.logReads` |
@@ -214,14 +222,14 @@ PostgreSQL connection details (`username`, `password`, `jdbcUrl`) are stored in 
 | Property | Default | Description |
 |----------|---------|-------------|
 | `kafkaConsumer.enabled` | `false` | Enable Kafka topic consumption |
-| `kafkaConsumer.bootstrapServers` | | Kafka broker address |
-| `kafkaConsumer.groupId` | | Consumer group ID |
+| `kafkaConsumer.bootstrapServers` | `localhost:9092` (`kafka:9092` in Docker) | Kafka broker address |
+| `kafkaConsumer.groupId` | `oss-group` | Consumer group ID |
 | `kafkaConsumer.topicPollingInterval` | `500` | Topic polling interval (ms) |
-| `kafkaConsumer.topicPrefix` | | Prefix for topic names |
+| `kafkaConsumer.topicPrefix` | `oss` | Prefix for topic names |
 
 ### AI (Required)
 
-AI configuration is split into three independent slots, each pointing at its own self-describing Vault secret. The resolver reads whatever it finds in the secret — `provider`, `endpoint`, `model`, `apiKey`, and (optionally) `version` — so the YAML side never needs a `provider` field.
+AI configuration is split into four independent slots (three seeded at first boot, plus optional web search), each pointing at its own self-describing Vault secret. The resolver reads whatever it finds in the secret — `provider`, `endpoint`, `model`, `apiKey`, and (optionally) `version` — so the YAML side never needs a `provider` field.
 
 | Property | Default | Description |
 |----------|---------|-------------|
@@ -229,6 +237,8 @@ AI configuration is split into three independent slots, each pointing at its own
 | `ai.aiPrimary.secretName` | `oss/ai-primary` | Vault secret for the main AI model used for general reasoning (NL→SQL, search answers, etc.). Seeded with the strongest available model — Anthropic gets `claude-opus-5`, OpenAI gets `gpt-5.5`. |
 | `ai.codegen.secretName` | `oss/codegen` | Vault secret for the code-generation model (tap scripts, AI DQ, AI transformations, schema generation). Seeded with the strongest available model — Anthropic gets `claude-opus-5`, OpenAI gets `gpt-5.5`. |
 | `ai.embedding.secretName` | `oss/embedding` | Vault secret for the embedding model used by vector destinations (Chroma, Qdrant, Milvus, Weaviate, pgvector) and search. For Anthropic-only deployments this is seeded to point at the bundled TEI sidecar serving `BAAI/bge-m3` (1024-dim), so vector destinations work out of the box without an OpenAI key. |
+| `ai.webSearch.secretName` | `oss/web-search` | Vault secret for the optional live web-search provider used during tap script generation and diagnosis. Not seeded at first boot — configure it from the Configuration tab. |
+| `ai.extendedThinking` | `true` | Enable extended thinking on the Assistant tab's agent loop (Anthropic models only); the model's reasoning is shown above the visible response. Set to `false` to disable platform-wide. |
 
 Each Vault secret is self-describing and looks like:
 
@@ -328,7 +338,7 @@ See [AI Configuration](/ai-configuration) for full setup details.
 | `oversize` | `split` | What to do with chunks over the cap: `split` (lossless — fan one input into N sub-chunks, token-boundary with `openai`, char-boundary with heuristic), `truncate` (lossy — drop the tail), or `fail` (raise an error naming the chunk index). |
 | `retryIndividualOnFailure` | `false` | When the embedding API rejects a batch with a 4xx, retry each chunk one-at-a-time so a single poison chunk doesn't lose the whole batch. Costs N HTTP calls in the failure path. |
 
-The guard always runs. When `maxChunkTokens` is set on the destination's `chunking` config (see [Pipeline configuration](/configuration)), the chunker stops merging segments before they cross the token cap, leaving the guard as a true safety net rather than the primary defender.
+The guard always runs. When `maxChunkTokens` is set on the destination's `chunking` config (see [Pipeline configuration](/pipeline-configuration#chunking-config)), the chunker stops merging segments before they cross the token cap, leaving the guard as a true safety net rather than the primary defender.
 
 ## MinIO Buckets
 
@@ -350,6 +360,19 @@ The following buckets are created automatically by the `minio-init` container:
 | `{environment}-archived-metadata` | File ingestion metadata |
 | `{environment}-file-notifier-message` | Processed message deduplication |
 | `{environment}-data-pull` | Database pull scheduling state |
+| `{environment}-pipeline-version` | Append-only pipeline definition versions (pruned per `versionCap`) |
+| `{environment}-tap` | Tap configurations |
+| `{environment}-tap-version` | Append-only tap definition versions (pruned per `versionCap`) |
+| `{environment}-tap-state` | Per-tap incremental-sync state (bookmarks / cursors) |
+| `{environment}-tap-log` | Tap run history |
+| `{environment}-tap-ledger` | Document-tap ledger of processed documents |
+| `{environment}-tap-prompt` | Tap prompt fragments |
+| `{environment}-code-repo` | Git repository connections for repo-backed tap scripts |
+| `{environment}-codegen-scripts` | Last CodeGen transformation script per pipeline |
+| `{environment}-run-lineage` | One document per pipeline run (what it read, wrote, and how it ended) |
+| `{environment}-column-lineage` | AI-inferred column mappings per pipeline version |
+| `{environment}-user` | User accounts (when `USE_USER_AUTH=true`) |
+| `{environment}-user-session` | Login sessions (when `USE_USER_AUTH=true`) |
 | `{environment}-audit-log` | Audit entries (when `USE_AUDIT_LOG=true`); TTL-expired per `AUDIT_LOG_RETENTION_DAYS` |
 | `{environment}-agent-policy` | The [agent policy](/agent-policy) document (when `USE_AGENT_POLICY=true`) |
 | `{environment}-pending-action` | Agent actions queued for approval; TTL-expired at their own expiry |
@@ -365,7 +388,7 @@ These environment variables are read by `docker-compose.yml` and passed into the
 | `TAP_MAX_OUTPUT_MB` | `100` | Override the `tapMaxOutputMB` cap. Applies to all tap scripts; affects when the platform fails fast on oversized output. Raise on hosts with larger heaps when single-shot backfills genuinely need more buffer; lower on memory-constrained deployments to fail earlier. |
 | `USE_USER_AUTH` | `false` | Enable username/password login + admin gating. See [User Authentication](/user-auth). |
 | `USE_API_KEYS` | `false` | Enable per-tenant API-key gating on the REST/MCP API. See [API Keys](/api-keys). |
-| `MULTI_TENANT` | `false` | Switch to per-tenant database isolation (intended for hosted/managed deployments). |
+| `MULTI_TENANT` | `false` | Advanced: switch to per-tenant database isolation, with each request routed by its API key. Requires `USE_API_KEYS=true`. |
 | `ANTHROPIC_OVERLOAD_FALLBACK_MODEL` | `claude-sonnet-4-6` | Model used for the current request when Anthropic returns a sustained `overloaded_error` on an Opus call (after the automatic retries). Only consulted when the configured model is an Anthropic Opus variant — other providers ignore it. Bump when a newer Sonnet ships to keep the fallback current. |
 | `CAPABILITY_ENFORCEMENT` | `enforce` | `enforce` returns HTTP 403 on policy violations by scoped keys. Set to `log-only` to emit would-deny log lines without rejecting — useful when iterating on a new scope policy. |
 | `USE_AUDIT_LOG` | `false` | Enable the [Audit Log](/audit-log) — who did what, by login or API key. |

--- a/docs/configuring-claude.mdx
+++ b/docs/configuring-claude.mdx
@@ -11,7 +11,6 @@ The MCP server is a transparent forwarder — it has no API key of its own. When
 
 - **Single-tenant OSS with `USE_API_KEYS=false`** (default): no key needed. The snippets below work as-is.
 - **Single-tenant OSS with `USE_API_KEYS=true`**: append `--header x-api-key:<your-key>` to the `args` array. Issue and rotate keys from **Configuration → API-Keys** in the UI — the value shown when you create a key is what your client sends.
-- **Hosted / multi-tenant**: each tenant gets a key from the trial provisioning flow. Append `--header x-api-key:<your-key>` to the `args` array. That same key authenticates both the REST API and the MCP server for that tenant.
 
 The Configuration UI's **Connect Your Agent** panel pre-generates these snippets — paste your API key into the field there and the `--header` flag gets added automatically.
 
@@ -44,7 +43,7 @@ The underlying connection is SSE to port 3000, so sessions register with the Dat
 
 Requires Node.js on your `PATH` (`brew install node`). On macOS, Claude Desktop is a GUI app and doesn't inherit your shell `PATH`, so use the full path to `npx` (e.g. `/opt/homebrew/bin/npx`) if `npx` alone doesn't resolve.
 
-If your instance requires an API key (`USE_API_KEYS=true` or hosted), append two more args:
+If your instance requires an API key (`USE_API_KEYS=true`), append two more args:
 
 ```json
 "args": [
@@ -75,7 +74,7 @@ If you're not running the Docker stack — for example, you only want the MCP se
 Requires `uv` / `uvx` (`brew install uv`). On macOS, Claude Desktop is a GUI app and doesn't inherit your shell PATH, so use the full path to `uvx` (e.g. `/Users/you/.local/bin/uvx`) if `uvx` alone doesn't resolve.
 
 <Note>
-The stdio transport has no header layer, so it can't carry an API key. If your Datris instance has `USE_API_KEYS=true`, use the mcp-remote option above instead. With `USE_API_KEYS=false` (single-tenant OSS default), stdio works fine but tool calls won't appear in the Agent Monitor tab.
+The stdio transport has no header layer, so the API key comes from the environment instead: if your Datris instance has `USE_API_KEYS=true`, add `"DATRIS_API_KEY": "<your-key>"` to the `env` block (or use the mcp-remote option above). With `USE_API_KEYS=false` (single-tenant OSS default), stdio works fine without a key, but tool calls won't appear in the Agent Monitor tab.
 </Note>
 
 ## Configuring Claude Code
@@ -101,7 +100,7 @@ Add to `.mcp.json` in your project root. The same two options apply.
 }
 ```
 
-To add an API key (`USE_API_KEYS=true` or hosted), append `"--header", "x-api-key:<your-key>"` to the args array.
+To add an API key (`USE_API_KEYS=true`), append `"--header", "x-api-key:<your-key>"` to the args array.
 
 ### Alternative: stdio via uvx (no Docker)
 

--- a/docs/configuring-openclaw.mdx
+++ b/docs/configuring-openclaw.mdx
@@ -14,7 +14,7 @@ This isn't a "no memory vs. memory" comparison. OpenClaw already has memory. It'
 The short version:
 
 1. **OpenClaw's built-in memory is best-effort** — the model decides when to save and when to look — so long sessions, restarts, and context compaction quietly erode recall. Datris moves memory out of the prompt and enforces it at the system layer, so your agent stops forgetting.
-2. **The same MCP connection that gives OpenClaw enforced semantic memory also exposes 30+ Datris tools** — pipelines, ingestion, SQL, vector search — so you're not bolting on a memory product, you're handing your agent a full data platform.
+2. **The same MCP connection that gives OpenClaw enforced semantic memory also exposes 70+ Datris tools** — pipelines, ingestion, SQL, vector search — so you're not bolting on a memory product, you're handing your agent a full data platform.
 
 ### vs. OpenClaw's default memory (best-effort, not enforced)
 
@@ -39,8 +39,8 @@ Datris is a memory layer exposed over MCP. OpenClaw stays OpenClaw. Your agent l
 Indexing local memory files into Datris gives you the best of both worlds — markdown stays human-editable and version-controllable, while Datris handles retrieval at scale.
 
 - **Agent-runtime-agnostic.** Datris exposes memory through MCP, so OpenClaw, Claude Desktop, Cursor, or any custom MCP client can point at the same instance and share the same memory. No bespoke integration per agent, no rewriting your agent loop to match someone else's runtime.
-- **Tool-rich, not just retrieval.** The same MCP connection that gives OpenClaw memory also exposes pipeline management, ingestion, and SQL and vector query tools — over 30 in total. Memory-only products stop at recall; Datris hands the agent the rest of a data platform on the same connection.
-- **Auditable.** The **Agents** tab in the Datris UI shows OpenClaw's memory tool calls as they happen, so you can see exactly what the agent searched for, what came back, and what it stored.
+- **Tool-rich, not just retrieval.** The same MCP connection that gives OpenClaw memory also exposes pipeline management, ingestion, and SQL and vector query tools — over 70 in total. Memory-only products stop at recall; Datris hands the agent the rest of a data platform on the same connection.
+- **Auditable.** The **Agent Monitor** tab in the Datris UI shows OpenClaw's memory tool calls as they happen, so you can see exactly what the agent searched for, what came back, and what it stored.
 - **Semantic recall, not substring search.** Ask in natural language and get the right snippet back even when the wording doesn't match — *"what did we decide about the pipeline architecture?"* finds the note filed under "ingestion topology."
 - **Scales past the context window.** Large memory corpora that would never fit into a single prompt become retrievable on demand. The agent pulls only what's relevant for the current turn.
 - **Files remain the source of truth.** For memory you author yourself, the markdown files are yours — Datris is a derived index. Edit locally, re-ingest when ready. No vendor lock-in on your notes.
@@ -93,7 +93,7 @@ Verify the registration:
 openclaw mcp show datris
 ```
 
-You should see the `datris` server listed with its URL. SSE registration also means OpenClaw will appear in the Datris UI's **Agents** tab with live tool-call streaming — useful for watching what the agent is actually doing during ingestion and retrieval.
+You should see the `datris` server listed with its URL. SSE registration also means OpenClaw will appear in the Datris UI's **Agent Monitor** tab with live tool-call streaming — useful for watching what the agent is actually doing during ingestion and retrieval.
 
 ## Step 4 — Install the Datris memory skill
 
@@ -107,7 +107,7 @@ You have two options for installing the skill.
 openclaw skills install datris-memory
 ```
 
-This pulls the latest published version of the skill, drops it at `~/.openclaw/workspace/skills/datris-memory/skill.md`, and you're done. Skip ahead to Step 5.
+This pulls the latest published version of the skill, drops it at `~/.openclaw/workspace/skills/datris-memory/SKILL.md`, and you're done. Skip ahead to Step 5.
 
 ### Option B: install manually
 
@@ -117,74 +117,41 @@ Create the skill directory:
 mkdir -p ~/.openclaw/workspace/skills/datris-memory
 ```
 
-Then create `~/.openclaw/workspace/skills/datris-memory/skill.md` with the contents below:
+Then create `~/.openclaw/workspace/skills/datris-memory/SKILL.md` with the contents below:
 
 ```markdown
 ---
 name: datris-memory
-description: Long-term semantic memory layer for AI agents, built on the Datris Platform via MCP. Local markdown files (MEMORY.md, memory/*.md) are the source of truth; Datris is the queryable index, rebuilt from them with strict one-file-per-upload provenance and incremental mtime-based sync (background timer, post-write flush, on-demand). Triggers on memory-shaped questions — saving, recalling, ingesting, syncing, searching — even when the user doesn't say "Datris."
-version: 1.0.0
-metadata:
-  openclaw:
-    requires:
-      bins:
-        - datris
-        - docker
-    envVars:
-      - name: MCP_SERVER_URL
-        required: false
-        description: Datris MCP server SSE endpoint. Defaults to http://localhost:3000/sse.
-    install:
-      - id: brew
-        kind: brew
-        formula: datris/tap/datris
-        bins: [datris]
-        label: Install Datris CLI (brew)
+description: Use the Datris Platform as a long-term semantic memory layer through the Datris MCP server. Local markdown memory files (MEMORY.md, memory/*.md) stay canonical; Datris is the retrieval index built from them. Use this skill any time the user mentions saving, recalling, ingesting, syncing, or searching memory through Datris — and any time they ask a memory-shaped question ("what did I note about X", "find anything related to Y", "summarize what I've written down about Z") even when they don't explicitly say "Datris." Trigger on any work involving long-term memory ingestion, retrieval, or sync. Datris MCP is the only memory backend — do not substitute a built-in `memory_search`, `recall`, or host-provided knowledge tool, even when one is available.
 ---
 
 # Datris memory layer
 
 Datris is the long-term semantic memory layer. Local memory files are the source of truth. Datris is rebuilt from them — never the other way around.
 
-## Prerequisites
-
-This skill assumes a local Datris install:
-
-- **Datris Platform** (includes the MCP server) — Docker-based, see [docs.datris.ai/installation](https://docs.datris.ai/installation). The MCP server runs at `http://localhost:3000/sse` by default; override with `MCP_SERVER_URL`.
-- **Datris CLI** — `brew tap datris/tap && brew install datris`. See [docs.datris.ai/cli](https://docs.datris.ai/cli) for command reference.
-
-Confirm both are working before relying on this skill: `datris health` pings every backend service the memory pipeline needs.
-
 ## Rules
 
-- Prefer Datris MCP tools over the CLI for memory operations. The CLI is a fallback for the cases listed under "When to use the CLI" below.
+- **Datris MCP is the only memory backend.** If the host exposes a built-in memory tool (`memory_search`, `recall`, an internal RAG store, a sibling skill's memory index, etc.), do not use it for memory-shaped queries. Those tools index a different corpus and produce divergent results — the local markdown files are the source of truth and Datris is the only retrieval index built from them. There is no third channel.
+- Prefer Datris MCP tools over shell or CLI for memory operations.
 - **One file in = one `upload_data` call.** Never concatenate, bundle, or consolidate multiple memory files into a single corpus upload. Each file's name is its provenance — it must round-trip cleanly into Datris and back out in retrieval results. Bundling looks like an optimization and is not one: it permanently breaks provenance, blocks per-file incremental sync, and makes resets harder.
+- **Source filenames preserve the full relative path.** Use `MEMORY.md` and `memory/2026-05-06.md` as source filenames — the directory prefix is part of the provenance and must round-trip into retrieval results. Some Datris builds reject path separators at the temp-file staging layer; if uploads fail on slashes, encode the separator reversibly (e.g., `memory__2026-05-06.md`) and tell the user what encoding was applied. Never silently flatten to a basename — that strips the directory and creates ambiguity if two memory subdirectories ever contain files with the same name.
 - Upload each file as-is. Let Datris chunk server-side. Do not pre-chunk. Do not use a document tap for local files. The only time to split a single file is when that one file genuinely exceeds the upload limit; in that case, split it with explicit provenance markers in the chunk filenames (e.g. `MEMORY.md.part1`, `MEMORY.md.part2`).
-- Upload files in parallel. Each `upload_data` call returns a job token immediately — fire all uploads first, then poll. Do not wait for one job to finish before starting the next.
-- Poll job status to completion before claiming any ingestion succeeded. Polling is for verification, not for gating subsequent uploads.
+- **Run uploads concurrently across files.** Each `upload_data` call returns a job token immediately — collect all the tokens first, then poll. Use a bounded concurrency limit (8–16 parallel uploads is safe for most Datris builds) rather than unbounded fan-out. On bootstrap, where there are no pre-existing chunks to remove, this is straight parallelism.
+- **Re-uploads are delete-then-upload, serialized per file.** When re-ingesting a file that already exists in the pipeline, delete its existing chunks first, wait for the delete to complete, then upload. Do not rely on upsert behavior — some Datris builds append duplicates rather than overwriting on filename collision, and a delete-then-upload pair is build-agnostic and idempotent. Within a single file, delete→upload is serial. Across files, multiple delete→upload pairs run concurrently up to the same bounded limit.
+- Poll job status to completion before claiming any ingestion succeeded. Polling is for verification across the batch, not for gating cross-file uploads.
 - Verify retrieval with a semantic search after every ingestion run.
 - Memory pipelines must target a vector destination (pgvector, Qdrant, Weaviate, Milvus, or Chroma).
 - The embedding model is pinned at pipeline-creation time. Vector dimensions cannot change after the fact. Confirm the embedder matches the pipeline before ingesting. Switching embedders means dropping and recreating the destination collection.
-- **Place every created resource in the `openclaw` data catalog by default.** Pipelines, taps, secrets, destination collections — anything the agent creates in Datris on OpenClaw's behalf goes in the catalog named `openclaw` unless the user explicitly directs otherwise. This keeps OpenClaw's footprint cleanly separated from other Datris workloads on the same instance, makes cleanup and auditing trivial, and lets multiple OpenClaw users share an instance without colliding. If an existing resource the agent wants to reuse lives in a different catalog, do not migrate it silently — surface the mismatch to the user and ask before continuing. Set the catalog at creation time (`create_pipeline` accepts `catalog: "openclaw"`; `create_tap` writes the field through) or after the fact via the `set_catalog` MCP tool.
-
-## When to use the CLI
-
-MCP tools are the default. Reach for the `datris` CLI in these specific situations:
-
-- **Health checks during bootstrap or troubleshooting.** `datris health` confirms every backend service is up. Use it as a more thorough cross-check when MCP `check_service_health` returns ambiguous results, or when diagnosing a stuck ingestion.
-- **MCP server unavailable.** If the MCP connection is down, `datris ingest <file> --dest pgvector` and `datris search "<query>" --store pgvector --collection <name>` are the equivalent fallbacks for ingestion and retrieval. Use these only to keep the user unblocked; restore MCP-based operation as soon as the server is reachable.
-- **Pipeline status when MCP polling stalls.** `datris status <pipeline>` is a clean way to read the latest job state if the MCP `get_job_status` loop has lost track of which token to follow.
-- **Spot-checks the user runs themselves.** When the user wants to verify an ingestion by hand, point them at `datris search` against the destination collection rather than walking them through MCP tool calls.
-
-Log every CLI invocation in the audit log (`memory/<today>.md`) the same way an MCP call would be logged — same provenance discipline applies.
+- **Place every created resource in the `openclaw` data catalog by default.** Pipelines, taps, secrets, destination collections — anything the agent creates in Datris on OpenClaw's behalf goes in the catalog named `openclaw` unless the user explicitly directs otherwise. This keeps OpenClaw's footprint cleanly separated from other Datris workloads on the same instance, makes cleanup and auditing trivial, and lets multiple OpenClaw users share an instance without colliding. If an existing resource the agent wants to reuse lives in a different catalog, do not migrate it silently — surface the mismatch to the user and ask before continuing.
+- **Return to prescribed concurrency after debugging.** When isolating a failure — a Datris bug, a tool returning unexpected output, a transient error — it is reasonable to drop temporarily to single-file sequential operations to get a clean signal. Once the issue is identified and resolved, return to the concurrency model in the rules above before processing the rest of the batch. Do not carry a debug-mode sequential pattern into subsequent ingestion or sync runs. Note in the audit log when this happens, including the reason and what was done.
 
 ## First-run bootstrap
 
 1. Read the Datris MCP resources and tool descriptions. Understand the pipeline, upload, job-status, and search workflows before acting.
-2. Check service health via the MCP `check_service_health` tool. If it returns ambiguous or partial results, fall back to `datris health` for a more detailed per-service view.
+2. Check service health.
 3. Reuse an existing vector pipeline for memory in the `openclaw` catalog if one exists. Otherwise create one in the `openclaw` catalog — pgvector is fine. If a memory pipeline exists outside the `openclaw` catalog, surface that to the user before reusing or migrating it.
 4. Ingest `MEMORY.md` and each `memory/*.md` file via its own `upload_data` call — one upload per file, no exceptions. Do not concatenate them into a single corpus document, even if the total set is small. Fire the uploads in parallel and collect all the job tokens before polling.
-5. Poll all jobs concurrently until every one is done. Call `get_job_status(pipeline_token=...)` per job and treat it as complete when `rollup.allDone` is `true`; the per-job outcome is `rollup.status` (`success` / `warning` / `error`), with failure detail in `rollup.jobs[].lastError`.
+5. Poll all jobs concurrently until every one reports completion.
 6. Verify with two or three representative semantic queries. Confirm both that (a) the expected content comes back, and (b) results show real source filenames (`MEMORY.md`, `memory/2026-05-06.md`, etc.) — not a consolidated corpus filename or any other synthetic name. The filename round-trip check is the early-warning signal that the one-file-per-upload rule is being followed; if results show a corpus filename, stop and apply the remediation workflow below.
 7. Record the run in `memory/<today>.md`: pipeline used, files ingested, verification queries and results, any failures.
 8. Propose an incremental sync strategy for future edits.
@@ -209,9 +176,9 @@ Memory edits made outside of an agent session — for example, the user editing 
 
 Compare each memory file's filesystem `mtime` against the most recent sync timestamp recorded for that file in the `memory/<date>.md` audit logs. Three cases:
 
-- **No sync record exists** — treat as a new file, ingest it.
-- **`mtime` newer than last-sync timestamp** — re-upload.
-- **`mtime` unchanged** — skip. Do not re-ingest unchanged files; the point of incremental sync is to do less work.
+- **No sync record exists** → treat as a new file, ingest it.
+- **`mtime` newer than last-sync timestamp** → re-upload.
+- **`mtime` unchanged** → skip. Do not re-ingest unchanged files; the point of incremental sync is to do less work.
 
 A content hash is more reliable than `mtime` if the user touches files without editing them (some editors do this on save), but `mtime` is sufficient as a default. Switch to hashing only if redundant uploads start showing up in the audit log.
 
@@ -219,15 +186,15 @@ A content hash is more reliable than `mtime` if the user touches files without e
 
 Classify each changed file into one of four cases and act accordingly:
 
-- **Edited file** — re-upload via `upload_data`. Pipelines upsert on source filename, so this overwrites the file's existing chunks cleanly.
-- **New file** (no prior sync record) — upload via `upload_data` like any other.
-- **Renamed file** — treat as `delete + add`, never as `update`. Delete chunks for the old filename from the destination collection, then upload the new file. Otherwise the index keeps orphan chunks under the old name.
-- **Deleted file** — delete its chunks from the destination collection. Do not leave orphans.
+- **Edited file** → delete existing chunks for that source filename, wait for the delete to complete, then upload via `upload_data`. Per-file serial; multiple files' delete→upload pairs run concurrently.
+- **New file** (no prior sync record) → upload via `upload_data` directly. No delete step needed since there are no existing chunks for this filename.
+- **Renamed file** → delete chunks for the old filename, then upload the new file. Same per-file serialization as edits, same cross-file concurrency.
+- **Deleted file** → delete its chunks from the destination collection. Do not leave orphans.
 
 Then:
 
-- Fire all uploads in parallel, collect the job tokens, poll concurrently to completion.
-- Verify with one or two semantic queries that touch the changed content. Confirm filenames in results reflect the post-sync state — no stale entries from before a rename or delete, no consolidated-corpus names.
+- Wait for all jobs to complete, polling concurrently.
+- Verify with one or two semantic queries that touch the changed content. Confirm filenames in results reflect the post-sync state — no stale entries from before a rename or delete, no consolidated-corpus names, no duplicate chunks (same content under the same filename appearing more than once would indicate the delete step was skipped).
 - Append a per-file entry to today's audit log: filename, change type (edit / new / rename / delete), timestamp, verification result.
 
 ## Inheriting a consolidated-corpus pipeline
@@ -241,7 +208,18 @@ If the existing memory pipeline was bootstrapped with a single consolidated uplo
 
 ## Retrieval
 
-When the user asks a memory-shaped question, reach for `vector_search` (or `ai_answer` for synthesis) against the memory pipeline before grepping local files. Substring search on local markdown is a fallback, not the default. If the MCP layer is unreachable, `datris search "<query>" --store pgvector --collection <name>` is the equivalent fallback against the same destination.
+When the user asks a memory-shaped question:
+
+1. Call `vector_search` against the Datris memory pipeline (or `ai_answer` for synthesis).
+2. If — and only if — Datris MCP is unreachable, grep local memory files as a fallback. Tell the user you fell back and why.
+
+**Do not** call:
+
+- Built-in agent memory tools (`memory_search`, `recall`, etc.)
+- Host-provided knowledge stores or RAG indexes
+- Sibling skills' memory features
+
+These index a different corpus than Datris and will return inconsistent results. Before sending your answer, name the tool you actually called in your own reasoning — if it isn't `vector_search`/`ai_answer` against the Datris memory pipeline, stop and re-route.
 
 ## Reporting
 
@@ -256,12 +234,11 @@ After any bootstrap or sync, report:
 ### What this skill enforces
 
 - **Auto-triggers on memory intent** — the skill's `description` covers explicit phrasing ("sync memory," "save what we discussed") *and* implicit memory-shaped questions ("what did I note about X"), so the user never has to remember to invoke it.
-- **Declares its prerequisites** — the `metadata.openclaw` block tells OpenClaw the skill needs the `datris` and `docker` binaries and offers a Homebrew install path (`datris/tap/datris`) if `datris` is missing. Override the default MCP endpoint via the `MCP_SERVER_URL` env var.
-- **One file in = one upload** — no bundling, no concatenation. Filenames round-trip into retrieval results so provenance is preserved and per-file incremental sync stays clean.
-- **Parallel uploads, then poll** — fires every `upload_data` call up front, collects job tokens, polls concurrently. No serial waiting.
+- **Datris MCP is the only memory backend** — built-in agent memory tools, host-provided knowledge stores and sibling skills' memory features are never used for memory-shaped queries; local files are grepped only if Datris MCP is unreachable, and the agent says so.
+- **One file in = one upload** — no bundling, no concatenation. Filenames (including their directory prefix) round-trip into retrieval results so provenance is preserved and per-file incremental sync stays clean.
+- **Bounded parallel uploads, then poll** — fires `upload_data` calls concurrently (8–16 at a time), collects job tokens, polls concurrently. Re-uploads are delete-then-upload, serialized per file.
 - **Catalog isolation** — every resource the agent creates lands in the `openclaw` data catalog by default, keeping OpenClaw's footprint separate from other workloads on the same Datris instance.
 - **Three-mode incremental sync** — periodic timer sweep (default 30 min), end-of-response flush for agent-authored writes, and explicit user "sync memory" trigger. Renames go through delete-then-add so the index never accumulates orphans.
-- **CLI fallback for resilience** — MCP tools are the default, but the skill documents when to drop to `datris health`, `datris ingest`, `datris search`, and `datris status` — so a flaky MCP connection or a stalled poll doesn't leave the user blocked.
 - **Self-healing for inherited corpora** — if a previous setup bundled everything into one file, the skill includes the reset-and-re-ingest workflow rather than papering over broken provenance.
 
 ## Step 5 — Restart the OpenClaw gateway
@@ -272,7 +249,7 @@ Skills are discovered at gateway startup, so the new `datris-memory` skill won't
 openclaw gateway restart
 ```
 
-After the restart, OpenClaw will pick up `~/.openclaw/workspace/skills/datris-memory/skill.md` and auto-trigger it on any memory-shaped request.
+After the restart, OpenClaw will pick up `~/.openclaw/workspace/skills/datris-memory/SKILL.md` and auto-trigger it on any memory-shaped request.
 
 ## Step 6 — Kick off the bootstrap, then use it
 
@@ -280,7 +257,7 @@ With the skill loaded, point OpenClaw at it once so it runs the first-time boots
 
 > "You now have the `datris-memory` skill installed. Use it to ingest my existing memory into Datris."
 
-Watch the **Agents** tab in the Datris UI as it runs — you'll see each `upload_data` call, `pipeline_status` poll, and `vector_search` verification stream in real time. When the bootstrap finishes, OpenClaw will write a summary into today's `memory/<date>.md` audit log.
+Watch the **Agent Monitor** tab in the Datris UI as it runs — you'll see each `upload_data` call, `get_job_status` poll, and `search_pgvector` verification stream in real time. When the bootstrap finishes, OpenClaw will write a summary into today's `memory/<date>.md` audit log.
 
 After that, just talk normally. The skill auto-triggers on any memory-shaped request and reaches for Datris semantic search instead of grepping local files:
 

--- a/docs/data-catalog.mdx
+++ b/docs/data-catalog.mdx
@@ -24,9 +24,9 @@ Catalogs aren't a separate table or external system. Each tap and pipeline carri
 
 When you create a catalog explicitly via the UI, Datris persists the name by writing a placeholder tap named `__catalog__<name>` (description "Catalog placeholder", `enabled=false`). This makes empty catalogs survive across UI reloads. The placeholder is hidden from the Taps list and ignored by the runtime.
 
-## The Data Catalog page
+## The Catalog tab
 
-The **Data Catalog** tab in the UI shows one card per catalog plus an **Uncataloged** card.
+The **Catalog** tab in the UI shows one card per catalog plus an **Uncataloged** card.
 
 - Each card shows the catalog name and counts of taps + pipelines.
 - Click a card to expand it. Inside you'll see:

--- a/docs/data-quality/ai-rules.mdx
+++ b/docs/data-quality/ai-rules.mdx
@@ -54,10 +54,11 @@ For all formats, the instruction is the same plain-English description. The LLM 
 
 ## Behavior
 
-- The AI rule generates the Python script once per rule evaluation- The generated script runs in the container via `python3` with a 5-minute timeout
+- The AI rule generates the Python script once per rule evaluation
+- The generated script runs in the container via `python3` with a 5-minute timeout
 - Scripts are constrained to Python standard library only (no external packages)
 - Rules with `onFailureIsError: true` are counted as errors; `onFailureIsError: false` are warnings
-- Processing aborts immediately if the error count exceeds **100**
+- All rows are evaluated; the abort message lists the first **100** errors and a count of any remaining
 - After all rows are evaluated, if **any errors** exist, processing is aborted
 - Warnings are summarized at the end of validation
 

--- a/docs/data-quality/schema-validation.mdx
+++ b/docs/data-quality/schema-validation.mdx
@@ -12,7 +12,7 @@ Schema validation checks incoming JSON or XML files against a formal schema defi
 
 ## Configuration
 
-Set the `validationSchema` field in the `dataQuality` block to the filename of the schema. The pipeline resolves the file from the MinIO config bucket at `{environment}-config/validation-schema/{filename}`.
+Set the `validationSchema` field in the `dataQuality` block to the filename of the schema. The pipeline resolves the file from the MinIO config bucket at `{environment}-config/validation-schema/{filename}`. A full `s3://bucket/key` URL is also accepted and used as-is.
 
 ```json
 {
@@ -59,7 +59,7 @@ A JSON Schema file stored in MinIO at `{environment}-config/validation-schema/pr
 ## Behavior
 
 1. The pipeline loads the schema file from the configured path in the environment's config bucket.
-2. Each record in the source file is validated against the schema.
+2. The whole file is validated as a single document against the schema. A JSON file containing an array of records therefore needs a schema with `"type": "array"` and `items` describing each record; the example above validates a file that holds a single object.
 3. If any record fails validation, the file is rejected and processing stops.
 4. Validation errors are logged with details about which fields failed and why.
 

--- a/docs/destinations/chroma.mdx
+++ b/docs/destinations/chroma.mdx
@@ -41,7 +41,7 @@ Chroma is the simplest vector database to set up — a single Docker container w
 | `collectionName` | string | (required) | Chroma collection name. Auto-created with cosine distance if it doesn't exist. |
 | `chunking` | object | recursive, 500/50 | Chunking strategy configuration (see below). |
 | `metadata` | map | `{}` | Static key-value metadata stored on every chunk. Used for filtered search. |
-| `embeddingSecretName` | string | _server default_ | Optional override of the embedding Vault secret. Defaults to the server-level `ai.embedding.secretName` (`oss/embedding`), which is seeded automatically — set this only to point a single pipeline at a different embedding model. |
+| `embeddingSecretName` | string | _server default_ | Embedding Vault secret name. Only consulted when the server-level `ai.embedding.secretName` is unset; with the default configuration (`oss/embedding`, seeded automatically) the server-level secret is always used and this field is ignored. |
 | `chromaSecretName` | string | (required) | Vault secret name for Chroma connection. |
 
 ## Supported File Types

--- a/docs/destinations/milvus.mdx
+++ b/docs/destinations/milvus.mdx
@@ -39,7 +39,7 @@ Ingest unstructured documents into [Milvus](https://milvus.io), a high-performan
 | `collectionName` | string | (required) | Milvus collection name. Auto-created if it doesn't exist. |
 | `chunking` | object | recursive, 500/50 | Chunking strategy configuration (see below). |
 | `metadata` | map | `{}` | Static key-value metadata stored as dynamic fields on every chunk. |
-| `embeddingSecretName` | string | _server default_ | Optional override of the embedding Vault secret. Defaults to the server-level `ai.embedding.secretName` (`oss/embedding`), which is seeded automatically — set this only to point a single pipeline at a different embedding model. |
+| `embeddingSecretName` | string | _server default_ | Embedding Vault secret name. Only consulted when the server-level `ai.embedding.secretName` is unset; with the default configuration (`oss/embedding`, seeded automatically) the server-level secret is always used and this field is ignored. |
 | `milvusSecretName` | string | (required) | Vault secret name for Milvus connection. |
 
 ## Supported File Types
@@ -150,7 +150,7 @@ The collection is auto-created on first upsert with a cosine distance index on t
 
 ## Running Milvus
 
-Milvus runs outside the pipeline's Docker Compose (like Qdrant and Weaviate). Unlike simpler vector databases, Milvus requires etcd and MinIO as internal dependencies, so a simple `docker run` won't work.
+Milvus runs outside the pipeline's Docker Compose (unlike Qdrant, Weaviate, and Chroma, which ship as opt-in Compose profiles). Unlike simpler vector databases, Milvus requires etcd and MinIO as internal dependencies, so a simple `docker run` won't work.
 
 **Option 1 — Milvus standalone script (recommended):**
 

--- a/docs/destinations/mongodb.mdx
+++ b/docs/destinations/mongodb.mdx
@@ -15,8 +15,10 @@ The JSON input mode is controlled by `everyRowContainsObject` in the source `fil
 
 | Value   | Description                                                                          |
 |---------|--------------------------------------------------------------------------------------|
-| `true`  | Each line of the file is a separate JSON document (newline-delimited JSON). Default. |
+| `true`  | Each line of the file is a separate JSON document (newline-delimited JSON).          |
 | `false` | The file contains a single JSON array; each element becomes a separate document.     |
+
+The effective default depends on whether the `jsonAttributes` block is present: when `fileAttributes.jsonAttributes` is absent altogether, the loader assumes `true` (newline-delimited); when the block is present but `everyRowContainsObject` is omitted, it defaults to `false` (single JSON array). Set it explicitly to avoid surprises.
 
 ## Upsert with Compound Keys
 

--- a/docs/destinations/pgvector.mdx
+++ b/docs/destinations/pgvector.mdx
@@ -43,7 +43,7 @@ pgvector uses your existing PostgreSQL infrastructure — no separate vector dat
 | `schemaName` | string | `"public"` | PostgreSQL schema name. Auto-created if it doesn't exist. |
 | `chunking` | object | recursive, 500/50 | Chunking strategy configuration (see below). |
 | `metadata` | map | `{}` | Static key-value metadata stored as columns on every chunk. Use snake_case for column names. |
-| `embeddingSecretName` | string | _server default_ | Optional override of the embedding Vault secret. Defaults to the server-level `ai.embedding.secretName` (`oss/embedding`), which is seeded automatically — set this only to point a single pipeline at a different embedding model. |
+| `embeddingSecretName` | string | _server default_ | Embedding Vault secret name. Only consulted when the server-level `ai.embedding.secretName` is unset; with the default configuration (`oss/embedding`, seeded automatically) the server-level secret is always used and this field is ignored. |
 | `postgresSecretName` | string | (required) | Vault secret name for PostgreSQL connection. |
 
 ## Supported File Types

--- a/docs/destinations/postgres.mdx
+++ b/docs/destinations/postgres.mdx
@@ -96,7 +96,7 @@ Connection credentials are configured globally in `application.yaml` via `secret
 | Field                 | Required | Default  | Description                                      |
 |-----------------------|----------|----------|--------------------------------------------------|
 | `dbName`              | yes      |          | Target database name                             |
-| `schema`              | no       | `public` | Target schema                                    |
+| `schema`              | yes      |          | Target schema. The literal placeholder `SCHEMA_NAME` is replaced with `public` when the pipeline is saved (likewise `DATABASE_NAME` in `dbName` becomes the configured Postgres database); any other value is used as-is |
 | `table`               | yes      |          | Target table name                                |
 | `usePostgres`         | yes      | `false`  | Must be `true` to enable PostgreSQL destination  |
 | `manageTableManually` | no       | `false`  | If `true`, skip auto-creation of the table       |

--- a/docs/destinations/qdrant.mdx
+++ b/docs/destinations/qdrant.mdx
@@ -39,7 +39,7 @@ Ingest unstructured documents (PDFs, text files, HTML) into [Qdrant](https://qdr
 | `collectionName` | string | (required) | Qdrant collection name. Auto-created if it doesn't exist. |
 | `chunking` | object | recursive, 500/50 | Chunking strategy configuration (see below). |
 | `metadata` | map | `{}` | Static key-value metadata stored on every chunk as Qdrant payload. Used for filtered search. |
-| `embeddingSecretName` | string | _server default_ | Optional override of the embedding Vault secret. Defaults to the server-level `ai.embedding.secretName` (`oss/embedding`), which is seeded automatically — set this only to point a single pipeline at a different embedding model. |
+| `embeddingSecretName` | string | _server default_ | Embedding Vault secret name. Only consulted when the server-level `ai.embedding.secretName` is unset; with the default configuration (`oss/embedding`, seeded automatically) the server-level secret is always used and this field is ignored. |
 | `qdrantSecretName` | string | (required) | Vault secret name for Qdrant connection. |
 
 ## Supported File Types
@@ -92,7 +92,7 @@ vault kv put secret/oss/embedding \
 
 | Field | Description |
 |-------|-------------|
-| `provider` | `openai` or `ollama`. (Anthropic has no embeddings API.) |
+| `provider` | `openai`, `azure`, `tei`, or `ollama`. (Anthropic has no embeddings API.) |
 | `endpoint` | Embedding API URL. Must speak the OpenAI embeddings contract. |
 | `model` | Embedding model name. |
 | `apiKey` | API key. Omit for local Ollama. |

--- a/docs/destinations/rest-endpoint.mdx
+++ b/docs/destinations/rest-endpoint.mdx
@@ -61,7 +61,7 @@ Set `async` to control whether the pipeline waits for a response:
 | `async` | Behavior                                                                              |
 |---------|---------------------------------------------------------------------------------------|
 | `false` | The pipeline waits for the endpoint to return a response before proceeding (default). |
-| `true`  | The pipeline sends the request and continues without waiting for a response.          |
+| `true`  | The pipeline sends the request, then waits for the endpoint to call back `POST /api/v1/restendpoint/callback` with the same `pipelineToken` and the result payload. If no callback arrives within `timeoutMs`, the job fails. |
 
 ## Authentication
 
@@ -69,7 +69,7 @@ Set `bearerToken` to include an `Authorization: Bearer {token}` header on every 
 
 ## Timeout
 
-The `timeoutMs` field controls the maximum time in milliseconds the pipeline will wait for a response when `async` is `false`. The default is `300000` ms (5 minutes).
+The `timeoutMs` field controls the maximum time in milliseconds the pipeline will wait — for the HTTP response when `async` is `false`, or for the callback when `async` is `true`. The default is `300000` ms (5 minutes).
 
 ## Configuration Example
 
@@ -93,10 +93,10 @@ The `timeoutMs` field controls the maximum time in milliseconds the pipeline wil
 | Field            | Required | Default | Description                                           |
 |------------------|----------|---------|-------------------------------------------------------|
 | `endpoint`       | yes      |         | Target endpoint URL                                   |
-| `async`          | no       | `false` | If `true`, send the request and continue without waiting for a response |
+| `async`          | no       | `false` | If `true`, send the request and wait for a callback to `/api/v1/restendpoint/callback` instead of the HTTP response |
 | `bearerToken`    | no       |         | Bearer token added as `Authorization: Bearer` header  |
-| `apiKey`         | no       |         | API key for endpoint authentication                   |
-| `timeoutMs`      | no       | `300000`| Response timeout in milliseconds (sync mode only)     |
+| `apiKey`         | no       |         | API key sent as an `x-api-key` header                 |
+| `timeoutMs`      | no       | `300000`| Response (sync) or callback (async) timeout in milliseconds |
 
 ## Completion Notification
 

--- a/docs/destinations/s3.mdx
+++ b/docs/destinations/s3.mdx
@@ -41,7 +41,7 @@ If any of `accessKey`, `secretKey`, or `region` is missing, the write fails at r
     "objectStore": {
       "provider": "s3",
       "destinationBucketOverride": "acme-analytics-prod",
-      "credentialsSecret": "aws/acme-analytics",
+      "credentialsSecret": "acme-analytics-s3",
       "prefixKey": "events/orders",
       "partitionBy": ["dt"],
       "fileFormat": "parquet",
@@ -57,7 +57,7 @@ If any of `accessKey`, `secretKey`, or `region` is missing, the write fails at r
 |-----------------------------|----------|----------------|--------------------------------------------------------------------------|
 | `provider`                  | yes      | `minio`        | Set to `s3` to select the AWS S3 path                                    |
 | `destinationBucketOverride` | yes      |                | Bucket to write to. No default for S3                                    |
-| `credentialsSecret`         | yes*     |                | Vault secret holding `accessKey`/`secretKey`/`region`                    |
+| `credentialsSecret`         | yes*     |                | Name of the Platform secret holding `accessKey`/`secretKey`/`region`. Pass the bare name as shown on Configuration → Secrets → Platform; the `{environment}/` Vault prefix is added automatically |
 | `endpoint`                  | no       | AWS regional   | Override the S3 endpoint URL. Must use `https://`                        |
 | `prefixKey`                 | yes      |                | Key prefix under the bucket                                              |
 | `fileFormat`                | no       | `parquet`      | `parquet` or `orc`                                                       |

--- a/docs/destinations/weaviate.mdx
+++ b/docs/destinations/weaviate.mdx
@@ -39,7 +39,7 @@ Ingest unstructured documents (PDFs, Word docs, text files, HTML) into [Weaviate
 | `className` | string | (required) | Weaviate class name. **Must be PascalCase** (e.g., `FinancialDocuments`). Auto-created if it doesn't exist. |
 | `chunking` | object | recursive, 500/50 | Chunking strategy configuration (see below). |
 | `metadata` | map | `{}` | Static key-value metadata stored on every chunk as Weaviate properties. Used for filtered search. |
-| `embeddingSecretName` | string | _server default_ | Optional override of the embedding Vault secret. Defaults to the server-level `ai.embedding.secretName` (`oss/embedding`), which is seeded automatically — set this only to point a single pipeline at a different embedding model. |
+| `embeddingSecretName` | string | _server default_ | Embedding Vault secret name. Only consulted when the server-level `ai.embedding.secretName` is unset; with the default configuration (`oss/embedding`, seeded automatically) the server-level secret is always used and this field is ignored. |
 | `weaviateSecretName` | string | (required) | Vault secret name for Weaviate connection. |
 
 ## Supported File Types

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -9,7 +9,7 @@ The `examples/` directory contains standalone applications that integrate with a
 
 | Example | Description |
 |---------|-------------|
-| [Market Macro Agent](/examples/market-macro-agent) | MacroAgent — a real-time financial data pipeline agent. Connects to Datris via MCP, fetches live market data (FRED, yfinance, CoinGecko, SEC EDGAR), creates pipelines, ingests data, and answers market questions — all visible in a browser UI. Full agentic loop with background refresh. |
+| [Market Macro Agent](/examples/market-macro-agent) | MacroAgent — a real-time financial data pipeline agent. Connects to Datris via MCP, provisions four platform-owned taps (FRED, yfinance, CoinGecko, SEC EDGAR), triggers them to refresh data, and answers market questions grounded in the landed numbers — all visible in a browser UI. Full agentic loop with background refresh. |
 
 ## Data Processing
 

--- a/docs/examples/chat-vector-store.mdx
+++ b/docs/examples/chat-vector-store.mdx
@@ -32,6 +32,7 @@ python app.py -s chroma            # short flag
 # Shared
 EMBEDDING_PROVIDER=openai
 EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_ENDPOINT=http://localhost:11434   # only used by the ollama embedding provider
 OPENAI_API_KEY=your-key
 LLM_PROVIDER=anthropic
 LLM_MODEL=claude-sonnet-4-6
@@ -48,6 +49,7 @@ WEAVIATE_HOST=localhost
 WEAVIATE_PORT=8079
 WEAVIATE_GRPC_PORT=50051
 WEAVIATE_SCHEME=http
+WEAVIATE_API_KEY=            # leave empty for anonymous access
 WEAVIATE_CLASS=FinancialDocuments
 
 # Milvus

--- a/docs/examples/market-macro-agent.mdx
+++ b/docs/examples/market-macro-agent.mdx
@@ -5,7 +5,7 @@ description: "Market macro agent example"
 
 **Location:** `examples/market-macro-agent/`
 
-A real-time financial data pipeline agent powered by Datris. MacroAgent connects to the Datris MCP server, discovers available tools, fetches live market data from public APIs, creates pipelines, ingests data, and answers market questions grounded in actual numbers. Everything runs in the browser with a live activity feed.
+A real-time financial data pipeline agent powered by Datris. MacroAgent acts as a pipeline orchestrator: it connects to the Datris MCP server, provisions four platform-owned taps (FRED, equities, crypto, SEC filings), triggers them to refresh data, and answers market questions grounded in actual numbers. The Datris platform does the fetching; the agent decides when and what to refresh. Everything runs in the browser with a live activity feed.
 
 100% Python — FastAPI backend, vanilla JS frontend, no Node.js required.
 
@@ -24,20 +24,33 @@ Browser (vanilla JS)
                  │     ↕ tool_use / end_turn
                  │
                  ├── agent/executor.py
-                 │     ├── MCP tools → Datris MCP Server (port 3000)
-                 │     └── ingest_data → data_fetcher.py (cached server-side)
+                 │     └── MCP tools → Datris MCP Server (port 3000)
+                 │           (run_tap, get_pipeline_status, query_postgres,
+                 │            list_taps, get_tap_logs, …)
                  │
-                 └── agent/scheduler.py (background refresh)
+                 └── agent/scheduler.py → run_tap every N minutes
+
+              ┌──────────────────────────────────────┐
+              │ Datris Platform                      │
+              │  Tap runner (Docker sandbox)         │
+              │    fred_tap → FRED API               │
+              │    equities_tap → yfinance           │
+              │    crypto_tap → CoinGecko            │
+              │    sec_tap → SEC EDGAR               │
+              │           ▼                          │
+              │   Pipelines (Postgres destinations)  │
+              └──────────────────────────────────────┘
 ```
 
 ## How It Works
 
-1. **On startup** — Connects to Datris MCP server via SSE, discovers tools via `tools/list`, reads the Pipeline Configuration Reference resource
-2. **User asks a question** — MacroAgent determines which data sources are needed
-3. **Data acquisition** — Agent fetches live data from public APIs, caches it server-side, and uses MCP tools (`create_pipeline` → `upload_data`) to ingest
-4. **Pipeline management** — MacroAgent monitors jobs via `get_job_status`, queries results via `query_postgres` — all through MCP tools discovered dynamically
-5. **Intelligent acquisition** — If the user asks about data the agent doesn't have, it asks for confirmation before fetching and ingesting new data
-6. **Background refresh** — Active pipelines are automatically refreshed on a configurable timer
+1. **On startup** — Connects to the Datris MCP server via SSE, discovers tools via `tools/list`, loads the server's instructions and resources, pushes `FRED_API_KEY` from `.env` into Datris as a tap secret (`create_tap_secret`), and provisions four taps (`fred_tap`, `equities_tap`, `crypto_tap`, `sec_tap`), each wired to its own pipeline. Idempotent: re-running against an existing install is a no-op. Taps are created with scheduling disabled so the agent's own loop drives refreshes.
+2. **User asks a question** — MacroAgent determines which data family is relevant
+3. **Refresh** — The agent calls `run_tap`. The platform runs the tap's Python `fetch()` in a Docker sandbox and submits records into the pipeline
+4. **Wait for ingestion** — Ingestion is asynchronous; the agent polls `get_pipeline_status` with the run's `publisherToken` until every row's state is `end` or `error`
+5. **Query** — The agent queries the landed data via `query_postgres` and answers grounded in actual numbers
+6. **Background refresh** — Every `REFRESH_INTERVAL_MINUTES` the scheduler calls `run_tap` for every pipeline that has been exercised at least once
+7. **Tap health** — Ask about failures and the agent calls `get_tap_logs` to report the last runs and any errors
 
 ## Data Sources
 
@@ -46,7 +59,7 @@ Browser (vanilla JS)
 | FRED | Macro series — yields, VIX, CPI, unemployment, credit spreads | [Free API key](https://fred.stlouisfed.org/docs/api/api_key.html) |
 | yfinance | Equity / ETF OHLCV (SPY, QQQ, GLD, TLT, XLE, IWM) | None |
 | CoinGecko | Crypto prices, market cap, volume (BTC, ETH, SOL) | None (30 req/min) |
-| SEC EDGAR | 10-K / 10-Q filings for RAG | None (10 req/sec) |
+| SEC EDGAR | 10-K / 10-Q filings | None (10 req/sec) |
 
 ## Quick Start
 
@@ -67,10 +80,10 @@ Open **http://localhost:8001**
 
 ## Demo Queries
 
-- `"What's the current macro picture?"` — creates pipelines, fetches live FRED + equity data
-- `"Refresh all pipelines"` — re-fetches all active data sources
+- `"What's the current macro picture?"` — runs the FRED + equities taps, then queries
+- `"Refresh all taps"` — triggers `run_tap` across all four data families
 - `"Is crypto confirming the risk-on trade in equities?"` — cross-pipeline analysis
-- `"Which pipeline is most stale?"` — exercises `list_pipelines` and timestamp comparison
+- `"Show me the last few tap runs"` — exercises `get_tap_logs` live
 
 ## Environment Variables
 

--- a/docs/examples/topic-subscriber.mdx
+++ b/docs/examples/topic-subscriber.mdx
@@ -21,9 +21,9 @@ ACTIVEMQ_HOST=localhost
 ACTIVEMQ_PORT=61613
 ACTIVEMQ_USER=admin
 ACTIVEMQ_PASSWORD=admin
-TOPIC_NAME=oss-pipeline-notification
-SUBSCRIPTION_STYLE=virtual_topic    # virtual_topic or durable_topic
-CLIENT_ID=my-subscriber
+ACTIVEMQ_TOPIC=oss-pipeline-notification
+USE_VIRTUAL_TOPIC=true    # true = Virtual Topic queue, false = durable topic subscription
+ACTIVEMQ_CLIENT_ID=my-subscriber
 ```
 
 ## Setup

--- a/docs/incidents.mdx
+++ b/docs/incidents.mdx
@@ -15,7 +15,7 @@ Requires the [agent policy](/agent-policy) (`USE_AGENT_POLICY=true`) for its app
 
    ```bash
    RECOVERY_AGENT_ENABLED=true
-   # optional: JSON POST on incident open / awaiting-approval / resolved / failed
+   # optional: JSON POST on incident open / awaiting_approval / resolved / failed / abandoned
    INCIDENT_WEBHOOK_URL=
    ```
 
@@ -42,7 +42,7 @@ A per-tap or per-pipeline override can put one resource on a different mode — 
 | Tap failure | A scheduled run fails **after** the retry ladder is exhausted |
 | Pipeline failure | A pipeline job ends in error |
 | Stale tap | A scheduled tap hasn't run within 2× its cadence |
-| Volume anomaly | A pipeline's records this day are ±60 % vs its 7-day baseline (with at least 3 prior runs) |
+| Volume anomaly | A pipeline's records in the current 24-hour window are ±60 % vs the previous 24-hour window (with at least 3 runs in that prior window) |
 
 Guards, all enforced in code: one open incident per resource; a resource whose latest run is healthy never gets one; a cooldown (default 6 h) after a failed or abandoned attempt; a cap on simultaneous open incidents. Volume incidents are **diagnosis-only** — the value is the triage, not an action.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,7 +13,7 @@ Datris sits beside your warehouse and lake; it doesn't replace them. It runs on-
 
 Your agents already acquire, validate, and load data. Without a control plane, they do it badly: credentials scattered across configs and prompts, the chat log as the only record, generated scripts that lose state when regenerated. Datris puts that work behind one governed surface:
 
-- **One MCP door** — 63 capabilities behind a single [MCP server](/mcp-server) (stdio and SSE). Claude, Cursor, OpenClaw, and any MCP-compatible agent learn one interface instead of 63 integrations
+- **One MCP door** — 73 capabilities behind a single [MCP server](/mcp-server) (stdio and SSE). Claude, Cursor, OpenClaw, and any MCP-compatible agent learn one interface instead of 73 integrations
 - **Vault-brokered credentials** — the agent references a secret by name; it never holds a key. Agent-written code runs in an [isolated container](/tap-execution-isolation) with no keys inside
 - **Every run recorded** — job state, row counts, and provenance for every run; every generated script [versioned in git](/tap-github-storage)
 - **Durable state** — pipelines and [sync bookmarks](/taps) live in the platform, not in the agent's context, so a regenerated script picks up where the old one left off
@@ -62,7 +62,7 @@ Full RAG pipeline built in. Extract, chunk, embed, and upsert documents into any
 
 - **5 vector databases** - Qdrant, Weaviate, Milvus, Chroma, pgvector (PostgreSQL)
 - **Chunking strategies** - Fixed-size, sentence, paragraph, recursive
-- **Embedding providers** - OpenAI (the recommended default when you have an OpenAI key), bundled TEI (`bge-m3` — runs locally, no API key), or Ollama (local models)
+- **Embedding providers** - OpenAI (the recommended default when you have an OpenAI key), Azure OpenAI (an embedding deployment on your Azure resource), bundled TEI (`bge-m3` — runs locally, no API key), or Ollama (local models)
 - **Document extraction** - PDF, Word, PowerPoint, Excel, HTML, email, EPUB, plain text
 
 ## Key Features
@@ -105,7 +105,7 @@ Transformation (AI transformations)
   |
   v
 Destinations (executed in parallel)
-  ├── Object Store (MinIO or AWS S3 - Parquet, ORC, CSV)
+  ├── Object Store (MinIO or AWS S3 - Parquet, ORC)
   ├── PostgreSQL (COPY bulk insert)
   ├── MongoDB (document upsert)
   ├── Snowflake (PUT + COPY INTO / MERGE into the user's account)
@@ -158,7 +158,7 @@ Query Source
 | JSON | Single object or NDJSON (one per line) | MongoDB, Kafka, REST |
 | XML | Single document or one per line | Database, Kafka, REST |
 | Excel (XLS) | Worksheet selection, auto-CSV conversion | Same as CSV |
-| Unstructured | PDF, Word, PowerPoint, Excel, HTML, email, EPUB, text | Object store, Qdrant, Weaviate, pgvector |
+| Unstructured | PDF, Word, PowerPoint, Excel, HTML, email, EPUB, text | Object store, Qdrant, Weaviate, Milvus, Chroma, pgvector |
 | Archives | .zip, .tar, .gz, .jar | Extracted and processed individually |
 
 ## Quick Links

--- a/docs/ingestion/database-pull.mdx
+++ b/docs/ingestion/database-pull.mdx
@@ -13,6 +13,10 @@ The pipeline can pull data directly from relational databases on a schedule. Con
 | MySQL | `com.mysql.cj.jdbc.Driver` |
 | MSSQL | `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
 
+<Note>
+The PostgreSQL and MySQL drivers ship with the server. The Microsoft SQL Server JDBC driver is not bundled — to use an MSSQL source, add the `mssql-jdbc` jar to the server classpath (for example by adding it to `build.sbt` and rebuilding the image).
+</Note>
+
 ## Configuration
 
 Database sources are configured in the `databaseAttributes` section of a pipeline configuration. Connection credentials (JDBC URL, username, password) are stored in Vault — not in the pipeline config itself.
@@ -61,11 +65,11 @@ Database sources are configured in the `databaseAttributes` section of a pipelin
 | `mysqlSecretsName` | Conditional | Vault secret name for MySQL credentials |
 | `mssqlSecretsName` | Conditional | Vault secret name for MSSQL credentials |
 | `cronExpression` | Yes | Quartz-format cron expression controlling the pull schedule |
-| `database` | No | Database name (if not in the JDBC URL) |
+| `database` | No | Database name; when set, the generated query references the table as `database.schema.table` |
 | `schema` | No | Schema within the database |
 | `table` | Yes* | Table to pull data from (*unless `sqlOverride` is set) |
 | `timestampFieldName` | Yes* | Column used for incremental pulls. Effectively required — the generated query always appends this column and orders by it. |
-| `includeFields` | No | Array of column names to select; when omitted, all columns are selected |
+| `includeFields` | No | Array of column names to select; when omitted, the column list is taken from the pipeline's `source.schemaProperties.fields` (not `SELECT *`) |
 | `sqlOverride` | No | Custom SQL query that replaces the generated SELECT statement |
 | `outputDelimiter` | No | Delimiter for CSV output (default `,`) |
 
@@ -86,7 +90,7 @@ The Vault secret must contain `username`, `password`, and `jdbcUrl` keys:
 Store the credentials in Vault using the CLI:
 
 ```bash
-vault kv put oss/postgres \
+vault kv put secret/oss/postgres \
   username="pipeline_reader" \
   password="s3cureP@ss" \
   jdbcUrl="jdbc:postgresql://db.internal.example.com:5432/production"

--- a/docs/ingestion/file-upload.mdx
+++ b/docs/ingestion/file-upload.mdx
@@ -40,7 +40,7 @@ d4f8e1a2-7b3c-4e9f-a5d6-1c2b3e4f5a6b
 
 Use this token to track the job's processing status, view errors, or cancel the job.
 
-When a compressed archive contains multiple inner files that are submitted as separate jobs, the response is instead the literal string:
+When a compressed archive is processed on the per-file path (non-CSV pipelines, or a single-file archive), the response is instead the literal string:
 
 ```
 3 file(s) submitted
@@ -53,14 +53,14 @@ When the uploaded file has a compressed extension, the archive is extracted **in
 | Extension | Handling |
 |---|---|
 | `.zip` | Extracted in memory |
-| `.gz` | Decompressed in memory |
+| `.gz` | Decompressed in memory (gunzip only — a `.tar.gz` is not untarred; the inner `.tar` is submitted as a single file) |
 | `.tar` | Extracted in memory |
 | `.jar` | Extracted in memory |
 
 Compressed archives may contain multiple data files. Handling depends on the pipeline type:
 
 - **CSV pipelines** — when an archive contains multiple inner files, they are concatenated into a single job. The header is kept from the first file and stripped from the 2nd and later files. The response is the single pipeline token.
-- **Non-CSV pipelines, or single-file archives** — each inner file is submitted as its own job. With more than one file, the response is the `"N file(s) submitted"` string.
+- **Non-CSV pipelines, or single-file archives** — each inner file is submitted as its own job. The response is always the `"N file(s) submitted"` string on this path, even for a single file (`1 file(s) submitted`) — the pipeline token is not returned.
 
 ## Uncompressed Files
 

--- a/docs/ingestion/kafka.mdx
+++ b/docs/ingestion/kafka.mdx
@@ -104,7 +104,7 @@ Produce a test message and verify ingestion:
 ```bash
 # Produce a JSON record to the topic
 echo '{"id":1001,"email":"jane@example.com","order_date":"2025-06-15","total":249.99}' | \
-  docker exec -i kafka kafka-console-producer.sh --bootstrap-server kafka:9092 --topic oss.orders
+  docker exec -i kafka kafka-console-producer --bootstrap-server kafka:9092 --topic oss.orders
 
 # Check pipeline status
 curl -s "http://localhost:8080/api/v1/pipeline/status?pipelinename=orders" | jq .

--- a/docs/ingestion/object-store.mdx
+++ b/docs/ingestion/object-store.mdx
@@ -18,14 +18,14 @@ Place a file in the MinIO raw bucket following this naming pattern:
 | Segment | Description |
 |---------|-------------|
 | `pipeline` | Name of the registered pipeline configuration |
-| `publishertoken` | Optional identifier for the data publisher — must be a unique value, UUID recommended |
+| `publishertoken` | Identifier for the data publisher — must be a valid UUID. If the second segment is not a UUID, it is ignored and a random UUID is generated |
 | `anything` | Any additional text (timestamp, version, etc.) |
 | `pipeline` (literal) | Fixed literal sentinel string |
 | `ext` | File extension: `csv`, `json`, `xml` |
 
 **Example:**
 ```
-stock_price.publisher-001.2026-03-15.1.pipeline.csv
+stock_price.28c39a6f-de32-4625-9bee-6af9ee547798.2026-03-15.1.pipeline.csv
 ```
 
 ### Metadata File + Data File
@@ -65,8 +65,10 @@ Upload multiple files to a directory, then trigger processing with a metadata fi
 Compressed archives (`.zip`, `.gz`, `.tar`, `.jar`) are automatically decompressed. The pipeline name and publisher token are parsed from the archive filename:
 
 ```
-stock_price.publisher-001.2026-03-15.pipeline.zip
+stock_price.28c39a6f-de32-4625-9bee-6af9ee547798.2026-03-15.pipeline.zip
 ```
+
+Note that the bundled MinIO setup (`docker/minio-init.sh`) only registers bucket events for the `.metadata.json`, `.pipeline.csv`, `.pipeline.json`, and `.pipeline.xml` suffixes. To have archives picked up automatically, add a matching `mc event add ... --suffix .pipeline.zip` rule (see below).
 
 ## How It Works
 
@@ -97,15 +99,19 @@ The pipeline tracks processed message IDs in MongoDB to prevent duplicate proces
 
 ## MinIO Webhook Setup
 
-Configure MinIO to send bucket notifications. The Docker setup uses the MinioWebhookController endpoint:
+Configure MinIO to send bucket notifications. The Docker setup (`docker/minio-init.sh`) points a webhook target at the `/minio-events` endpoint and registers per-suffix events on the raw bucket:
 
 ```bash
-# Using mc to configure notifications
-mc admin config set myminio notify_webhook:pipeline \
-  endpoint="http://datris:8080/minio-events"
+# Using mc to configure notifications (auth_token must match MINIO_WEBHOOK_TOKEN on the datris service)
+mc admin config set myminio notify_webhook:1 \
+  endpoint="http://datris:8080/minio-events" \
+  auth_token="${MINIO_WEBHOOK_TOKEN}"
 
 mc admin service restart myminio
-mc event add myminio/oss-raw arn:minio:sqs::pipeline:webhook --event put
+mc event add myminio/oss-raw arn:minio:sqs::1:webhook --suffix .metadata.json --event put
+mc event add myminio/oss-raw arn:minio:sqs::1:webhook --suffix .pipeline.csv --event put
+mc event add myminio/oss-raw arn:minio:sqs::1:webhook --suffix .pipeline.json --event put
+mc event add myminio/oss-raw arn:minio:sqs::1:webhook --suffix .pipeline.xml --event put
 ```
 
 Alternatively, ActiveMQ-based notifications can be configured (see MinIO documentation for AMQP notification targets).

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -165,7 +165,7 @@ docker compose up -d
 
 **Warning:** `docker compose down -v` is destructive. The `-v` flag removes every Docker volume the project owns (both named volumes and the anonymous volumes the data services create automatically). You will lose:
 
-- **All your pipelines, runs, taps, and metadata** (Postgres `datris` database)
+- **All your pipelines, runs, taps, and metadata** (MongoDB internal `oss` database) and **all data landed in Postgres** (`datris` database)
 - **All Vault secrets** — API keys, database credentials, AI configuration (will be re-seeded from your `.env` on next start, but only the defaults — any UI-edited overrides are gone)
 - **All MinIO object storage** — raw uploads, configs, temp files, processed outputs
 - **MongoDB destination data**
@@ -177,7 +177,7 @@ Only run `down -v` if you are certain none of the above matters, e.g. on a brand
 
 After `docker compose up -d`, `vault-init.sh` re-seeds the AI configuration secrets from your `.env`, MinIO buckets are recreated, Postgres starts empty, and the bundled embedding service re-downloads `bge-m3` (a few minutes one-time).
 
-> **Note for production deployments:** the `deploy/docker-compose.prod.yml` file used by managed/dedicated installs uses bind mounts to host directories under `/data/*` instead of Docker volumes, so `docker compose -f docker-compose.prod.yml down -v` does **not** wipe the data — the host directories survive. To reset a prod install, you'd need to also delete the relevant `/data/*` directories on the host, which is a much riskier operation and not recommended outside of disaster recovery.
+> **Note for production deployments:** the `deploy/docker-compose.prod.yml` file used by dedicated production installs uses bind mounts to host directories under `/data/*` instead of Docker volumes, so `docker compose -f docker-compose.prod.yml down -v` does **not** wipe the data — the host directories survive. To reset a prod install, you'd need to also delete the relevant `/data/*` directories on the host, which is a much riskier operation and not recommended outside of disaster recovery.
 
 ## Volumes
 
@@ -241,7 +241,7 @@ Datris supports six AI providers. Set your keys in `.env`:
 | **Azure OpenAI** | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_MODEL` | Same as OpenAI, served from your Azure resource (models addressed by deployment name) |
 | **Amazon Bedrock** | `AI_PROVIDER=bedrock` + `AWS_REGION` (AWS keys optional — IAM role works) | Claude served through your AWS account with IAM auth and AWS billing |
 | **Grok (xAI)** | `XAI_API_KEY` | Chat and CodeGen on Grok via xAI's OpenAI-compatible API (no embeddings) |
-| **Ollama** (local) | `OLLAMA_MODEL` | Same as above — no API key needed, runs locally |
+| **Ollama** (local) | `OLLAMA_MODEL` (requires uncommenting the `ollama` service in `docker-compose.yml`) | Same as above — no API key needed, runs locally |
 
 At least one AI provider key is required for AI features. The embedding provider for RAG is configured via Vault secrets — see [AI Configuration](/ai-configuration) for details.
 
@@ -343,6 +343,6 @@ In `docker-compose.yml`, uncomment the `build:` lines and comment out the `image
 
 ```yaml
 datris:
-  # image: datris/datris-server:latest
+  # image: datrisai/datris-server:latest
   build: .  # Build from source
 ```

--- a/docs/integrations/airflow.mdx
+++ b/docs/integrations/airflow.mdx
@@ -39,7 +39,7 @@ Add a connection of type **Datris** in the Airflow UI (or via env var / CLI):
 
 - **Local / single-tenant with `useApiKeys=false` (default):** leave the password
   blank — the header is ignored.
-- **Single-tenant with `useApiKeys=true`, or a hosted/multi-tenant install:**
+- **Single-tenant with `useApiKeys=true`, or a multi-tenant install:**
   set the password to an API key that holds the `tap:run` capability for the
   taps you trigger.
 
@@ -78,8 +78,8 @@ The operator:
 ### Date-windowed backfills
 
 Pass per-run params via `tap_params` (named to avoid Airflow's reserved
-`params` attribute). Each value is exposed to the tap script as an environment
-variable, so the script can read a run-specific window. Values are
+`params` attribute). Each value is exposed to the tap script as a
+`DATRIS_TAP_PARAM_<key>` environment variable, so the script can read a run-specific window. Values are
 Jinja-templated by Airflow:
 
 ```python
@@ -92,7 +92,7 @@ DatrisRunTapOperator(
 )
 ```
 
-Inside the tap script, read them as env vars (e.g. `os.environ["since"]`).
+Inside the tap script, read them as env vars (e.g. `os.environ["DATRIS_TAP_PARAM_since"]`).
 
 ## One scheduler at a time
 
@@ -125,7 +125,7 @@ task would mask it.
 | `401`/`403` from `/tap/run` | Missing or wrong API key, or the key lacks `tap:run` for that tap. Check the connection password and key capabilities. |
 | Task succeeds but no data loaded | The tap returned zero records, or has no target pipeline. Check the tap's Run History in Datris. |
 | Operator fails: "tap is Datris-scheduled" | The tap has a cron, so Datris already schedules it. Remove the tap's cron to let Airflow drive it (or remove the DAG). |
-| `params` not visible in the script | Read them as environment variables, not function arguments. Nested values arrive JSON-encoded. |
+| `params` not visible in the script | Read them as `DATRIS_TAP_PARAM_<key>` environment variables, not function arguments. Nested values arrive JSON-encoded. |
 
 ## What's not covered yet
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -35,6 +35,8 @@ The MCP server exposes resources that agents can read on demand for detailed doc
 | `set_catalog` | Set or clear the catalog grouping label on an existing pipeline or tap. Pass exactly one of `pipeline` or `tap`. |
 | `kill_job` | Kill a running job by pipeline token |
 | `profile_data` | AI-profile data (base64-encoded) with summary stats and suggested DQ rules |
+| `get_dest_types` | Propose real column types for a pipeline whose destination columns are all stored as text: samples up to 1000 landed rows, infers types deterministically and returns per-column evidence. Postgres, Snowflake and Databricks destinations only; nothing is changed by this call |
+| `apply_dest_types` | Apply destination column types to an all-string pipeline (requires explicit user approval). `fields` must list every destination column with its intended type (`string`, `boolean`, `int`, `bigint`, `float`, `double`, `date`, `timestamp`); landed data is migrated first and any value that will not cast fails the whole apply with nothing changed |
 | `get_version` | Get pipeline server version |
 | `check_service_health` | Check which backend services are up, down, or not configured (slow — use for diagnostics only) |
 
@@ -184,7 +186,8 @@ Client-side setup for Claude Desktop and Claude Code — including recommended a
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATRIS_API_URL` | `http://localhost:8080` | Datris REST API server URL |
-| `REQUIRE_API_KEY` | `false` | Reject SSE/HTTP sessions that connect without `x-api-key` |
+| `REQUIRE_API_KEY` | `false` | Reject SSE/HTTP sessions that connect without `x-api-key` (and stdio sessions started without `DATRIS_API_KEY`) |
+| `DATRIS_API_KEY` | — | stdio transport only: the API key forwarded as `x-api-key` on every tool call (stdio has no request headers) |
 
 All database connections, vector search, and embedding are handled by the pipeline server. The MCP server only needs the pipeline URL.
 

--- a/docs/monitoring.mdx
+++ b/docs/monitoring.mdx
@@ -137,7 +137,7 @@ Job statuses are stored in MongoDB in the `{environment}-pipeline-status` collec
 
 ## Datris UI
 
-The [Datris UI](http://localhost:4200) provides a visual interface for managing your entire Datris platform. Six top-level tabs — **Assistant** (in-product agent), **MCP** (server status, tools, and a pop-out Agent Monitor for live AI agent activity), **Catalog** (taps and pipelines grouped by catalog), **Search** (semantic search across vector destinations), **Ops** (ingestion activity dashboard, job history, file-upload ingestion), and **Configuration** (AI providers, secrets, API keys, users) — cover everything you can do through the API.
+The [Datris UI](http://localhost:4200) provides a visual interface for managing your entire Datris platform. Six top-level tabs — **Assistant** (in-product agent), **MCP** (server status, tools, and a pop-out Agent Monitor for live AI agent activity), **Catalog** (taps and pipelines grouped by catalog), **Search** (semantic search across vector destinations), **Ops** (ingestion activity dashboard, job history, file-upload ingestion), and **Configuration** (AI providers, secrets, data sources, code repository, users, API keys, audit log, agent policy) — cover everything you can do through the API.
 
 ## Ops Activity Dashboard
 
@@ -187,7 +187,7 @@ Each agent label uses the most descriptive identifier available, in this order:
 4. The API-key prefix
 5. The session short-id (last-resort fallback)
 
-The activity log below the visualization lists every tool call as it happens — timestamped per the platform's configured [date format and timezone](/configuration-reference), with the calling agent, tool name, argument preview, record count, response size, status, and latency. Clicking a row expands it to reveal the full arguments and response bodies as pretty-printed JSON (capped at 2 KB per blob). A header toolbar lets you copy the full log (with per-row detail) to the clipboard or clear the on-screen history.
+The activity log below the visualization lists every tool call as it happens — timestamped per the platform's configured [date format and timezone](/configuration-reference), with the calling agent, tool name, argument preview, record count, response size, status, and latency. Clicking a row expands it to reveal the full arguments and response bodies as pretty-printed JSON. A header toolbar lets you copy the full log (with per-row detail) to the clipboard or clear the on-screen history.
 
 Activity is held in an in-memory ring buffer on the MCP server (the most recent 200 calls) and served via the UI's internal `/api/v1/mcp/activity` proxy. It is not persisted — restarts clear the history. For a durable, queryable record of what each agent (and each human) actually changed, enable the [Audit Log](/audit-log); its entries carry the same key label the monitor shows.
 

--- a/docs/notifications.mdx
+++ b/docs/notifications.mdx
@@ -9,7 +9,7 @@ The pipeline publishes event notifications after each destination loader complet
 
 The pipeline uses ActiveMQ's [Virtual Destinations](https://activemq.apache.org/virtual-destinations) pattern:
 
-1. Each destination loader (PostgreSQL, MongoDB, Snowflake, Databricks, Kafka, ActiveMQ, Object Store, REST Endpoint, Qdrant, Weaviate, Milvus, Chroma, pgvector) publishes a notification to `VirtualTopic.{environment}-pipeline-notification`
+1. Each destination loader (PostgreSQL, MongoDB, Snowflake, Databricks, Kafka, ActiveMQ, Object Store, Qdrant, Weaviate, Milvus, Chroma, pgvector) publishes a notification to `VirtualTopic.{environment}-pipeline-notification`
 2. Consumers subscribe by creating a queue named `Consumer.{name}.VirtualTopic.{environment}-pipeline-notification`
 3. ActiveMQ automatically copies topic messages to all matching consumer queues
 4. Each consumer gets its own independent queue with its own message cursor
@@ -32,6 +32,8 @@ For example, with environment `oss`:
 Each consumer queue receives a copy of every notification independently.
 
 ### Quick Start: Python Consumer (Minimal)
+
+> The bundled ActiveMQ image (`apache/activemq-classic`) enables its STOMP connector on port 61613 by default, but `docker-compose.yml` only publishes 61616 (OpenWire) and 8161 (web console). To connect over STOMP from outside the Docker network, add `"61613:61613"` to the `activemq` service's `ports` list and recreate the container.
 
 ```python
 import stomp
@@ -76,7 +78,7 @@ Notifications include JMS message properties that can be used with **JMS selecto
 | Property | Description |
 |----------|-------------|
 | `pipeline` | Pipeline name |
-| `destination` | Destination type (`postgres`, `mongodb`, `snowflake`, `databricks`, `objectStore`, `kafka`, `activemq`, `restEndpoint`, `qdrant`, `weaviate`, `milvus`, `chroma`, `pgvector`) |
+| `destination` | Destination type (`postgres`, `mongodb`, `snowflake`, `databricks`, `objectStore`, `kafka`, `activemq`, `qdrant`, `weaviate`, `milvus`, `chroma`, `pgvector`) |
 | `schema` | Database schema (database destinations) |
 | `database` | Database name (database destinations) |
 | `table` | Table name (database destinations) |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,7 +5,7 @@ info:
     REST API for the Datris AI Data Platform. Ingest, validate, transform, store, and retrieve data.
 
     For AI agent integration, use the [MCP Server](https://docs.datris.ai/mcp-server) instead.
-  version: 1.11.3
+  version: 1.28.0
   contact:
     name: Datris
     url: https://datris.ai
@@ -196,6 +196,26 @@ components:
         multiTenant:
           type: string
           description: Whether the server is running in multi-tenant mode (true/false)
+        hosted:
+          type: string
+        useUserAuth:
+          type: string
+        useApiKeys:
+          type: string
+        useAuditLog:
+          type: string
+        useAgentPolicy:
+          type: string
+        recoveryAgentEnabled:
+          type: string
+        postgresDatabase:
+          type: string
+          description: Canonical Postgres database name
+        mongodbDatabase:
+          type: string
+          description: Canonical MongoDB database name
+        useTapRunner:
+          type: string
 
     KillJobResponse:
       type: object
@@ -923,7 +943,7 @@ paths:
                   description: Optional publisher identifier
       responses:
         '200':
-          description: Pipeline token (for uncompressed files) or empty (for compressed files)
+          description: Pipeline token (uncompressed files, single-file archives, and CSV batch archives) or the text "N file(s) submitted" when each extracted archive entry was submitted as its own job
           content:
             text/plain:
               schema:
@@ -1138,6 +1158,9 @@ paths:
                 collection:
                   type: string
                   description: MongoDB collection name
+                database:
+                  type: string
+                  description: MongoDB database name (defaults to the configured database)
                 filter:
                   type: object
                   default: {}
@@ -1810,6 +1833,13 @@ paths:
       tags: [Secrets]
       summary: List all secrets
       description: Lists all secret names under the current environment path in Vault.
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by the secret's _type tag (e.g. tap). "platform" returns every secret not tagged _type=tap.
       responses:
         '200':
           description: Array of secret names
@@ -1827,18 +1857,13 @@ paths:
     get:
       tags: [Secrets]
       summary: Get secret details
-      description: Returns the key-value fields of a secret. Sensitive fields (password, apiKey, secretKey, token) are masked unless reveal=true.
+      description: Returns the key-value fields of a secret. Sensitive fields (names containing password, secret, token, key, credential, signature, bearer, or private) are always masked.
       parameters:
         - name: name
           in: path
           required: true
           schema:
             type: string
-        - name: reveal
-          in: query
-          schema:
-            type: string
-            default: "false"
       responses:
         '200':
           description: Secret details with fields
@@ -2533,6 +2558,13 @@ paths:
       description: |
         Executes the tap script without sending data to a pipeline. Returns results, logs, and an
         AI-generated diagnosis if errors or zero records are detected.
+      parameters:
+        - name: testLimit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: When > 0, injects DATRIS_TAP_TEST_LIMIT=<N> into the script process so well-behaved scripts cap their reads.
       requestBody:
         required: true
         content:

--- a/docs/preprocessor.mdx
+++ b/docs/preprocessor.mdx
@@ -50,7 +50,9 @@ Add a `preprocessor` section to the pipeline configuration:
 | `endpoint` | string | Required | URL of the preprocessing service |
 | `async` | boolean | `false` | Synchronous or asynchronous mode |
 | `bearerToken` | string | `null` | Optional `Authorization: Bearer` token |
+| `apiKey` | string | `null` | Optional API key sent to the endpoint as an `x-api-key` header |
 | `timeoutMs` | int | `300000` | Request timeout in milliseconds |
+| `timeoutSeconds` | int | `0` | Legacy timeout in seconds; used only when `timeoutMs` is `0` or omitted. Prefer `timeoutMs` |
 
 ## Synchronous Mode
 
@@ -60,7 +62,7 @@ In synchronous mode (`async: false`), the pipeline POSTs the data to the endpoin
 
 ```json
 {
-  "pipelineToken": "pt-abc12345-...",
+  "pipelineToken": "5b2f4a1d-8c7e-4f0a-9b3d-6e1c2a4f8b9e",
   "pipelineName": "stock_price",
   "data": {
     "size": 1024,
@@ -68,13 +70,12 @@ In synchronous mode (`async: false`), the pipeline POSTs the data to the endpoin
     "rows": [
       "AAPL,150.25,2026-03-15",
       "GOOG,2800.00,2026-03-15"
-    ],
-    "rawData": null
+    ]
   }
 }
 ```
 
-For JSON/XML sources, `rows` is null and `rawData` contains the raw content.
+For JSON/XML sources, `header` and `rows` are omitted and `rawData` contains the raw content (null fields are left out of the payload rather than sent as `null`).
 
 ### Expected Response
 
@@ -88,11 +89,12 @@ Return the (optionally modified) data in the same format:
     "rows": [
       "AAPL,150.25,2026-03-15",
       "GOOG,2800.00,2026-03-15"
-    ],
-    "rawData": null
+    ]
   }
 }
 ```
+
+Any of `header`, `rows`, or `rawData` you leave out of the response keeps its original value.
 
 You can modify, add, or remove rows. The pipeline continues with whatever data is returned. If you return an `error` field, processing is aborted:
 
@@ -126,13 +128,12 @@ Callback payload:
 
 ```json
 {
-  "pipelineToken": "pt-abc12345-...",
+  "pipelineToken": "5b2f4a1d-8c7e-4f0a-9b3d-6e1c2a4f8b9e",
   "pipelineName": "stock_price",
   "data": {
     "size": 1024,
     "header": ["symbol", "price", "date"],
-    "rows": ["AAPL,150.25,2026-03-15"],
-    "rawData": null
+    "rows": ["AAPL,150.25,2026-03-15"]
   }
 }
 ```
@@ -143,7 +144,7 @@ If the callback is not received within `timeoutMs` milliseconds, the pipeline ab
 
 ## Example: Preprocessor Service
 
-A complete working example is provided in [`examples/preprocessor/app.py`](../examples/preprocessor/app.py). This Python Flask application implements both synchronous and asynchronous preprocessing:
+A complete working example is provided in [`examples/preprocessor/app.py`](https://github.com/datris/datris-platform-oss/blob/main/examples/preprocessor/app.py). This Python Flask application implements both synchronous and asynchronous preprocessing:
 
 ```python
 # Synchronous - process and return immediately

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -19,7 +19,7 @@ installed? Start it from your install directory:
 docker compose up -d
 ```
 
-Wait for the `datris` container to show `Started PipelineServiceApplication`.
+Wait for the `datris` container to show `Started Application`.
 
 ## 2. Register a pipeline
 
@@ -80,16 +80,16 @@ curl -X POST http://localhost:8080/api/v1/pipeline/upload \
   -F "pipeline=employees"
 ```
 
-The response contains a `pipelineToken` for tracking:
+The response body is the `pipelineToken` for tracking — a plain UUID:
 
 ```
-pt-abc12345-6789-...
+5b2f4a1d-8c7e-4f0a-9b3d-6e1c2a4f8b9e
 ```
 
 ## 4. Check status
 
 ```bash
-curl "http://localhost:8080/api/v1/pipeline/status?pipelinetoken=pt-abc12345-6789-..."
+curl "http://localhost:8080/api/v1/pipeline/status?pipelinetoken=5b2f4a1d-8c7e-4f0a-9b3d-6e1c2a4f8b9e"
 ```
 
 The status shows processing stages: `begin`, `processing`, `end`.

--- a/docs/schemas.mdx
+++ b/docs/schemas.mdx
@@ -114,7 +114,7 @@ curl -X POST "http://localhost:8080/api/v1/pipeline/generate" \
 
 The AI analyzes the file content (up to 100 lines for CSV, or 10,000 characters for JSON/XML) and returns a complete pipeline configuration with inferred field names and data types. You can edit the output before saving it to a pipeline configuration.
 
-In the UI, this happens automatically in Step 1 of the pipeline creation wizard when you upload a sample file and click "Analyze File".
+In the UI, this happens automatically in Step 1 of the pipeline creation wizard when you upload a sample file (analysis starts as soon as the file is selected).
 
 ## AI-Generated Validation Schemas
 
@@ -123,7 +123,7 @@ For JSON and XML pipelines, you can also generate validation schemas using AI:
 - **JSON Schema (Draft 4)** — for validating JSON data against an Everit-compatible schema
 - **W3C XSD** — for validating XML data against an XML Schema
 
-In the UI (Step 4 — Data Quality), choose "Generate schema with AI", enter a schema name, and provide sample data (or load it from your uploaded file). The AI generates a compliant schema that is stored in MinIO and referenced automatically in the pipeline config.
+In the UI (Step 5 — Data Quality), choose "Generate schema with AI", enter a schema name, and provide sample data (or load it from your uploaded file). The AI generates a compliant schema that is stored in MinIO and referenced automatically in the pipeline config.
 
 Via API:
 

--- a/docs/source-code.mdx
+++ b/docs/source-code.mdx
@@ -14,9 +14,9 @@ Datris is fully open source. The complete platform — server, MCP server, CLI, 
 | `datrisserver/` | Scala/Spring Boot pipeline server — ingestion, data quality, transformation, destinations |
 | `mcp-server/` | Python MCP server and CLI (`server.py`, `cli.py`) |
 | `ui/` | Angular web dashboard — pipeline management, ingestion monitoring, search, secrets |
-| `docker/` | Docker Compose configuration, Vault init scripts, Dockerfiles |
+| `docker/` | Vault and MinIO init scripts, Vault config, and the Compose-time server `application.yaml` override |
 | `docs/` | Mintlify documentation (what you're reading now) |
-| `examples/` | Example applications — RAG chat, Kafka loader, preprocessor, topic subscriber, MCP test |
+| `examples/` | Example applications — RAG chat, Kafka loader, preprocessor, topic subscriber, MCP test, Airflow DAGs, market/macro agent |
 | `test-data/` | Test data files and scripts |
 
 ## Key Files
@@ -44,7 +44,7 @@ cd datris-platform-oss
 sbt clean assembly
 ```
 
-Produces a fat JAR in `datrisserver/target/scala-2.13/`.
+Produces a fat JAR in `datrisserver/target/scala-2.12/`.
 
 ### Docker Images
 

--- a/docs/tap-execution-isolation.mdx
+++ b/docs/tap-execution-isolation.mdx
@@ -78,6 +78,11 @@ These apply in **both** modes, regardless of the runner setting:
 - **Extra packages install in isolation.** Packages a tap declares are installed into a
   throwaway virtual environment, never into the system Python. The pre-installed common
   packages remain available; the per-tap environment is discarded after the run.
+- **Private-network egress is blocked.** HTTP taps and REST endpoint destinations refuse to
+  connect to loopback, link-local, private, or cloud-metadata addresses, so a tap cannot be
+  pointed at internal services. If your endpoints legitimately live on an internal network,
+  set `DATRIS_ALLOW_PRIVATE_EGRESS=true` in `.env` (see the
+  [Configuration Reference](/configuration-reference#container-environment-variables)).
 
 ## Configuration
 

--- a/docs/tap-http-contract.mdx
+++ b/docs/tap-http-contract.mdx
@@ -147,8 +147,8 @@ The same shape ports directly to Go (`net/http` + `encoding/json`), Node/TypeScr
 ## Creating an HTTP tap
 
 - **UI**: Catalog → Create Tap → choose **HTTP Endpoint**, paste the URL, optionally attach a
-  secret whose `endpoint_token` your service checks. Test Script POSTs to your endpoint with
-  `testLimit` set and previews the response without persisting.
+  secret whose `endpoint_token` your service checks. Test Script POSTs to your endpoint (with
+  `testLimit: null` — the wizard does not cap HTTP-tap samples) and previews the response without persisting.
 
 <Note>
 The request comes from **inside the Datris container**. For an endpoint running on the same

--- a/docs/tap-prompts.mdx
+++ b/docs/tap-prompts.mdx
@@ -27,7 +27,7 @@ If a key appears in any of those texts, the fragment's `content` is appended to 
 
 ## Managing fragments
 
-Fragments are managed via the `/api/v1/tap-prompts` REST endpoints (GET / POST / DELETE / `suggest`). There is no dedicated UI surface today — tap creation and editing live in the **Catalog** tab, and prompt fragments continue to apply transparently to tap creation, brainstorm, auto-fix, and optimize whenever a matching keyword appears.
+Fragments are managed via the `/api/v1/tap-prompts` REST endpoints (GET / POST / DELETE / `suggest`). The only UI surface is **Configuration → Data Sources**, which edits the reserved `data-sources` fragment; other fragments are managed through the API. Tap creation and editing live in the **Catalog** tab, and prompt fragments continue to apply transparently to tap creation, brainstorm, auto-fix, and optimize whenever a matching keyword appears.
 
 To add a fragment from the CLI or a script:
 
@@ -59,7 +59,7 @@ Keep them dense and actionable:
 - Lead with the **preferred library** and the exact **env var names** the generator should use. Example: `Use the stripe Python SDK (pip install stripe). Set stripe.api_key = os.environ.get("STRIPE_API_KEY")`.
 - State **rate limits** explicitly so the generator can add throttling up front. Example: `Polygon.io free tier is 5 requests per second. Throttle with time.sleep(0.25) or a ThreadPoolExecutor with max_workers=3.`
 - Note **required headers** or auth quirks. Example: `SEC EDGAR requires a User-Agent header identifying the requester (e.g. "CompanyName contact@email"). Rate limit: 10 requests per second.`
-- Never include secrets or long examples. A fragment over ~2000 characters triggers a soft warning — multiple matching fragments can crowd the LLM context.
+- Never include secrets or long examples — multiple matching fragments can crowd the LLM context.
 
 ## Injection preview in the tap wizard
 

--- a/docs/taps.mdx
+++ b/docs/taps.mdx
@@ -88,7 +88,7 @@ The generated script can use these pre-installed packages:
 - `requests`, `beautifulsoup4`, `pandas`, `lxml`, `feedparser`
 - `boto3` (AWS S3), `google-cloud-storage` (GCS), `azure-storage-blob` (Azure Blob)
 - `openpyxl` (Excel), `pyyaml` (YAML), `python-dateutil`, `pytz`
-- Additional packages can be specified and are installed at runtime via pip. Datris caches installed packages in Docker volumes so subsequent runs reuse them instantly.
+- Additional packages can be specified and are installed at runtime via pip into a throwaway per-run environment. In in-process mode the pip download cache lives in a Docker volume so reinstalls skip the download; in the isolated runner (compose default) packages are fetched fresh on every run.
 
 **Example instructions:**
 - *"Fetch current weather data for New York from the Open-Meteo API"*
@@ -173,7 +173,7 @@ Tap scripts can query data already stored in the Datris platform. The following 
 |---|---|
 | `DATRIS_POSTGRES_DATABASE` | PostgreSQL database name (configured via `postgres.database` in `application.yaml`, or the tenant name in multi-tenant mode) |
 | `DATRIS_MONGODB_DATABASE` | MongoDB database name (configured via `mongodb.database` in `application.yaml`, or the tenant name in multi-tenant mode) |
-| `DATRIS_PLATFORM_HOST` | Hostname of the Datris platform (`localhost` inside the Docker container) |
+| `DATRIS_PLATFORM_HOST` | Hostname of the Datris platform (`localhost` when the tap runs in-process; `datris` — the server's service name — when it runs in the isolated runner container) |
 | `DATRIS_PLATFORM_PORT` | Port of the Datris platform (`8080` by default) |
 | `DATRIS_PLATFORM_TOKEN` | A per-run credential for the platform API, minted when the run starts and revoked when it ends. You normally never touch it — see below |
 
@@ -244,8 +244,8 @@ Tap secrets are tagged with `_type=tap` and only appear in the tap dropdown — 
 ## Running Taps
 
 <Note>
-Tap code runs in-process by default, and can optionally run in an isolated runner container
-that's separated from the platform's credentials and internal services. See
+On docker compose, tap code runs in an isolated runner container by default (`USE_TAP_RUNNER=true`),
+separated from the platform's credentials and internal services; `sbt` / IDE runs stay in-process. See
 [Tap Execution & Isolation](/tap-execution-isolation).
 </Note>
 
@@ -403,6 +403,10 @@ AI agents can manage taps via MCP:
 | `get_tap_ledger` | Document taps only: read the ledger of discovered documents (URI, filename, status, hashes, first/last seen timestamps). Pass `clear_uri` to force one file to be re-processed on the next run, or `clear_all=true` to force a full re-scan. |
 | `get_tap_state` | Read a tap's incremental-sync state (the bookmark committed by its last successful run). |
 | `set_tap_state` | Overwrite a tap's state (e.g. rewind a cursor to re-fetch a window), or pass `reset=true` to clear it so the next run does a full first-run fetch. |
+| `list_tap_versions` | List the change history of a tap's definition, newest first (`version`, `createdAt`, `createdBy`, `changeNote`). An empty result means the tap has not been edited since versioning was enabled; the current version number is the `version` field on the tap itself. |
+| `get_tap_version` | View one historical snapshot of a tap: the full config and pinned script as they were at that version. Read-only. |
+| `diff_tap_versions` | Compare two versions of a tap: a field-by-field config diff plus a line-level script diff. `version` is the selected snapshot, `against` the baseline. |
+| `restore_tap_version` | Roll a tap back (or forward) to a prior version. Append-only: the chosen snapshot is written as a new latest version, so history is never overwritten. |
 | `delete_tap` | Delete a tap and its stored script |
 
 End-to-end agent flow when a tap needs credentials:

--- a/docs/transformation/dropping-columns.mdx
+++ b/docs/transformation/dropping-columns.mdx
@@ -7,7 +7,7 @@ You can exclude columns from the output by defining a **destination schema** tha
 
 ## How It Works
 
-When a destination schema (`destination.schemaProperties`) is defined, only the columns listed in it are written to the destination. Columns present in the source but absent from the destination schema are dropped.
+For the PostgreSQL, Snowflake, and Databricks destinations, when a destination schema (`destination.schemaProperties`) is defined, only the columns listed in it are written to the destination. Columns present in the source but absent from the destination schema are dropped. These loaders project each row onto the destination columns by name.
 
 ## Example
 
@@ -52,6 +52,6 @@ In this example, `internal_code` and `created_at` are present in the source but 
 
 ## Notes
 
-- Column dropping applies to delimited/CSV row data, where each row is projected to the destination columns. JSON and XML pipelines use a single raw `_json`/`_xml` document that passes through without per-column projection, so column dropping does not apply to them.
+- Column dropping applies to delimited/CSV row data loaded into PostgreSQL, Snowflake, or Databricks, where each row is projected to the destination columns by name. The object store (Parquet/ORC) destination maps values to destination fields by position, so its destination schema must list the same columns in the same order as the source. MongoDB and the vector destinations do not use per-column projection. JSON and XML pipelines use a single raw `_json`/`_xml` document that passes through without per-column projection, so column dropping does not apply to them.
 - The destination schema field names must match source schema field names (case-insensitive)
 - Column order in the destination schema determines the output column order

--- a/docs/user-auth.mdx
+++ b/docs/user-auth.mdx
@@ -10,7 +10,7 @@ By default, the Datris OSS install runs single-tenant with no login screen — a
 When `USE_USER_AUTH=true`:
 
 - The UI shows a **login screen** before any tab is reachable.
-- Sensitive **Configuration** sub-tabs (Secrets, API-Keys, [Audit Log](/audit-log)) are gated to **admin** users. The AI Providers and Environment sub-tabs remain visible to all roles. The Users and API-Keys sub-tabs appear based on the active flags (see the [matrix](/api-keys#supported-configurations) for full visibility rules).
+- Sensitive **Configuration** sub-tabs (Secrets, API-Keys, [Audit Log](/audit-log), [Agent Policy](/agent-policy)) are gated to **admin** users. The AI Providers, Data Sources, and Code Repository sub-tabs remain visible to all roles. The Users and API-Keys sub-tabs appear based on the active flags (see the [matrix](/api-keys#supported-configurations) for full visibility rules).
 - A new **Users** sub-tab appears under Configuration for adding, removing, and changing roles (admin-only by virtue of being inside Configuration).
 - Sessions are server-side, with a TTL index cleaning them up automatically.
 
@@ -53,7 +53,7 @@ The default `admin` row is seeded on **every startup** (idempotent — only when
 | **editor** | ✓ | ✓ |   |
 | **viewer** | ✓ |   |   |
 
-All roles see the **Configuration** tab in the top nav, but the sub-tabs differ: admins see Secrets and API-Keys; editors and viewers see only AI Providers, Users, and Environment. Everything outside Configuration (Pipelines, Taps, Search, etc.) is accessible to all roles per the read/write rules above.
+All roles see the **Configuration** tab in the top nav, but the sub-tabs differ: admins see Secrets, API-Keys, Audit Log, and Agent Policy; editors and viewers see only AI Providers, Data Sources, Code Repository, and Users. Everything outside Configuration (Pipelines, Taps, Search, etc.) is accessible to all roles per the read/write rules above.
 
 ## Adding users
 


### PR DESCRIPTION
## Summary
Full accuracy audit of all 78 docs pages plus `openapi.yaml` against the v1.28.0 server, MCP server, CLI, UI, and compose sources. Every claim contradicted by the code was corrected; historical changelog entries were scrubbed to user-facing outcomes and hosted-platform residue removed.

Highlights:
- MCP tool count 63 → 73; missing tools added, phantom tool names fixed; CLI auth and HTTP tap flags corrected
- Assistant, incidents, agent policy, taps, ingestion, destinations, data quality, AI configuration, API reference and examples all corrected against code (see commit message for the full list)
- OpenClaw page's embedded `datris-memory` skill synced to the real `SKILL.md`
- **Compose fix:** `DATRIS_ENV`, `DATRIS_ALLOW_PLAINTEXT_DB`, `DATRIS_ALLOW_PRIVATE_EGRESS` and `TAP_MAX_OUTPUT_MB` were documented but never forwarded into the `datris` container. They are now passed through, `docker-compose.standalone.yml` regenerated, and all four documented in the configuration reference.

## Verification
- `mintlify broken-links`: no broken links
- `openapi.yaml` parses; JSX/code-fence balance checked on every edited page
- `docker compose config -q` passes for both compose files
- `scripts/build-standalone-compose.py` output matches the committed standalone file (CI guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)