### PR TITLE
Fresh-install AI defaults follow the model catalog's recommendations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,10 +84,10 @@ OPENAI_API_KEY=
 # AI_PROVIDER=anthropic
 
 # Optional model overrides (defaults shown)
-# ANTHROPIC_MODEL=claude-opus-5
-# OPENAI_MODEL=gpt-5.5
+# ANTHROPIC_MODEL=claude-fable-5-1
+# OPENAI_MODEL=gpt-5.6-sol
 # GROK_MODEL=grok-4.6
-# CODEGEN_MODEL=claude-opus-5   # or gpt-5.5 if using OpenAI, grok-4.6 for Grok;
+# CODEGEN_MODEL=claude-opus-5   # or gpt-5.6-sol if using OpenAI, grok-4.6 for Grok;
 #                               # for Azure this is a deployment name (defaults
 #                               # to AZURE_OPENAI_MODEL)
 
@@ -101,7 +101,7 @@ OPENAI_API_KEY=
 # OpenAI-only and other-provider deployments can ignore this entirely.
 # Bump this when a newer Sonnet ships so the fallback stays current
 # without a recompile.
-# ANTHROPIC_OVERLOAD_FALLBACK_MODEL=claude-sonnet-4-6
+# ANTHROPIC_OVERLOAD_FALLBACK_MODEL=claude-sonnet-5
 
 # Optional embedding provider override (decoupled from AI_PROVIDER).
 # By default the embedding slot follows AI_PROVIDER: anthropic→bundled TEI

--- a/datrisserver/src/main/scala/ai/datris/util/AgentLoop.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/AgentLoop.scala
@@ -456,7 +456,7 @@ object AgentLoop {
       * OpenAI and other providers return None and the caller surfaces the
       * original error.
       *
-      * The Anthropic default (`claude-sonnet-4-6`) is only consulted on this
+      * The Anthropic default (`claude-sonnet-5`) is only consulted on this
       * Anthropic top-tier path, so an OpenAI-only deployment never carries a
       * Claude string in its config surface. Operator-overridable via
       * `ANTHROPIC_OVERLOAD_FALLBACK_MODEL` so the fallback can be bumped
@@ -469,7 +469,7 @@ object AgentLoop {
         val model = if (cfg.model == null) "" else cfg.model.toLowerCase
         val isTopTier = model.contains("opus") || model.contains("fable") || model.contains("mythos")
         if (provider == "anthropic" && isTopTier) {
-            val fallback = sys.env.getOrElse("ANTHROPIC_OVERLOAD_FALLBACK_MODEL", "claude-sonnet-4-6").trim
+            val fallback = sys.env.getOrElse("ANTHROPIC_OVERLOAD_FALLBACK_MODEL", "claude-sonnet-5").trim
             if (fallback.nonEmpty && fallback != cfg.model) Some(fallback) else None
         } else None
     }

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1011,12 +1011,12 @@ configs:
           seed_if_absent secret/oss/ai-primary \
             provider="openai" \
             endpoint="https://api.openai.com/v1/chat/completions" \
-            model="$${OPENAI_MODEL:-gpt-5.5}" \
+            model="$${OPENAI_MODEL:-gpt-5.6-sol}" \
             apiKey="$${OPENAI_API_KEY}"
           seed_if_absent secret/oss/codegen \
             provider="openai" \
             endpoint="https://api.openai.com/v1/chat/completions" \
-            model="$${CODEGEN_MODEL:-gpt-5.5}" \
+            model="$${CODEGEN_MODEL:-gpt-5.6-sol}" \
             apiKey="$${OPENAI_API_KEY}"
         elif [ "$$PROVIDER" = "grok" ]; then
           if [ -z "$${XAI_API_KEY:-}" ]; then
@@ -1046,7 +1046,7 @@ configs:
           seed_if_absent secret/oss/ai-primary \
             provider="anthropic" \
             endpoint="https://api.anthropic.com/v1/messages" \
-            model="$${ANTHROPIC_MODEL:-claude-opus-5}" \
+            model="$${ANTHROPIC_MODEL:-claude-fable-5-1}" \
             apiKey="$${ANTHROPIC_API_KEY}" \
             version="2023-06-01"
           seed_if_absent secret/oss/codegen \

--- a/docker/vault-init.sh
+++ b/docker/vault-init.sh
@@ -194,12 +194,12 @@ else
     seed_if_absent secret/oss/ai-primary \
       provider="openai" \
       endpoint="https://api.openai.com/v1/chat/completions" \
-      model="${OPENAI_MODEL:-gpt-5.5}" \
+      model="${OPENAI_MODEL:-gpt-5.6-sol}" \
       apiKey="${OPENAI_API_KEY}"
     seed_if_absent secret/oss/codegen \
       provider="openai" \
       endpoint="https://api.openai.com/v1/chat/completions" \
-      model="${CODEGEN_MODEL:-gpt-5.5}" \
+      model="${CODEGEN_MODEL:-gpt-5.6-sol}" \
       apiKey="${OPENAI_API_KEY}"
   elif [ "$PROVIDER" = "grok" ]; then
     if [ -z "${XAI_API_KEY:-}" ]; then
@@ -229,7 +229,7 @@ else
     seed_if_absent secret/oss/ai-primary \
       provider="anthropic" \
       endpoint="https://api.anthropic.com/v1/messages" \
-      model="${ANTHROPIC_MODEL:-claude-opus-5}" \
+      model="${ANTHROPIC_MODEL:-claude-fable-5-1}" \
       apiKey="${ANTHROPIC_API_KEY}" \
       version="2023-06-01"
     seed_if_absent secret/oss/codegen \

--- a/docs/ai-configuration.mdx
+++ b/docs/ai-configuration.mdx
@@ -86,8 +86,8 @@ When `OPENAI_API_KEY` is set, all three slots are seeded against OpenAI:
 
 | Slot | Provider | Endpoint | Model |
 |------|----------|----------|-------|
-| `oss/ai-primary` | openai | `https://api.openai.com/v1/chat/completions` | `gpt-5.5` |
-| `oss/codegen` | openai | `https://api.openai.com/v1/chat/completions` | `gpt-5.5` |
+| `oss/ai-primary` | openai | `https://api.openai.com/v1/chat/completions` | `gpt-5.6-sol` |
+| `oss/codegen` | openai | `https://api.openai.com/v1/chat/completions` | `gpt-5.6-sol` |
 | `oss/embedding` | openai | `https://api.openai.com/v1/embeddings` | `text-embedding-3-small` |
 
 ### Azure OpenAI path
@@ -207,7 +207,7 @@ When `ANTHROPIC_API_KEY` is set, `aiPrimary` and `codegen` use Claude. Anthropic
 
 | Slot | Provider | Endpoint | Model |
 |------|----------|----------|-------|
-| `oss/ai-primary` | anthropic | `https://api.anthropic.com/v1/messages` | `claude-opus-5` |
+| `oss/ai-primary` | anthropic | `https://api.anthropic.com/v1/messages` | `claude-fable-5-1` |
 | `oss/codegen` | anthropic | `https://api.anthropic.com/v1/messages` | `claude-opus-5` |
 | `oss/embedding` | tei | `http://tei:80/v1/embeddings` | `BAAI/bge-m3` |
 
@@ -232,11 +232,11 @@ The Configuration UI makes this easy — select **Ollama (if optional service en
 Override the seeded models by setting these in `.env`:
 
 ```bash
-ANTHROPIC_MODEL=claude-opus-5
-OPENAI_MODEL=gpt-5.5
+ANTHROPIC_MODEL=claude-fable-5-1
+OPENAI_MODEL=gpt-5.6-sol
 GROK_MODEL=grok-4.6
-CODEGEN_MODEL=claude-opus-5   # or gpt-5.5 if using OpenAI, grok-4.6 for Grok
-ANTHROPIC_OVERLOAD_FALLBACK_MODEL=claude-sonnet-4-6   # used for the current request when an Anthropic Opus call stays overloaded after retries
+CODEGEN_MODEL=claude-opus-5   # or gpt-5.6-sol if using OpenAI, grok-4.6 for Grok
+ANTHROPIC_OVERLOAD_FALLBACK_MODEL=claude-sonnet-5   # used for the current request when an Anthropic Opus call stays overloaded after retries
 ```
 
 ### Mix-and-match: Anthropic chat + OpenAI embeddings
@@ -305,7 +305,7 @@ docker compose exec -e VAULT_ADDR=http://vault:8200 \
   vault kv put secret/oss/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \
-  model="claude-opus-5" \
+  model="claude-fable-5-1" \
   apiKey="sk-ant-..." \
   version="2023-06-01"
 ```
@@ -373,7 +373,7 @@ OpenAI web search requires the **Responses API**. When the configured endpoint i
 **Highly recommended: Anthropic with the latest coding model for CodeGen.** Tap script generation, AI data quality rules, AI transformations, and NL→SQL all depend heavily on the model's coding ability — Claude produces dramatically better results than smaller or cheaper models. The same recommendation appears in the Configuration UI's CodeGen section and in `.env.example`.
 </Tip>
 
-CodeGen tasks (tap scripts, `aiRule`, `aiTransformation`, JSON Schema / XSD generation, natural-language → SQL) have their own slot so they can run a different model than the general default. On a fresh install both slots seed the strongest available model — `gpt-5.5` with OpenAI, `claude-opus-5` with Anthropic — so code generation is at full quality out of the box. The separate slot is your cost-tuning lever: point `aiPrimary` at a cheaper model (e.g. `claude-sonnet-4-6`) for the chatty paths and keep the stronger model only on the calls that benefit from it.
+CodeGen tasks (tap scripts, `aiRule`, `aiTransformation`, JSON Schema / XSD generation, natural-language → SQL) have their own slot so they can run a different model than the general default. On a fresh install the slot seeds the strongest code-generation model — `gpt-5.6-sol` with OpenAI, `claude-opus-5` with Anthropic — so code generation is at full quality out of the box, while `aiPrimary` seeds the recommended chat model (`claude-fable-5-1` / `gpt-5.6-sol`). The separate slot is your cost-tuning lever: point `aiPrimary` at a cheaper model (e.g. `claude-sonnet-5`) for the chatty paths and keep the stronger model only on the calls that benefit from it.
 
 | Feature | Uses codegen slot? |
 |---|---|
@@ -434,7 +434,7 @@ docker compose exec -e VAULT_ADDR=http://vault:8200 \
   vault kv put secret/acme/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \
-  model="claude-opus-5" \
+  model="claude-fable-5-1" \
   apiKey="sk-ant-..." \
   version="2023-06-01"
 ```

--- a/docs/configuration-reference.mdx
+++ b/docs/configuration-reference.mdx
@@ -234,8 +234,8 @@ AI configuration is split into four independent slots (three seeded at first boo
 | Property | Default | Description |
 |----------|---------|-------------|
 | `ai.enabled` | `true` | Enable AI features (required for the platform to start) |
-| `ai.aiPrimary.secretName` | `oss/ai-primary` | Vault secret for the main AI model used for general reasoning (NL→SQL, search answers, etc.). Seeded with the strongest available model — Anthropic gets `claude-opus-5`, OpenAI gets `gpt-5.5`. |
-| `ai.codegen.secretName` | `oss/codegen` | Vault secret for the code-generation model (tap scripts, AI DQ, AI transformations, schema generation). Seeded with the strongest available model — Anthropic gets `claude-opus-5`, OpenAI gets `gpt-5.5`. |
+| `ai.aiPrimary.secretName` | `oss/ai-primary` | Vault secret for the main AI model used for general reasoning (NL→SQL, search answers, etc.). Seeded with the recommended chat model — Anthropic gets `claude-fable-5-1`, OpenAI gets `gpt-5.6-sol`. |
+| `ai.codegen.secretName` | `oss/codegen` | Vault secret for the code-generation model (tap scripts, AI DQ, AI transformations, schema generation). Seeded with the strongest code-generation model — Anthropic gets `claude-opus-5`, OpenAI gets `gpt-5.6-sol`. |
 | `ai.embedding.secretName` | `oss/embedding` | Vault secret for the embedding model used by vector destinations (Chroma, Qdrant, Milvus, Weaviate, pgvector) and search. For Anthropic-only deployments this is seeded to point at the bundled TEI sidecar serving `BAAI/bge-m3` (1024-dim), so vector destinations work out of the box without an OpenAI key. |
 | `ai.webSearch.secretName` | `oss/web-search` | Vault secret for the optional live web-search provider used during tap script generation and diagnosis. Not seeded at first boot — configure it from the Configuration tab. |
 | `ai.extendedThinking` | `true` | Enable extended thinking on the Assistant tab's agent loop (Anthropic models only); the model's reasoning is shown above the visible response. Set to `false` to disable platform-wide. |
@@ -246,7 +246,7 @@ Each Vault secret is self-describing and looks like:
 vault kv put secret/oss/ai-primary \
   provider="anthropic" \
   endpoint="https://api.anthropic.com/v1/messages" \
-  model="claude-opus-5" \
+  model="claude-fable-5-1" \
   apiKey="sk-ant-..." \
   version="2023-06-01"
 ```
@@ -258,8 +258,8 @@ These `.env` variables tune what gets seeded. They apply on the **first boot onl
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AI_PROVIDER` | auto | Explicit provider pick (`anthropic`, `openai`, `azure`, `bedrock`, or `grok`) for the `ai-primary` and `codegen` slots. When unset, whichever API key is present wins (OpenAI wins ties; azure and grok are auto-picked only when they hold the sole key; bedrock is never auto-picked). |
-| `ANTHROPIC_MODEL` | `claude-opus-5` | Model seeded into `oss/ai-primary` on the Anthropic path. |
-| `OPENAI_MODEL` | `gpt-5.5` | Model seeded into `oss/ai-primary` on the OpenAI path. |
+| `ANTHROPIC_MODEL` | `claude-fable-5-1` | Model seeded into `oss/ai-primary` on the Anthropic path. |
+| `OPENAI_MODEL` | `gpt-5.6-sol` | Model seeded into `oss/ai-primary` on the OpenAI path. |
 | `AZURE_OPENAI_ENDPOINT` | — | Azure resource base URL (`https://YOUR-RESOURCE.openai.azure.com`). Required on the Azure path. |
 | `AZURE_OPENAI_MODEL` | — | Chat deployment name seeded into `oss/ai-primary` on the Azure path. Required on the Azure path. |
 | `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` | — | Entra ID service principal for keyless Azure OpenAI auth (no API key stored anywhere). Single-tenant only; the Configuration tab's Azure credentials section is the equivalent UI path. On Azure compute, leave all auth unset to use the server's managed identity. |
@@ -268,7 +268,7 @@ These `.env` variables tune what gets seeded. They apply on the **first boot onl
 | `BEDROCK_MODEL` | `anthropic.claude-fable-5-1` | Invokable Bedrock model id seeded into `oss/ai-primary` on the Bedrock path. |
 | `XAI_API_KEY` | — | Grok (xAI) API key from console.x.ai, for the Grok path (`AI_PROVIDER=grok`, or auto-picked when it's the sole key). |
 | `GROK_MODEL` | `grok-4.6` | Grok model seeded into `oss/ai-primary` on the Grok path. |
-| `CODEGEN_MODEL` | `claude-opus-5` or `gpt-5.5` | Model seeded into `oss/codegen` (Anthropic and OpenAI defaults; the Azure path defaults to `AZURE_OPENAI_MODEL`; the Bedrock path defaults to `anthropic.claude-opus-5`; the Grok path defaults to `grok-4.6`). |
+| `CODEGEN_MODEL` | `claude-opus-5` or `gpt-5.6-sol` | Model seeded into `oss/codegen` (Anthropic and OpenAI defaults; the Azure path defaults to `AZURE_OPENAI_MODEL`; the Bedrock path defaults to `anthropic.claude-opus-5`; the Grok path defaults to `grok-4.6`). |
 | `EMBEDDING_PROVIDER` | follows provider | `openai`, `azure`, `tei`, or `ollama`. When unset: `openai` when the AI provider is OpenAI, otherwise the bundled TEI sidecar (Azure embeddings are opt-in only). |
 | `EMBEDDING_MODEL` | provider default | `text-embedding-3-small` (openai; also the azure default deployment name), `BAAI/bge-m3` (tei), `bge-m3` (ollama). |
 | `EMBEDDING_ENDPOINT` | provider default | Endpoint override for the `tei`, `ollama`, and `azure` providers — useful when the service runs on a separate host or a non-standard path. |
@@ -389,7 +389,7 @@ These environment variables are read by `docker-compose.yml` and passed into the
 | `USE_USER_AUTH` | `false` | Enable username/password login + admin gating. See [User Authentication](/user-auth). |
 | `USE_API_KEYS` | `false` | Enable per-tenant API-key gating on the REST/MCP API. See [API Keys](/api-keys). |
 | `MULTI_TENANT` | `false` | Advanced: switch to per-tenant database isolation, with each request routed by its API key. Requires `USE_API_KEYS=true`. |
-| `ANTHROPIC_OVERLOAD_FALLBACK_MODEL` | `claude-sonnet-4-6` | Model used for the current request when Anthropic returns a sustained `overloaded_error` on an Opus call (after the automatic retries). Only consulted when the configured model is an Anthropic Opus variant — other providers ignore it. Bump when a newer Sonnet ships to keep the fallback current. |
+| `ANTHROPIC_OVERLOAD_FALLBACK_MODEL` | `claude-sonnet-5` | Model used for the current request when Anthropic returns a sustained `overloaded_error` on an Opus call (after the automatic retries). Only consulted when the configured model is an Anthropic Opus variant — other providers ignore it. Bump when a newer Sonnet ships to keep the fallback current. |
 | `CAPABILITY_ENFORCEMENT` | `enforce` | `enforce` returns HTTP 403 on policy violations by scoped keys. Set to `log-only` to emit would-deny log lines without rejecting — useful when iterating on a new scope policy. |
 | `USE_AUDIT_LOG` | `false` | Enable the [Audit Log](/audit-log) — who did what, by login or API key. |
 | `AUDIT_LOG_RETENTION_DAYS` | `90` | Days to keep audit entries; `0` = forever. |


### PR DESCRIPTION
## Summary

The example env, the Vault seed script and both AI docs pages still defaulted to models the catalog at datris.ai no longer recommends. This bumps them:

| Setting | Was | Now |
|---|---|---|
| Anthropic chat (`ANTHROPIC_MODEL`, ai-primary seed) | `claude-opus-5` | `claude-fable-5-1` |
| OpenAI chat and codegen (`OPENAI_MODEL`, `CODEGEN_MODEL`) | `gpt-5.5` | `gpt-5.6-sol` |
| Overload fallback (`ANTHROPIC_OVERLOAD_FALLBACK_MODEL`) | `claude-sonnet-4-6` | `claude-sonnet-5` |

Unchanged on purpose: Anthropic and Bedrock codegen stay on `claude-opus-5` (still the codegen recommendation); Bedrock, Grok and embedding defaults were already current.

Touches `.env.example`, `docker/vault-init.sh`, the compiled fallback default in `AgentLoop`, `docs/ai-configuration.mdx`, `docs/configuration-reference.mdx` (including the `vault kv put` examples), and regenerates `docker-compose.standalone.yml` since it inlines the seed script.

## Backward compatibility

The Vault seed is create-if-absent, so only a brand-new install picks these up. Existing Vault secrets and running stacks are untouched. The overload fallback default only applies where the operator has not set the env var.

## Test plan

- [x] `sbt compile`
- [x] `scripts/build-standalone-compose.py` output committed (CI guard)
- [ ] Fresh-install seed on an OpenAI-keyed `.env` lands `gpt-5.6-sol` and the Assistant answers (not exercised here; this machine runs Anthropic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)