### PR TITLE
security: clear open Dependabot and Trivy image alerts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,16 +46,17 @@ lazy val datrisserver = project
             "org.apache.hadoop" % "hadoop-client-api" % "3.3.4",
             "org.apache.hadoop" % "hadoop-client-runtime" % "3.3.4",
             // Embedded Tomcat (Spring Boot's servlet container — the process
-            // serving the API). Boot 3.5.16 manages this same version; the
-            // override stays as an explicit floor so a Boot downgrade can't
-            // silently reintroduce the 4 critical CVEs fixed here: partial-PUT
-            // RCE, HTTP/2 header validation, digest-auth bypass, and
-            // security-constraint bypass.
+            // serving the API). Pinned ahead of what Boot 3.5.16 manages so the
+            // override acts as an explicit floor: a Boot downgrade can't
+            // silently reintroduce the critical CVEs fixed here (partial-PUT
+            // RCE, HTTP/2 header validation, digest-auth bypass and replay,
+            // security-constraint / FORM-auth authorization bypasses —
+            // GHSA-9xv2-5v5q-p794, GHSA-gcx9-497g-6cp6, GHSA-h3x4-894j-xpx5).
             // All three tomcat-embed-* artifacts MUST move together — a version
             // mismatch between them makes the embedded server fail to start.
-            "org.apache.tomcat.embed" % "tomcat-embed-core" % "10.1.55",
-            "org.apache.tomcat.embed" % "tomcat-embed-el" % "10.1.55",
-            "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.55",
+            "org.apache.tomcat.embed" % "tomcat-embed-core" % "10.1.59",
+            "org.apache.tomcat.embed" % "tomcat-embed-el" % "10.1.59",
+            "org.apache.tomcat.embed" % "tomcat-embed-websocket" % "10.1.59",
             // CVE patch bumps over what Spark 3.5.x pulls transitively. Avro
             // 1.11.4 is a patch release over Spark's 1.11.2 (CVE-2024-47561,
             // code execution reading untrusted Avro). ZooKeeper 3.8.6 replaces

--- a/tap-runner/Dockerfile
+++ b/tap-runner/Dockerfile
@@ -3,6 +3,10 @@
 # Pinned by digest (multi-arch manifest list); Dependabot docker sends digest-bump PRs.
 FROM python:3.12-slim-bookworm@sha256:0f5b26b9518d002b6173fd61daad821fa340635ebfec5bba471013f9ca114579
 
+# The Debian packages in the slim image lag behind bookworm-security fixes
+# (libpcre2 CVEs flagged by the weekly Trivy image scan).
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # The pip/setuptools bundled with the bookworm image lag behind their own security fixes.
 RUN pip install --no-cache-dir --upgrade pip setuptools
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,6 +9,12 @@ RUN npm run build
 
 # Stage 2: Serve (non-root nginx, listens on 8080)
 FROM nginxinc/nginx-unprivileged:alpine@sha256:d9083fe47768377ef55dedafd67d4da7c2f2bc2bece7554954f29359deb0dce9
+# The Alpine packages in the pinned base lag behind alpine-security fixes
+# (libuuid/util-linux, libexpat, curl CVEs flagged by the weekly Trivy image
+# scan). Upgrade as root, then drop back to the unprivileged nginx user.
+USER root
+RUN apk upgrade --no-cache
+USER nginx
 COPY --from=build /app/dist/pipeline-ui/browser /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 # The base image already runs as the unprivileged nginx user (UID 101); the


### PR DESCRIPTION
## Summary
- **Tomcat 10.1.55 → 10.1.59** (all three `tomcat-embed-*` artifacts together). Closes the three critical Dependabot alerts (DIGEST auth replay bypass, improper access control, FORM auth authorization bypass). 10.1.58 was never published to Maven Central, so 10.1.59 is the first available patched release.
- **UI image:** `apk upgrade` in the nginx stage so the digest-pinned Alpine base picks up the libuuid / libexpat / curl security fixes flagged by the weekly image scan.
- **Tap-runner image:** `apt-get upgrade` so the digest-pinned bookworm base picks up the libpcre2 fixes.

## Not fixed
- `snowflake-jdbc` GHSA-gx6c-pv62-9mcf (low): no patched version exists upstream.

## Verification
- `sbt datrisserver/compile` passes; `show dependencyClasspath` resolves `tomcat-embed-{core,el,websocket}-10.1.59.jar`
- Local `docker build` + Trivy (`--ignore-unfixed`, MEDIUM+): UI image 0 findings; tap-runner 0 OS findings, only the pip-vendored entries already in `.trivyignore`
- The Trivy code-scanning alerts target the published `:latest` images and will clear after the next release rebuild and weekly scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)