### PR TITLE
fix: attribute destination load failures to the loader in the status rollup

### DIFF
--- a/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
@@ -58,6 +58,9 @@ object JobRunner {
         loaderFailure match {
             case Some((loaderName, t)) =>
                 val message = loaderName + " failed: " + loaderErrorMessage(t)
+                // The shared processName still names whichever loader last
+                // overrode it; the terminal event is JobRunner's, so say so.
+                statusUtil.overrideProcessName("JobRunner")
                 statusUtil.info("end", "Process completed, error: " + message + "\n" + stack)
                 message
             case None =>

--- a/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/controller/JobRunner.scala
@@ -13,6 +13,7 @@ import ai.datris.util._
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, DurationInt}
 
@@ -30,6 +31,40 @@ object JobRunner {
     }
 
     private val destinationTimeoutMinutes: Int = 10
+
+    /** The destination-facing text for a loader failure: the exception's own
+      * message, falling back to its class name. Never a stack trace — this is
+      * what lands in `rollup.jobs[].lastError.description`, the field agents
+      * already read to decide what to retry. The stack stays on the event stream. */
+    private[controller] def loaderErrorMessage(t: Throwable): String =
+        Option(t.getMessage).map(_.trim).filter(_.nonEmpty).getOrElse(t.getClass.getName)
+
+    /** Terminal status events for a failed job. Returns the short, destination-
+      * facing message the incident trigger should carry.
+      *
+      * When a loader already recorded its own error event (`loaderFailure`),
+      * JobRunner must NOT write a second one: the rollup classifier takes the
+      * first error event it finds, and a "JobRunner failed with <stack>" event
+      * would hide which destination died. JobRunner instead closes the stream
+      * with an info-level end event carrying the full stack trace for the detail
+      * view. Failures raised on the job thread itself (validator, preprocessor,
+      * DQ, transformation) keep today's JobRunner error event. */
+    private[controller] def reportFailure(
+        statusUtil: StatusUtil,
+        loaderFailure: Option[(String, Throwable)],
+        e: Throwable
+    ): String = {
+        val stack = Throwables.getStackTraceAsString(e)
+        loaderFailure match {
+            case Some((loaderName, t)) =>
+                val message = loaderName + " failed: " + loaderErrorMessage(t)
+                statusUtil.info("end", "Process completed, error: " + message + "\n" + stack)
+                message
+            case None =>
+                statusUtil.error("end", "Process completed, error: " + stack)
+                stack
+        }
+    }
 
     /** Derive a per-job record count and data type from the job's Data shape.
      *  CSV/delimited → row count, "record". Unstructured (rawBytes) → 1, "document".
@@ -83,6 +118,12 @@ class JobRunner(jobContext: JobContext) extends Runnable {
         // report which destinations finished before the failure.
         var loaderFutures: List[(String, Future[Unit])] = Nil
 
+        // First destination loader to fail, captured on the pool thread so the
+        // outer catch (job thread) can name it. Future completion establishes
+        // the happens-before; the AtomicReference keeps the first-wins rule
+        // honest when two destinations fail in the same run.
+        val loaderFailure = new AtomicReference[(String, Throwable)](null)
+
         try {
             statusUtil.info("begin", "Process started")
 
@@ -134,10 +175,18 @@ class JobRunner(jobContext: JobContext) extends Runnable {
             //     instantly. JobRunner is the right boundary for that translation:
             //     the JVM is still healthy enough to log + fail this job; we don't
             //     need to take down the whole server for one bad pipeline.
+            //  3. Record the failure under the LOADER's name before rethrowing, so
+            //     `rollup.jobs[].lastError` names the destination that died and
+            //     carries its own message rather than JobRunner + a stack trace.
+            //     Every failing loader writes its own event; the outer catch
+            //     below then stays quiet (see JobRunner.reportFailure).
             def runLoader(loaderName: String)(body: => Unit): Future[Unit] = Future {
                 try { withTenant(body) }
                 catch {
                     case t: Throwable =>
+                        loaderFailure.compareAndSet(null, (loaderName, t))
+                        try withTenant(statusUtil.errorAs(loaderName, "end", loaderName + " failed: " + JobRunner.loaderErrorMessage(t)))
+                        catch { case se: Exception => logger.warn("could not record " + loaderName + " failure event: " + se.getMessage) }
                         throw new RuntimeException(loaderName + " failed: " + t.getClass.getName + ": " + t.getMessage, t)
                 }
             }
@@ -201,8 +250,12 @@ class JobRunner(jobContext: JobContext) extends Runnable {
             // VirtualMachineError (OOM, StackOverflow) gets logged + reported here
             // but the JVM may still be unhealthy — that's a separate concern.
             case e: Throwable =>
-                val errorMessage = Throwables.getStackTraceAsString(e)
-                statusUtil.error("end", "Process completed, error: " + errorMessage)
+                // Full stack for the AI fix suggestion; the short destination-
+                // facing message (when a loader failed) for the incident trigger
+                // and the thrown exception, so every downstream reader starts
+                // from the same identity the rollup shows.
+                val stackTrace = Throwables.getStackTraceAsString(e)
+                val errorMessage = JobRunner.reportFailure(statusUtil, Option(loaderFailure.get), e)
                 recordRunLineage(
                     startedAtMs,
                     recordCount,
@@ -211,7 +264,7 @@ class JobRunner(jobContext: JobContext) extends Runnable {
                     if (jobContext.state == CANCELLED || e.isInstanceOf[InterruptedException]) "CANCELLED" else "ERROR",
                     Option(e.getMessage).getOrElse(e.getClass.getName)
                 )
-                val fix = FixSuggestionUtil.suggest("pipeline", new Gson().toJson(jobContext.config), errorMessage)
+                val fix = FixSuggestionUtil.suggest("pipeline", new Gson().toJson(jobContext.config), stackTrace)
                 if (fix != null) {
                     logger.info("AI Fix Suggestion: " + fix.summary)
                     statusUtil.suggestion(fix)

--- a/datrisserver/src/main/scala/ai/datris/util/PipelineStatusUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/PipelineStatusUtil.scala
@@ -114,7 +114,7 @@ object PipelineStatusUtil {
     // (the MCP `get_pipeline_status` tool, primarily) that want a single boolean to
     // poll on instead of having to replay the begin/info/end/error rules themselves.
 
-    private def classifyJob(events: List[PipelineStatus]): PipelineJobRollup = {
+    private[util] def classifyJob(events: List[PipelineStatus]): PipelineJobRollup = {
         val sorted = events.sortBy(_.epoch)
         val first = sorted.head
         val last = sorted.last

--- a/datrisserver/src/main/scala/ai/datris/util/StatusUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/StatusUtil.scala
@@ -80,6 +80,16 @@ class StatusUtil {
         send(state, "error", description)
     }
 
+    /** Write an error event attributed to an explicit process name instead of
+      * the shared `processName` field. Destination loaders run in parallel on a
+      * thread pool and each calls `overrideProcessName`, so by the time one of
+      * them fails the shared field may name a *different* loader. JobRunner uses
+      * this so the rollup's `lastError.processName` is the loader that died. */
+    def errorAs(processName: String, state: String, description: String): Unit = {
+        hadError = true
+        send(state, "error", description, processNameOverride = Option(processName))
+    }
+
     /** Record an AI fix suggestion for a failed job. Writes a normal info event
       * whose description carries the readable text (so existing detail views
       * show it unchanged) plus the structured fields, and stamps the one-line
@@ -95,7 +105,7 @@ class StatusUtil {
         send("end", "info", description, fix)
     }
 
-    private def send(state: String, code: String, description: String, fix: FixSuggestion = null): Unit = {
+    private def send(state: String, code: String, description: String, fix: FixSuggestion = null, processNameOverride: Option[String] = None): Unit = {
         state match {
             case "begin" | "processing" | "end" =>
             case _ => throw new InvalidParameterException("Invalid state. State must be one of the following: begin, processing, end")
@@ -106,7 +116,15 @@ class StatusUtil {
         }
 
         val status =
-            Status(processName.getOrElse(""), publisherToken.getOrElse(""), pipelineToken.getOrElse(""), filename.getOrElse(""), state, code, description)
+            Status(
+                processNameOverride.orElse(processName).getOrElse(""),
+                publisherToken.getOrElse(""),
+                pipelineToken.getOrElse(""),
+                filename.getOrElse(""),
+                state,
+                code,
+                description
+            )
 
         writeToNoSQLDb(status, fix)
 

--- a/datrisserver/src/test/scala/ai/datris/controller/JobRunnerFailureSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/controller/JobRunnerFailureSpec.scala
@@ -19,8 +19,11 @@ class JobRunnerFailureSpec extends AnyFunSuite {
     /** Captures events instead of writing to Mongo. (processName, state, code, description) */
     private class CapturingStatusUtil extends StatusUtil {
         val events = ListBuffer[(String, String, String, String)]()
-        override def info(state: String, description: String): Unit = events += (("JobRunner", state, "info", description))
-        override def error(state: String, description: String): Unit = events += (("JobRunner", state, "error", description))
+        // Mirrors the real StatusUtil: a shared, last-writer-wins process name.
+        var current = "SomeLoader"
+        override def overrideProcessName(processName: String): Unit = current = processName
+        override def info(state: String, description: String): Unit = events += ((current, state, "info", description))
+        override def error(state: String, description: String): Unit = events += ((current, state, "error", description))
         override def errorAs(processName: String, state: String, description: String): Unit =
             events += ((processName, state, "error", description))
     }
@@ -45,7 +48,7 @@ class JobRunnerFailureSpec extends AnyFunSuite {
         assert(message == "PostgresLoader failed: relation \"orders\" does not exist")
         assert(su.events.size == 1)
         val (process, state, code, description) = su.events.head
-        assert(process == "JobRunner")
+        assert(process == "JobRunner", "terminal event is JobRunner's even though a loader last set the shared process name")
         assert(state == "end")
         assert(code == "info", "a JobRunner error event would shadow the loader's own error in the rollup")
         assert(description.startsWith("Process completed, error: PostgresLoader failed: relation \"orders\" does not exist"))
@@ -60,7 +63,9 @@ class JobRunnerFailureSpec extends AnyFunSuite {
 
         assert(su.events.size == 1)
         val (process, state, code, description) = su.events.head
-        assert(process == "JobRunner" && state == "end" && code == "error")
+        // Job-thread failures keep the pre-existing attribution (the stage that
+        // last set the process name, e.g. DataQuality) — unchanged behaviour.
+        assert(process == "SomeLoader" && state == "end" && code == "error")
         assert(description.contains("IllegalStateException: schema mismatch"))
         assert(message.contains("IllegalStateException: schema mismatch"))
     }

--- a/datrisserver/src/test/scala/ai/datris/controller/JobRunnerFailureSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/controller/JobRunnerFailureSpec.scala
@@ -1,0 +1,67 @@
+package ai.datris.controller
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.StatusUtil
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.mutable.ListBuffer
+
+/** JobRunner's terminal status events on failure. A loader failure must
+  * surface under the loader's name with a destination-facing message; the
+  * JobRunner-level event then carries the stack trace at info level so the
+  * rollup does not see a second, misleading error event. */
+class JobRunnerFailureSpec extends AnyFunSuite {
+
+    /** Captures events instead of writing to Mongo. (processName, state, code, description) */
+    private class CapturingStatusUtil extends StatusUtil {
+        val events = ListBuffer[(String, String, String, String)]()
+        override def info(state: String, description: String): Unit = events += (("JobRunner", state, "info", description))
+        override def error(state: String, description: String): Unit = events += (("JobRunner", state, "error", description))
+        override def errorAs(processName: String, state: String, description: String): Unit =
+            events += ((processName, state, "error", description))
+    }
+
+    test("loaderErrorMessage is the exception message, never the class name when a message exists") {
+        assert(JobRunner.loaderErrorMessage(new RuntimeException("connection refused")) == "connection refused")
+        assert(JobRunner.loaderErrorMessage(new RuntimeException("  padded  ")) == "padded")
+    }
+
+    test("loaderErrorMessage falls back to the class name when the message is missing or blank") {
+        assert(JobRunner.loaderErrorMessage(new IllegalStateException()) == "java.lang.IllegalStateException")
+        assert(JobRunner.loaderErrorMessage(new IllegalStateException("   ")) == "java.lang.IllegalStateException")
+    }
+
+    test("loader failure: JobRunner writes an info end event with the stack, not a second error event") {
+        val su = new CapturingStatusUtil
+        val cause = new RuntimeException("relation \"orders\" does not exist")
+        val wrapped = new RuntimeException("PostgresLoader failed: java.lang.RuntimeException: " + cause.getMessage, cause)
+
+        val message = JobRunner.reportFailure(su, Some(("PostgresLoader", cause)), wrapped)
+
+        assert(message == "PostgresLoader failed: relation \"orders\" does not exist")
+        assert(su.events.size == 1)
+        val (process, state, code, description) = su.events.head
+        assert(process == "JobRunner")
+        assert(state == "end")
+        assert(code == "info", "a JobRunner error event would shadow the loader's own error in the rollup")
+        assert(description.startsWith("Process completed, error: PostgresLoader failed: relation \"orders\" does not exist"))
+        assert(description.contains("java.lang.RuntimeException"), "stack trace stays on the event stream for the detail view")
+    }
+
+    test("job-thread failure (no loader): today's JobRunner error event with the stack is preserved") {
+        val su = new CapturingStatusUtil
+        val e = new IllegalStateException("schema mismatch")
+
+        val message = JobRunner.reportFailure(su, None, e)
+
+        assert(su.events.size == 1)
+        val (process, state, code, description) = su.events.head
+        assert(process == "JobRunner" && state == "end" && code == "error")
+        assert(description.contains("IllegalStateException: schema mismatch"))
+        assert(message.contains("IllegalStateException: schema mismatch"))
+    }
+}

--- a/datrisserver/src/test/scala/ai/datris/util/PipelineStatusUtilSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/PipelineStatusUtilSpec.scala
@@ -1,0 +1,85 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.PipelineStatus
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Rollup classification of one job's event stream. Pins the contract agents
+  * rely on: `lastError` names the destination loader that failed and carries
+  * its own message, not JobRunner plus a stack trace. */
+class PipelineStatusUtilSpec extends AnyFunSuite {
+
+    private var clock = 1000L
+    private def ev(process: String, state: String, code: String, description: String, aiSummary: String = null): PipelineStatus = {
+        clock += 1
+        PipelineStatus(0, "t" + clock, "orders", process, "pub-1", "job-1", "orders.csv", state, code, description, clock, aiSummary = aiSummary)
+    }
+
+    test("loader failure: lastError names the loader and carries its message, not the JobRunner stack") {
+        val events = List(
+            ev("JobRunner", "begin", "info", "Process started"),
+            ev("PostgresLoader", "processing", "info", "Loading 6 rows"),
+            ev("PostgresLoader", "end", "error", "PostgresLoader failed: connection refused: db:5432"),
+            ev("JobRunner", "end", "info", "Process completed, error: PostgresLoader failed: connection refused: db:5432\njava.lang.RuntimeException: ...")
+        )
+        val job = PipelineStatusUtil.classifyJob(events)
+        assert(job.status == "error")
+        assert(job.lastError.processName == "PostgresLoader")
+        assert(job.lastError.description == "PostgresLoader failed: connection refused: db:5432")
+        assert(!job.lastError.description.contains("java.lang"))
+    }
+
+    test("two destinations, one fails: still one job, lastError is the failing loader") {
+        val events = List(
+            ev("JobRunner", "begin", "info", "Process started"),
+            ev("MongoDBLoader", "end", "info", "Process completed successfully"),
+            ev("SnowflakeLoader", "end", "error", "SnowflakeLoader failed: Table ORDERS does not exist"),
+            ev("JobRunner", "end", "info", "Process completed, error: SnowflakeLoader failed: Table ORDERS does not exist\nstack")
+        )
+        val job = PipelineStatusUtil.classifyJob(events)
+        assert(job.status == "error")
+        assert(job.pipelineToken == "job-1")
+        assert(job.lastError.processName == "SnowflakeLoader")
+        assert(job.lastError.description == "SnowflakeLoader failed: Table ORDERS does not exist")
+    }
+
+    test("all destinations succeed: success with no lastError") {
+        val events = List(
+            ev("JobRunner", "begin", "info", "Process started"),
+            ev("PostgresLoader", "end", "info", "Process completed successfully"),
+            ev("QdrantLoader", "end", "info", "Process completed successfully"),
+            ev("JobRunner", "end", "info", "Process completed")
+        )
+        val job = PipelineStatusUtil.classifyJob(events)
+        assert(job.status == "success")
+        assert(job.lastError == null)
+    }
+
+    test("job-thread failure (no loader involved) keeps the JobRunner error event") {
+        val events = List(
+            ev("JobRunner", "begin", "info", "Process started"),
+            ev("DataQuality", "processing", "info", "Validating"),
+            ev("JobRunner", "end", "error", "Process completed, error: java.lang.IllegalStateException: bad schema\n\tat ...")
+        )
+        val job = PipelineStatusUtil.classifyJob(events)
+        assert(job.status == "error")
+        assert(job.lastError.processName == "JobRunner")
+    }
+
+    test("AI suggestion headline is picked up independently of which event carries the error") {
+        val events = List(
+            ev("JobRunner", "begin", "info", "Process started"),
+            ev("PostgresLoader", "end", "error", "PostgresLoader failed: connection refused"),
+            ev("JobRunner", "end", "info", "Process completed, error: PostgresLoader failed: connection refused\nstack"),
+            ev("JobRunner", "end", "info", "AI Suggested Fix: check the host", aiSummary = "check the host")
+        )
+        val job = PipelineStatusUtil.classifyJob(events)
+        assert(job.status == "error")
+        assert(job.lastError.processName == "PostgresLoader")
+        assert(job.lastError.aiSummary == "check the host")
+    }
+}

--- a/docs/api-reference/status-api.mdx
+++ b/docs/api-reference/status-api.mdx
@@ -237,7 +237,7 @@ Each status entry (`PipelineStatus`) contains:
 | `FileUploadAPIController` | Upload request handling before the job is created |
 | `DataQuality` | Data quality validation |
 | `Transformation` | Data transformation |
-| `JobRunner` | Destination orchestration |
+| `JobRunner` | Destination orchestration. When a destination loader fails, the job's `lastError` is attributed to that loader (below), not to `JobRunner`; the `JobRunner` end event carries the full stack trace |
 | `PostgresLoader` | PostgreSQL loading |
 | `SnowflakeLoader` | Snowflake loading |
 | `DatabricksLoader` | Databricks loading |

--- a/mcp-server/cli.py
+++ b/mcp-server/cli.py
@@ -277,7 +277,9 @@ def ingest(file, pipeline, dest, table, database, schema, warehouse, credentials
                 jobs = rollup.get("jobs") or []
                 err = (jobs[0].get("lastError") or {}) if jobs else {}
                 msg = err.get("description") or "unknown error"
-                click.echo(f"  ✗ Failed: {msg[:200]}")
+                where = err.get("processName")
+                prefix = f"{where}: " if where and not msg.startswith(where) else ""
+                click.echo(f"  ✗ Failed: {prefix}{msg[:200]}")
                 sys.exit(1)
 
     if not completed:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1292,7 +1292,7 @@ Because of this, a tap NEVER needs the platform's own database credentials. Do n
 **`persisted: true`** — load is in flight. Call `get_pipeline_status(publisher_token=response.publisherToken)` and poll every few seconds until `rollup.allDone` is true. Then read `rollup.status`:
   - `success` — every job landed cleanly. Report counts.
   - `warning` — some jobs landed, some had non-fatal issues. Read `rollup.jobs[].lastError` for the affected ones.
-  - `error` — at least one job failed. Read `rollup.jobs[].lastError` for `processName` and `description`.
+  - `error` — at least one job failed. Read `rollup.jobs[].lastError` for `processName` and `description`. When a destination write fails, `processName` is that destination's loader (for example `PostgresLoader`, `SnowflakeLoader`) and `description` is the destination's own error message — act on that destination, not on the pipeline as a whole.
 
 Do not query the destination or report completion to the user before polling completes — the data isn't there yet.
 


### PR DESCRIPTION
## Summary

When a destination loader threw, JobRunner wrote the only error event under its own name with a full stack trace as the description. `get_pipeline_status` therefore reported `lastError.processName=JobRunner` plus a stack dump, so agents and the recovery agent's incident trigger could not tell which destination failed or why from the field they already poll.

- `StatusUtil.errorAs(processName, …)`: error event with an explicit name. Parallel loaders overwrite the shared process name, so the failing loader must name itself.
- `JobRunner.runLoader` records the first failure and writes `"<Loader> failed: <message>"` before rethrowing. Every failing loader writes its own event.
- `JobRunner.reportFailure`: when a loader already reported, the outer catch writes an info-level end event (named JobRunner) carrying the stack trace instead of a second error event. Job-thread failures (validator, DQ, transformation) keep today's behaviour.
- AI fix suggestion still receives the full stack. Incident trigger and the thrown exception carry the short destination-facing message.
- No per-destination job split, no new poll tool, no consistency policy.
- MCP prompt, CLI failure line, and status API docs say `processName` is the destination loader on load failures.

## Test plan

- [x] `PipelineStatusUtilSpec` (5) + `JobRunnerFailureSpec` (4); server suite 417/417
- [x] Live E2E after full rebuild:
  - Postgres, manual table mode, missing table → `error`, `processName=PostgresLoader`, description is the Postgres message
  - Postgres + object store, only Postgres fails → one job row, same lastError; object store completed its write
  - All destinations succeed → `success`, `lastError` null
  - DQ header failure on the job thread → unchanged attribution
  - AI fix suggestion fired for both failures (server log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
