### PR TITLE
datris doctor: operational self-check across server, CLI, MCP and UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       - name: MCP tool catalog drift check
         run: python3 scripts/check-mcp-tool-catalog.py
 
+      # Host-side `datris doctor` checks (mcp-server/doctor.py) against a
+      # faked docker/git runner — no Docker needed.
+      - name: CLI doctor tests
+        run: |
+          python3 -m pip install --quiet --user pytest requests
+          python3 -m pytest mcp-server/tests -q
+
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,6 +78,8 @@ jobs:
           context: ./ui
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ steps.tag.outputs.version }}
           tags: |
             ${{ env.DOCKERHUB_ORG }}/datris-ui:${{ steps.tag.outputs.version }}
             ${{ env.DOCKERHUB_ORG }}/datris-ui:latest

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,19 @@ lazy val datrisserver = project
             "at.yawk.lz4" % "lz4-java" % "1.11.1",
             "org.apache.ivy" % "ivy" % "2.5.2"
         ),
-        buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+        // gitHeadCommit + builtAtMillis let /api/v1/version say WHICH jar is
+        // running — `datris doctor` compares them with the checkout to catch a
+        // stale jar served from the Docker build cache (bit us in v1.17.0).
+        buildInfoKeys := Seq[BuildInfoKey](
+            name,
+            version,
+            scalaVersion,
+            sbtVersion,
+            BuildInfoKey.action("gitHeadCommit") {
+                scala.util.Try(scala.sys.process.Process("git rev-parse HEAD").!!.trim).getOrElse("unknown")
+            },
+            BuildInfoKey.action("builtAtMillis") { System.currentTimeMillis() }
+        ),
         buildInfoPackage := "ai.datris.build.sbt",
         libraryDependencies ++= Seq(
             "org.scalatest"     %% "scalatest"    % "3.2.19"   % Test,

--- a/datrisserver/src/main/resources/application.yaml
+++ b/datrisserver/src/main/resources/application.yaml
@@ -64,6 +64,13 @@ recoveryAgent:
 # until an admin sets an action to approve or deny. Env var: USE_AGENT_POLICY.
 useAgentPolicy: "false"
 
+# Doctor: operational self-check (Vault token TTL, AI slot secrets, embedding
+# model loaded, disk, version skew). onStartup logs the cheap subset at boot as
+# DOCTOR warn lines; the same checks run on demand via GET /api/v1/doctor,
+# the run_doctor MCP tool, and `datris doctor`. Env var: DOCTOR_ONSTARTUP.
+doctor:
+  onStartup: "true"
+
 # CORS allowed origins (comma-separated). Use "*" for any origin (dev only).
 # Production: lock down to specific origins, e.g. "https://app.datris.ai,https://admin.datris.ai"
 cors:

--- a/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
+++ b/datrisserver/src/main/scala/ai/datris/StartupRunner.scala
@@ -185,6 +185,12 @@ class StartupRunner extends ApplicationRunner {
     @Value("${versionCap:50}")
     var versionCap: Int = _
 
+    // Doctor: log the cheap operational self-checks at boot (Vault token TTL,
+    // AI slot secrets, embedding model, disk). Warn lines only — never blocks
+    // startup. GET /api/v1/doctor and `datris doctor` run the same checks.
+    @Value("${doctor.onStartup:true}")
+    var doctorOnStartup: Boolean = _
+
     @Override
     def run(args: ApplicationArguments): Unit = {
         ai.datris.util.TapScriptRunner.assertIsolationConfig()
@@ -411,6 +417,16 @@ class StartupRunner extends ApplicationRunner {
             else
                 null
         }
+        // Doctor's startup subset runs BEFORE the AI-secret hard failures below
+        // so a missing `oss/codegen` gets a DOCTOR line with its fix ahead of
+        // the stack trace that stops the boot. Wrapped: a doctor bug never
+        // blocks startup.
+        ai.datris.util.DoctorService.configure(ai.datris.util.DoctorService.Slots(aiPrimarySecretName, codegenSecretName, embeddingSecretName))
+        if (doctorOnStartup) {
+            try ai.datris.util.DoctorService.runStartupLive()
+            catch { case e: Exception => logger.warn("DOCTOR startup checks failed (continuing): " + e.getMessage) }
+        }
+
         // AI configuration is required — CodeGen data quality and transformation depend on it.
         // Three independent secrets, each fully self-describing (provider/endpoint/model/apiKey/version
         // all live inside the Vault secret).

--- a/datrisserver/src/main/scala/ai/datris/api/DoctorAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/DoctorAPIController.scala
@@ -1,0 +1,58 @@
+package ai.datris.api
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.util.{APIKeyValidator, DoctorService}
+import com.google.common.base.Throwables
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
+import org.springframework.web.bind.annotation._
+
+/** `GET /api/v1/doctor` — the operational self-check report.
+  *
+  * Query parameters:
+  *   - `mode=quick|full` (default full): quick runs only the cheap
+  *     startup-safe subset.
+  *   - `probes=ai` opts into the AI reachability probe (spends a few tokens).
+  *   - `cli=`, `mcp=`, `ui=`: versions the calling clients report, for the
+  *     version-skew check.
+  *
+  * Not public — the report names env keys, Vault paths and model ids — so it
+  * is capability-mapped to `config:read` (CapabilityRoutes) on top of the
+  * usual API-key validation. Host-side checks (Docker volumes, container
+  * env drift) live in `datris doctor` on the machine running Docker.
+  */
+@RestController
+@RequestMapping(Array("/api/v1"))
+class DoctorAPIController {
+    private val logger: Logger = LoggerFactory.getLogger(classOf[DoctorAPIController])
+
+    @GetMapping(path = Array("/doctor"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+    def doctor(
+        @RequestHeader(name = "x-api-key", required = false) apiKey: String,
+        @RequestParam(name = "mode", required = false, defaultValue = "full") mode: String,
+        @RequestParam(name = "probes", required = false) probes: String,
+        @RequestParam(name = "cli", required = false) cli: String,
+        @RequestParam(name = "mcp", required = false) mcp: String,
+        @RequestParam(name = "ui", required = false) ui: String
+    ): ResponseEntity[String] = {
+        try {
+            logger.info("API endpoint GET /api/v1/doctor called, mode=" + mode + ", probes=" + probes)
+            APIKeyValidator.validate(apiKey)
+            val groups = Option(probes).map(_.split(",").map(_.trim.toLowerCase).filter(_.nonEmpty).toSet).getOrElse(Set.empty[String])
+            val clients = Seq("cli" -> cli, "mcp" -> mcp, "ui" -> ui).collect { case (k, v) if v != null && v.trim.nonEmpty => k -> v.trim }.toMap
+            val report = DoctorService.runLive(mode, groups, clients)
+            new ResponseEntity[String](report.toJson, HttpStatus.OK)
+        } catch {
+            case e: ai.datris.model.DatrisException =>
+                logger.warn("Doctor request rejected: " + e.getMessage)
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body[String]("{\"error\": \"" + e.getMessage.replace("\"", "'") + "\"}")
+            case e: Exception =>
+                logger.error("Error: " + Throwables.getStackTraceAsString(e))
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body[String](Throwables.getStackTraceAsString(e))
+        }
+    }
+}

--- a/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
+++ b/datrisserver/src/main/scala/ai/datris/api/VersionAPIController.scala
@@ -38,6 +38,9 @@ class VersionAPIController {
                 else DatrisEnvironment.current.mongoDbConfig.database
             val map = Map(
                 "version" -> BuildInfo.version,
+                // Which jar is running (doctor's build.stale_jar compares these to the checkout).
+                "gitHeadCommit" -> BuildInfo.gitHeadCommit,
+                "builtAtMillis" -> BuildInfo.builtAtMillis.toString,
                 "environment" -> DatrisEnvironment.current.environment,
                 "multiTenant" -> DatrisEnvironment.current.multiTenant.toString,
                 "hosted" -> DatrisEnvironment.current.hosted.toString,

--- a/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/CapabilityRoutes.scala
@@ -151,6 +151,9 @@ object CapabilityRoutes {
         // Config
         Route("POST", "/api/v1/config/upload", "config", "write"),
         Route("GET", "/api/v1/ai/model-catalog", "config", "read"),
+        // Doctor — operational self-check. Not public: the report names env
+        // keys, Vault secret paths and model ids, so it rides config:read.
+        Route("GET", "/api/v1/doctor", "config", "read"),
 
         // Audit log — admin surface. Full-access keys hold it implicitly; a
         // scoped key needs `audit:read` explicitly (see the Keys catalog).

--- a/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
+++ b/datrisserver/src/main/scala/ai/datris/auth/MCPToolRoutes.scala
@@ -65,6 +65,7 @@ object MCPToolRoutes {
         // Infrastructure
         "get_version" -> Local,
         "check_service_health" -> Local,
+        "run_doctor" -> Mapped("GET", "/api/v1/doctor"),
 
         // Vector search
         "search_qdrant" -> Mapped("POST", "/api/v1/search/qdrant"),

--- a/datrisserver/src/main/scala/ai/datris/util/DoctorService.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DoctorService.scala
@@ -133,8 +133,6 @@ object DoctorService {
 
     private val Day = 86400L
     private val SevenDays = 7 * Day
-    private val Hours720 = 720L * 3600L
-    private val Hours87600 = 87600L * 3600L
 
     private def humanDuration(seconds: Long): String = {
         if (seconds >= Day) (seconds / Day) + "d"
@@ -160,9 +158,13 @@ object DoctorService {
                         "Vault token expires in " + humanDuration(ttl) + " (period " + humanDuration(period) + ", ttl clamped by max_lease_ttl). " +
                             "Check docker/vault.hcl has max_lease_ttl = \"87600h\", then `docker compose up -d --force-recreate vault` " +
                             "and restart datris to re-mint the token."
+                    // A periodic token renews to its full period, so a healthy one
+                    // sits near the period; one minted under a low max_lease_ttl
+                    // (Vault's 768h default) sits at that ceiling instead. "Under a
+                    // tenth of the period" catches any ceiling, not just 768h.
                     if (ttl <= 0 && period <= 0) ok("token has no expiry")
                     else if (ttl < SevenDays) error(detail + " — expires in " + humanDuration(ttl), remediation)
-                    else if (period >= Hours87600 && ttl < Hours720) warn(detail + " — clamped", remediation)
+                    else if (period > 0 && ttl < period / 10) warn(detail + " — clamped", remediation)
                     else ok(detail)
             }
         }

--- a/datrisserver/src/main/scala/ai/datris/util/DoctorService.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/DoctorService.scala
@@ -1,0 +1,647 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.{AIConfig, DatrisEnvironment}
+import com.google.gson.{Gson, JsonParser}
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
+
+/** Operational self-check ("datris doctor"). One place for the deterministic
+  * probes behind every incident that used to be diagnosed by hand from the
+  * logs — Vault token TTL clamped, an AI slot secret missing so the server
+  * crash-loops, the embedding model not pulled, a full disk, a mixed-version
+  * stack. Each check owns its remediation text.
+  *
+  * Three surfaces run the same checks: `GET /api/v1/doctor` (UI, MCP, CLI),
+  * and the startup subset logged at boot. Host-side checks (Docker volumes,
+  * container env drift, compose orphans) can't run in the JVM; the CLI runs
+  * those and merges them into the same report shape.
+  *
+  * Never mutates anything and never spends money by default: the AI
+  * reachability probe is opt-in (`?probes=ai`) and never runs at boot.
+  */
+object DoctorService {
+    private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    val DoctorVersion = 1
+
+    val StatusOk = "ok"
+    val StatusWarn = "warn"
+    val StatusError = "error"
+    val StatusSkip = "skip"
+
+    /** One check's outcome. `severity` is the level the check reports at
+      * when it fires (informational for `ok`/`skip`). Values never carry
+      * secrets — only key names and hashes. */
+    case class CheckResult(
+        id: String,
+        status: String,
+        severity: String,
+        detail: String,
+        remediation: String,
+        surface: String = "server",
+        ms: Long = 0L
+    )
+
+    case class Report(mode: String, surface: Map[String, String], checks: Seq[CheckResult]) {
+        def summary: Map[String, Int] =
+            Seq(StatusOk, StatusWarn, StatusError, StatusSkip).map(s => s -> checks.count(_.status == s)).toMap
+
+        def toJson: String = {
+            val root = new java.util.LinkedHashMap[String, Any]()
+            root.put("doctorVersion", DoctorVersion)
+            root.put("ranAt", java.time.Instant.now().toString)
+            root.put("mode", mode)
+            val surf = new java.util.LinkedHashMap[String, String]()
+            surface.foreach { case (k, v) => surf.put(k, v) }
+            root.put("surface", surf)
+            val sum = new java.util.LinkedHashMap[String, Int]()
+            val s = summary
+            Seq(StatusOk, StatusWarn, StatusError, StatusSkip).foreach(k => sum.put(k, s(k)))
+            root.put("summary", sum)
+            val arr = new java.util.ArrayList[java.util.Map[String, Any]]()
+            checks.foreach { c =>
+                val m = new java.util.LinkedHashMap[String, Any]()
+                m.put("id", c.id)
+                m.put("status", c.status)
+                m.put("severity", c.severity)
+                m.put("detail", c.detail)
+                m.put("remediation", c.remediation)
+                m.put("surface", c.surface)
+                m.put("ms", c.ms)
+                arr.add(m)
+            }
+            root.put("checks", arr)
+            new Gson().toJson(root)
+        }
+    }
+
+    /** A single probe. `startupSafe` checks are cheap, spend nothing, and
+      * run at boot; `optInGroup` checks only run when the caller names the
+      * group (`?probes=ai`). */
+    trait Check {
+        def id: String
+        def startupSafe: Boolean
+        def optInGroup: Option[String] = None
+        def run(): CheckResult
+
+        protected def ok(detail: String): CheckResult = CheckResult(id, StatusOk, StatusOk, detail, "")
+        protected def warn(detail: String, remediation: String): CheckResult = CheckResult(id, StatusWarn, StatusWarn, detail, remediation)
+        protected def error(detail: String, remediation: String): CheckResult = CheckResult(id, StatusError, StatusError, detail, remediation)
+        protected def skip(detail: String): CheckResult = CheckResult(id, StatusSkip, StatusOk, detail, "")
+    }
+
+    /** The AI slot secret names the server was configured with. */
+    case class Slots(aiPrimarySecret: String, codegenSecret: String, embeddingSecret: String)
+
+    /** Everything a check touches outside the JVM, so specs can fake it. */
+    trait Probes {
+
+        /** `auth/token/lookup-self` data fields as strings (ttl, period,
+          * creation_ttl, explicit_max_ttl — seconds). None when Vault or
+          * the token can't be reached. */
+        def vaultLookupSelf(): Option[Map[String, String]]
+        def secret(name: String): Option[Map[String, String]]
+        def apiKeyResolves(provider: String, rawKey: String): Boolean
+        def classPresent(className: String): Boolean
+
+        /** (pipelineName, source.databaseAttributes.type) for database-pull pipelines. */
+        def pipelineSources(): List[(String, String)]
+
+        /** Plain GET → (status, body). Throws on connect/read failure. */
+        def httpGet(url: String, timeoutMs: Int): (Int, String)
+
+        /** (totalBytes, usableBytes) for the file store holding `path`. */
+        def diskUsage(path: String): Option[(Long, Long)]
+        def envSeen(names: Seq[String]): Map[String, Boolean]
+
+        /** Chat slots configured on this server: (label, config). */
+        def chatSlots(): Seq[(String, AIConfig)]
+
+        /** Minimal chat request → (status, bodySnippet). Throws on timeout/IO. */
+        def probeChat(config: AIConfig, timeoutMs: Int): (Int, String)
+
+        /** One-input embedding request → (status, bodySnippet). Throws on timeout/IO. */
+        def probeEmbedding(provider: String, endpoint: String, model: String, apiKey: String, timeoutMs: Int): (Int, String)
+    }
+
+    private val Day = 86400L
+    private val SevenDays = 7 * Day
+    private val Hours720 = 720L * 3600L
+    private val Hours87600 = 87600L * 3600L
+
+    private def humanDuration(seconds: Long): String = {
+        if (seconds >= Day) (seconds / Day) + "d"
+        else if (seconds >= 3600) (seconds / 3600) + "h"
+        else (seconds / 60) + "m"
+    }
+
+    private def gb(bytes: Long): String = f"${bytes / 1073741824.0}%.1f GB"
+
+    // ------------------------------------------------------------------ checks
+
+    class VaultTokenTtlCheck(probes: Probes) extends Check {
+        val id = "vault.token_ttl"
+        val startupSafe = true
+        def run(): CheckResult = {
+            probes.vaultLookupSelf() match {
+                case None => skip("token lookup unavailable (Vault unreachable or no token resolved)")
+                case Some(data) =>
+                    val ttl = data.get("ttl").flatMap(v => scala.util.Try(v.toDouble.toLong).toOption).getOrElse(0L)
+                    val period = data.get("period").flatMap(v => scala.util.Try(v.toDouble.toLong).toOption).getOrElse(0L)
+                    val detail = "ttl " + humanDuration(ttl) + ", period " + humanDuration(period)
+                    val remediation =
+                        "Vault token expires in " + humanDuration(ttl) + " (period " + humanDuration(period) + ", ttl clamped by max_lease_ttl). " +
+                            "Check docker/vault.hcl has max_lease_ttl = \"87600h\", then `docker compose up -d --force-recreate vault` " +
+                            "and restart datris to re-mint the token."
+                    if (ttl <= 0 && period <= 0) ok("token has no expiry")
+                    else if (ttl < SevenDays) error(detail + " — expires in " + humanDuration(ttl), remediation)
+                    else if (period >= Hours87600 && ttl < Hours720) warn(detail + " — clamped", remediation)
+                    else ok(detail)
+            }
+        }
+    }
+
+    class VaultAiSlotsCheck(probes: Probes, slots: Slots) extends Check {
+        val id = "vault.ai_slots"
+        val startupSafe = true
+        private val keyless = Set("ollama", "bedrock", "tei")
+        private val keyOptional = keyless + "azure"
+
+        def run(): CheckResult = {
+            val slotList = Seq(("ai-primary", slots.aiPrimarySecret), ("codegen", slots.codegenSecret), ("embedding", slots.embeddingSecret))
+                .filter { case (_, name) => name != null && name.nonEmpty }
+            val problems = scala.collection.mutable.ListBuffer[String]()
+            val fixes = scala.collection.mutable.ListBuffer[String]()
+            val okDetails = scala.collection.mutable.ListBuffer[String]()
+            slotList.foreach { case (label, name) =>
+                probes.secret(name) match {
+                    case None =>
+                        problems += "Vault secret `" + name + "` (" + label + ") missing" +
+                            (if (label == "ai-primary") "; the server will refuse to start" else "")
+                        fixes += "vault kv put secret/" + name + " provider=<anthropic|openai|azure|bedrock|grok|ollama> endpoint=<url> model=<model> apiKey=<key>"
+                    case Some(s) =>
+                        val provider = s.getOrElse("provider", "").trim.toLowerCase
+                        val endpoint = s.getOrElse("endpoint", "").trim
+                        val model = s.getOrElse("model", "").trim
+                        val rawKey = s.getOrElse("apiKey", "")
+                        val missing = scala.collection.mutable.ListBuffer[String]()
+                        if (provider.isEmpty) missing += "provider"
+                        if (endpoint.isEmpty && provider != "bedrock") missing += "endpoint"
+                        if (model.isEmpty) missing += "model"
+                        val keyOk = keyOptional.contains(provider) || rawKey.nonEmpty || probes.apiKeyResolves(provider, rawKey)
+                        if (!keyOk) missing += "apiKey"
+                        if (missing.nonEmpty) {
+                            problems += "secret `" + name + "` (" + label + ") is missing " + missing.map("'" + _ + "'").mkString(", ")
+                            fixes += "vault kv patch secret/" + name + " " + missing.map(f => f + "=<value>").mkString(" ")
+                        } else
+                            okDetails += label + " (" + provider + "/" + model + ")"
+                }
+            }
+            if (problems.nonEmpty) error(problems.mkString("; "), fixes.mkString("; "))
+            else if (slotList.isEmpty) skip("no AI slot secrets configured")
+            else ok(okDetails.mkString(", "))
+        }
+    }
+
+    class JdbcMssqlDriverCheck(probes: Probes) extends Check {
+        val id = "jdbc.mssql_driver"
+        val startupSafe = true
+        def run(): CheckResult = {
+            val present = probes.classPresent("com.microsoft.sqlserver.jdbc.SQLServerDriver")
+            if (present) return ok("MSSQL JDBC driver on the classpath")
+            val users = probes.pipelineSources().collect { case (name, t) if t != null && t.equalsIgnoreCase("mssql") => name }
+            if (users.isEmpty) ok("MSSQL JDBC driver not bundled; no pipeline uses type: mssql")
+            else
+                error(
+                    "pipeline(s) " + users.mkString(", ") + " use `type: mssql` but the MSSQL JDBC driver is not on the classpath",
+                    "Add `com.microsoft.sqlserver % mssql-jdbc` to build.sbt and rebuild (see docs/ingestion/database-pull.mdx), or change the source type."
+                )
+        }
+    }
+
+    /** Embedding model actually loaded where the embedding slot points.
+      * `startup` softens "not reachable" to a skip: at boot the bundled
+      * embedding service is often still downloading its model, and that
+      * is not a misconfiguration. */
+    class AiEmbeddingModelCheck(probes: Probes, slots: Slots, startup: Boolean = false) extends Check {
+        val id = "ai.embedding_model"
+        val startupSafe = true
+
+        private def baseUrl(endpoint: String): String = {
+            val u = new java.net.URI(endpoint)
+            val port = if (u.getPort > 0) ":" + u.getPort else ""
+            u.getScheme + "://" + u.getHost + port
+        }
+
+        private def unreachable(what: String, base: String, why: String): CheckResult =
+            if (startup) skip(what + " at " + base + " not reachable yet (" + why + ")")
+            else
+                error(
+                    what + " at " + base + " unreachable: " + why,
+                    "Check `docker compose ps` — the embedding service the slot points at is not up. Re-run once it is healthy."
+                )
+
+        def run(): CheckResult = {
+            val secret = probes.secret(slots.embeddingSecret).getOrElse(return skip("embedding secret missing (see vault.ai_slots)"))
+            val provider = secret.getOrElse("provider", "").trim.toLowerCase
+            val endpoint = secret.getOrElse("endpoint", "").trim
+            val model = secret.getOrElse("model", "").trim
+            if (endpoint.isEmpty || model.isEmpty) return skip("embedding secret has no endpoint/model (see vault.ai_slots)")
+            val host = scala.util.Try(new java.net.URI(endpoint).getHost).toOption.getOrElse("").toLowerCase
+            val kind =
+                if (provider == "ollama" || (provider.isEmpty && (host.contains("ollama") || endpoint.contains(":11434")))) "ollama"
+                else if (provider == "tei" || (provider.isEmpty && host.contains("tei"))) "tei"
+                else provider
+            kind match {
+                case "ollama" =>
+                    val base = baseUrl(endpoint)
+                    val resp =
+                        try probes.httpGet(base + "/api/tags", 5000)
+                        catch { case e: Exception => return unreachable("Ollama", base, e.getClass.getSimpleName + ": " + e.getMessage) }
+                    if (resp._1 != 200) return unreachable("Ollama", base, "HTTP " + resp._1)
+                    val names =
+                        try {
+                            val root = JsonParser.parseString(resp._2).getAsJsonObject
+                            val arr = Option(root.getAsJsonArray("models")).map(_.asScala.toList).getOrElse(Nil)
+                            arr.map(_.getAsJsonObject.get("name").getAsString)
+                        } catch { case _: Exception => Nil }
+                    val wanted = model.toLowerCase
+                    val found = names.exists(n => n.toLowerCase == wanted || n.toLowerCase == wanted + ":latest" || n.toLowerCase.startsWith(wanted + ":"))
+                    if (found) ok("`" + model + "` loaded on Ollama at " + base)
+                    else
+                        error(
+                            "embedding slot expects `" + model + "` on Ollama at " + base + " but it is not pulled" +
+                                (if (names.nonEmpty) " (present: " + names.mkString(", ") + ")" else ""),
+                            "docker compose exec ollama ollama pull " + model
+                        )
+                case "tei" =>
+                    val base = baseUrl(endpoint)
+                    val health =
+                        try probes.httpGet(base + "/health", 5000)
+                        catch { case e: Exception => return unreachable("TEI", base, e.getClass.getSimpleName + ": " + e.getMessage) }
+                    if (health._1 != 200) return unreachable("TEI", base, "health HTTP " + health._1 + " (still loading the model?)")
+                    val info =
+                        try probes.httpGet(base + "/info", 5000)
+                        catch { case e: Exception => return unreachable("TEI", base, e.getClass.getSimpleName + ": " + e.getMessage) }
+                    val served =
+                        try JsonParser.parseString(info._2).getAsJsonObject.get("model_id").getAsString
+                        catch { case _: Exception => "" }
+                    val m = model.toLowerCase
+                    val s = served.toLowerCase
+                    if (s.nonEmpty && (s == m || s.endsWith("/" + m) || m.endsWith("/" + s))) ok("TEI at " + base + " serving " + served)
+                    else
+                        error(
+                            "TEI at " + base + " is serving `" + served + "`, embedding secret says `" + model + "`",
+                            "Set the embedding slot's model to the served id (Configuration → AI Providers) or change TEI's --model-id in docker-compose.yml and recreate it."
+                        )
+                case "openai" | "azure" =>
+                    ok("provider " + kind + " — endpoint verified by ai.model_reachable (opt-in)")
+                case other =>
+                    skip("provider '" + other + "' has no model-presence probe")
+            }
+        }
+    }
+
+    class DiskUsageCheck(probes: Probes, paths: Seq[String]) extends Check {
+        val id = "disk.usage"
+        val startupSafe = true
+        def run(): CheckResult = {
+            val rows = paths.distinct.flatMap { p =>
+                probes.diskUsage(p).map { case (total, usable) =>
+                    val pct = if (total <= 0) 0.0 else (total - usable) * 100.0 / total
+                    (p, pct, usable)
+                }
+            }
+            if (rows.isEmpty) return skip("no file store readable")
+            val detail = rows.map { case (p, pct, usable) => p + " " + f"$pct%.0f" + "% used (" + gb(usable) + " free)" }.mkString("; ")
+            val worst = rows.map(_._2).max
+            val remediation = "Free space on the disk holding Docker's data root: `docker image prune`, inspect the pip-cache and object-store volumes, " +
+                "and check `docker system df`. `docker compose pull` on a nearly full disk half-writes image layers."
+            if (worst >= 95.0) error(detail, remediation)
+            else if (worst >= 85.0) warn(detail, remediation)
+            else ok(detail)
+        }
+    }
+
+    /** Compares the server's version with whatever versions the calling
+      * clients report (`?cli=`, `?mcp=`, `?ui=`). Major.minor must match. */
+    class VersionSkewCheck(serverVersion: String, clients: Map[String, String]) extends Check {
+        val id = "version.skew"
+        val startupSafe = true
+        private def majorMinor(v: String): String = v.split("\\.").take(2).mkString(".")
+        def run(): CheckResult = {
+            val reported = clients.filter { case (_, v) => v != null && v.nonEmpty }
+            val listing = ("server " + serverVersion) +: reported.toSeq.map { case (k, v) => k + " " + v }
+            val remediation = "Bring every component to the same release: `docker compose pull && docker compose up -d --remove-orphans`; " +
+                "`pip install -U datris-mcp-server` or `brew upgrade datris` for the CLI."
+            if (reported.isEmpty) return ok("server " + serverVersion + "; no client reported a version")
+            val unknown = reported.collect { case (k, v) if v.equalsIgnoreCase("unknown") => k }
+            val skewed = reported.collect { case (k, v) if !v.equalsIgnoreCase("unknown") && majorMinor(v) != majorMinor(serverVersion) => k }
+            if (skewed.nonEmpty) warn(listing.mkString(", ") + " — " + skewed.mkString(", ") + " differ from the server in major.minor", remediation)
+            else if (unknown.nonEmpty)
+                warn(
+                    listing.mkString(", ") + " — " + unknown.mkString(", ") + " version unknown (image built without a version stamp)",
+                    "Pull the published image (`docker compose pull`), or pass APP_VERSION when building the UI image from source."
+                )
+            else ok(listing.mkString(", "))
+        }
+    }
+
+    /** Which hardening env vars reached the JVM. Always ok — evidence for the
+      * CLI's `env.not_forwarded` check, and a line in the report so a
+      * documented-but-unforwarded var is visible without shelling in. */
+    class EnvSeenCheck(probes: Probes) extends Check {
+        val id = "env.seen"
+        val startupSafe = true
+        val names = Seq("DATRIS_ENV", "DATRIS_ALLOW_PLAINTEXT_DB", "DATRIS_ALLOW_PRIVATE_EGRESS", "TAPMAXOUTPUTMB", "VAULT_TOKEN_FILE")
+        def run(): CheckResult = {
+            val seen = probes.envSeen(names)
+            val present = names.filter(n => seen.getOrElse(n, false))
+            val absent = names.filterNot(n => seen.getOrElse(n, false))
+            ok("seen: " + (if (present.isEmpty) "none" else present.mkString(", ")) +
+                (if (absent.nonEmpty) "; unset: " + absent.mkString(", ") else ""))
+        }
+    }
+
+    /** Opt-in (`?probes=ai`): a minimal request through each configured chat
+      * slot, and a one-input embed for hosted embedding providers. Costs a
+      * few tokens; never at startup. */
+    class AiModelReachableCheck(probes: Probes, slots: Slots) extends Check {
+        val id = "ai.model_reachable"
+        val startupSafe = false
+        override val optInGroup: Option[String] = Some("ai")
+        private val timeoutMs = 10000
+
+        private def classify(label: String, provider: String, model: String, status: Int, body: String): Option[(String, String, String)] = {
+            val b = if (body == null) "" else body.toLowerCase
+            val head = label + " (" + provider + ", model " + model + ")"
+            if (status >= 200 && status < 300) None
+            else if (status == 401 || status == 403)
+                Some((
+                    StatusError,
+                    head + ": HTTP " + status + " — the provider rejected the API key",
+                    "Re-enter the " + provider + " key in Configuration → AI Providers and confirm it has access to this model."
+                ))
+            else if (
+                status == 404 || (status == 400 && (b.contains("model") && (b.contains("not found") || b.contains("does not exist") || b.contains("unknown"))))
+            ) {
+                Some((
+                    StatusError,
+                    head + ": HTTP " + status + " model not found",
+                    "Pick a current model in Configuration → AI Providers (or check /api/v1/ai/model-catalog)."
+                ))
+            } else if (status >= 400 && status < 500)
+                Some((
+                    StatusError,
+                    head + ": HTTP " + status + " " + body.take(200).replaceAll("\\s+", " "),
+                    "Check the slot's endpoint, model and key in Configuration → AI Providers."
+                ))
+            else
+                Some((StatusWarn, head + ": HTTP " + status + " from the endpoint", "The provider is reachable but failing server-side; retry shortly."))
+        }
+
+        def run(): CheckResult = {
+            val findings = scala.collection.mutable.ListBuffer[(String, String, String)]()
+            val fine = scala.collection.mutable.ListBuffer[String]()
+            probes.chatSlots().foreach { case (label, cfg) =>
+                try {
+                    val (status, body) = probes.probeChat(cfg, timeoutMs)
+                    classify(label, cfg.provider, cfg.model, status, body) match {
+                        case None => fine += label + " (" + cfg.provider + "/" + cfg.model + ")"
+                        case Some(f) => findings += f
+                    }
+                } catch {
+                    case e: Exception =>
+                        findings += ((
+                            StatusWarn,
+                            label + " (" + cfg.provider + ", model " + cfg.model + "): no response within " + (timeoutMs / 1000) + "s (" + e.getClass
+                                .getSimpleName + ")",
+                            "Check the slot's endpoint URL and outbound network access from the datris container."
+                        ))
+                }
+            }
+            probes.secret(slots.embeddingSecret).foreach { s =>
+                val provider = s.getOrElse("provider", "").trim.toLowerCase
+                if (provider == "openai" || provider == "azure") {
+                    val endpoint = s.getOrElse("endpoint", "")
+                    val model = s.getOrElse("model", "")
+                    try {
+                        val (status, body) = probes.probeEmbedding(provider, endpoint, model, s.getOrElse("apiKey", ""), timeoutMs)
+                        classify("embedding", provider, model, status, body) match {
+                            case None => fine += "embedding (" + provider + "/" + model + ")"
+                            case Some(f) => findings += f
+                        }
+                    } catch {
+                        case e: Exception =>
+                            findings += ((
+                                StatusWarn,
+                                "embedding (" + provider + ", model " + model + "): no response within " + (timeoutMs / 1000) + "s (" + e.getClass
+                                    .getSimpleName + ")",
+                                "Check the embedding endpoint URL and outbound network access from the datris container."
+                            ))
+                    }
+                }
+            }
+            if (findings.isEmpty) {
+                if (fine.isEmpty) skip("no AI slots to probe") else ok(fine.mkString(", "))
+            } else {
+                val status = if (findings.exists(_._1 == StatusError)) StatusError else StatusWarn
+                CheckResult(id, status, status, findings.map(_._2).mkString("; "), findings.map(_._3).distinct.mkString(" "))
+            }
+        }
+    }
+
+    // ------------------------------------------------------------ assembly
+
+    /** Every server-side check, in report order. */
+    def checks(probes: Probes, slots: Slots, serverVersion: String, clients: Map[String, String], startup: Boolean = false): Seq[Check] =
+        Seq(
+            new VaultTokenTtlCheck(probes),
+            new VaultAiSlotsCheck(probes, slots),
+            new JdbcMssqlDriverCheck(probes),
+            new AiEmbeddingModelCheck(probes, slots, startup),
+            new DiskUsageCheck(probes, Seq(System.getProperty("user.dir"), System.getProperty("java.io.tmpdir"))),
+            new VersionSkewCheck(serverVersion, clients),
+            new EnvSeenCheck(probes),
+            new AiModelReachableCheck(probes, slots)
+        )
+
+    /** Run one check, timing it and turning a thrown exception into an
+      * error row rather than a failed report. */
+    def runOne(check: Check): CheckResult = {
+        val start = System.currentTimeMillis()
+        val r =
+            try check.run()
+            catch {
+                case e: Exception =>
+                    CheckResult(
+                        check.id,
+                        StatusError,
+                        StatusError,
+                        "check failed: " + e.getClass.getSimpleName + ": " + e.getMessage,
+                        "This is a doctor bug — report it with the server log."
+                    )
+            }
+        r.copy(ms = System.currentTimeMillis() - start)
+    }
+
+    /** Assemble a report. `mode` = `quick` (startup-safe subset) or `full`
+      * (everything except opt-in groups); `probeGroups` names the opt-in
+      * groups to include (`ai`). */
+    def run(
+        mode: String,
+        probeGroups: Set[String],
+        clients: Map[String, String],
+        probes: Probes,
+        slots: Slots,
+        serverVersion: String
+    ): Report = {
+        val quick = mode != null && mode.equalsIgnoreCase("quick")
+        val selected = checks(probes, slots, serverVersion, clients).filter { c =>
+            c.optInGroup match {
+                case Some(g) => probeGroups.contains(g)
+                case None => !quick || c.startupSafe
+            }
+        }
+        val results = selected.map(runOne)
+        Report(if (quick) "quick" else "full", Map("server" -> serverVersion) ++ clients, results)
+    }
+
+    /** Boot-time subset: one warn line per non-ok check. Anything that
+      * throws is caught here — a doctor bug must never block boot. */
+    def runStartup(probes: Probes, slots: Slots, serverVersion: String): Seq[CheckResult] = {
+        try {
+            val results = checks(probes, slots, serverVersion, Map.empty, startup = true).filter(c => c.startupSafe && c.optInGroup.isEmpty).map(runOne)
+            results.foreach { r =>
+                if (r.status == StatusWarn || r.status == StatusError)
+                    logger.warn("DOCTOR " + r.id + ": " + r.detail + (if (r.remediation.nonEmpty) " — " + r.remediation else ""))
+                else
+                    logger.info("DOCTOR " + r.id + ": " + r.status + " — " + r.detail)
+            }
+            results
+        } catch {
+            case e: Exception =>
+                logger.warn("DOCTOR startup checks failed to run (continuing): " + e.getMessage)
+                Nil
+        }
+    }
+
+    // --------------------------------------------------------- live wiring
+
+    @volatile private var configuredSlots: Slots = Slots("", "", "")
+
+    /** Called once from StartupRunner with the configured AI slot secret names. */
+    def configure(slots: Slots): Unit = configuredSlots = slots
+
+    def slots: Slots = configuredSlots
+
+    /** Real probes against this server's environment. */
+    object LiveProbes extends Probes {
+        private def readAll(conn: java.net.HttpURLConnection): String = {
+            val stream = if (conn.getResponseCode >= 400) conn.getErrorStream else conn.getInputStream
+            if (stream == null) ""
+            else
+                try new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+                finally stream.close()
+        }
+
+        def httpGet(url: String, timeoutMs: Int): (Int, String) = {
+            val conn = new java.net.URL(url).openConnection().asInstanceOf[java.net.HttpURLConnection]
+            conn.setConnectTimeout(timeoutMs)
+            conn.setReadTimeout(timeoutMs)
+            conn.setRequestMethod("GET")
+            try { (conn.getResponseCode, readAll(conn)) }
+            finally conn.disconnect()
+        }
+
+        def vaultLookupSelf(): Option[Map[String, String]] = {
+            try {
+                val token = VaultSecretsUtilBuilder.resolveToken()
+                val conn = new java.net.URL(VaultSecretsUtilBuilder.vaultAddress + "/v1/auth/token/lookup-self")
+                    .openConnection().asInstanceOf[java.net.HttpURLConnection]
+                conn.setConnectTimeout(5000)
+                conn.setReadTimeout(5000)
+                conn.setRequestProperty("X-Vault-Token", token)
+                val (status, body) =
+                    try { (conn.getResponseCode, readAll(conn)) }
+                    finally conn.disconnect()
+                if (status != 200) {
+                    logger.debug("Vault lookup-self returned HTTP " + status)
+                    return None
+                }
+                val data = JsonParser.parseString(body).getAsJsonObject.getAsJsonObject("data")
+                Some(data.entrySet().asScala.map(e => e.getKey -> (if (e.getValue.isJsonPrimitive) e.getValue.getAsString else e.getValue.toString)).toMap)
+            } catch {
+                case e: Exception =>
+                    logger.debug("Vault lookup-self failed: " + e.getMessage)
+                    None
+            }
+        }
+
+        def secret(name: String): Option[Map[String, String]] =
+            if (name == null || name.isEmpty) None
+            else SecretsUtil.getSecretMap(name).map(_.asScala.toMap)
+
+        def apiKeyResolves(provider: String, rawKey: String): Boolean =
+            try {
+                val env = DatrisEnvironment.values
+                AIUtil.resolveApiKey(rawKey, provider, env.multiTenant, env.environment).nonEmpty
+            } catch { case _: Exception => false }
+
+        def classPresent(className: String): Boolean =
+            try { Class.forName(className); true }
+            catch { case _: Throwable => false }
+
+        def pipelineSources(): List[(String, String)] =
+            try {
+                PipelineConfigIO.readAll(DatrisEnvironment.values.pipelineTableName)
+                    .filter(c => c.source != null && c.source.databaseAttributes != null)
+                    .map(c => (c.name, c.source.databaseAttributes.`type`))
+            } catch {
+                case e: Exception =>
+                    logger.debug("pipeline scan for doctor failed: " + e.getMessage)
+                    Nil
+            }
+
+        def diskUsage(path: String): Option[(Long, Long)] =
+            try {
+                if (path == null) return None
+                val p = java.nio.file.Paths.get(path)
+                if (!java.nio.file.Files.exists(p)) return None
+                val store = java.nio.file.Files.getFileStore(p)
+                Some((store.getTotalSpace, store.getUsableSpace))
+            } catch { case _: Exception => None }
+
+        def envSeen(names: Seq[String]): Map[String, Boolean] =
+            names.map(n => n -> sys.env.get(n).exists(_.nonEmpty)).toMap
+
+        def chatSlots(): Seq[(String, AIConfig)] = {
+            val env = DatrisEnvironment.values
+            val primary = Option(env.aiConfig).map(c => ("ai-primary", c)).toSeq
+            val codegen = env.codegenAiConfig.map(c => ("codegen", c)).toSeq
+            primary ++ codegen
+        }
+
+        def probeChat(config: AIConfig, timeoutMs: Int): (Int, String) =
+            ai.datris.util.aiutil.AIHttp.probeModel(config, timeoutMs)
+
+        def probeEmbedding(provider: String, endpoint: String, model: String, apiKey: String, timeoutMs: Int): (Int, String) = {
+            val env = DatrisEnvironment.values
+            val key = AIUtil.resolveApiKey(apiKey, provider, env.multiTenant, env.environment)
+            ai.datris.util.aiutil.AIHttp.probeEmbedding(provider, endpoint, model, key, timeoutMs)
+        }
+    }
+
+    def runLive(mode: String, probeGroups: Set[String], clients: Map[String, String]): Report =
+        run(mode, probeGroups, clients, LiveProbes, configuredSlots, ai.datris.build.sbt.BuildInfo.version)
+
+    def runStartupLive(): Seq[CheckResult] =
+        runStartup(LiveProbes, configuredSlots, ai.datris.build.sbt.BuildInfo.version)
+}

--- a/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/VaultSecretsUtil.scala
@@ -50,8 +50,13 @@ class VaultSecretsUtil(val vault: Vault) extends SecretsManagerUtility {
 }
 
 object VaultSecretsUtilBuilder {
+
+    /** Vault base URL the server talks to (also used by the doctor's raw
+      * `lookup-self` probe, which the KV-v2 client can't express). */
+    def vaultAddress: String = sys.env.getOrElse("VAULT_ADDR", "http://127.0.0.1:8200")
+
     def build(): SecretsManagerUtility = {
-        val address = sys.env.getOrElse("VAULT_ADDR", "http://127.0.0.1:8200")
+        val address = vaultAddress
         val token = resolveToken()
 
         val config = new VaultConfig()
@@ -69,7 +74,7 @@ object VaultSecretsUtilBuilder {
       * file never appears in `docker inspect`/process env the way a value does.
       * Falls back to the VAULT_TOKEN env var for setups that still pass it
       * directly (local dev, existing deployments). */
-    private def resolveToken(): String = {
+    private[util] def resolveToken(): String = {
         val fromFile = sys.env.get("VAULT_TOKEN_FILE")
             .map(_.trim)
             .filter(_.nonEmpty)

--- a/datrisserver/src/main/scala/ai/datris/util/aiutil/AIHttp.scala
+++ b/datrisserver/src/main/scala/ai/datris/util/aiutil/AIHttp.scala
@@ -608,4 +608,71 @@ object AIHttp {
         val client = getClient(aiConfig.provider)
         executeWithRetry(client, () => buildHttpPost(aiConfig, jsonBody, aiConfig.endpoint), aiConfig.model)
     }
+
+    // ---------------------------------------------------------------- doctor
+
+    private val probeRequestConfig: RequestConfig = RequestConfig
+        .custom()
+        .setConnectTimeout(10000)
+        .setConnectionRequestTimeout(10000)
+        .setSocketTimeout(10000)
+        .build()
+
+    /** Smallest request the provider will accept: a one-message chat with a
+      * 16-token ceiling. Returns (status, body snippet); throws on connect or
+      * read failure. No retry, no shared client — the doctor's opt-in
+      * reachability probe, never on the request path. */
+    def probeModel(aiConfig: AIConfig, timeoutMs: Int): (Int, String) = {
+        val user = new JsonObject()
+        user.addProperty("role", "user")
+        user.addProperty("content", "ping")
+        val arr = new JsonArray()
+        arr.add(user)
+        val requestObj = new JsonObject()
+        requestObj.addProperty("model", aiConfig.model)
+        val endpoint =
+            if (usesResponsesApi(aiConfig)) {
+                requestObj.add("input", arr)
+                requestObj.addProperty("max_output_tokens", 16)
+                responsesEndpointFor(aiConfig)
+            } else {
+                requestObj.add("messages", arr)
+                addTokenLimit(requestObj, aiConfig.provider, aiConfig.model, 16)
+                aiConfig.endpoint
+            }
+        executeProbe(buildHttpPost(aiConfig, requestObj.toString, endpoint), timeoutMs)
+    }
+
+    /** One-input embedding request for hosted embedding providers (openai,
+      * azure); bundled TEI/Ollama are covered by their own presence probe. */
+    def probeEmbedding(provider: String, endpoint: String, model: String, apiKey: String, timeoutMs: Int): (Int, String) = {
+        val input = new JsonArray()
+        input.add("ping")
+        val requestObj = new JsonObject()
+        requestObj.addProperty("model", model)
+        requestObj.add("input", input)
+        val httpPost = new HttpPost(endpoint)
+        if (provider.toLowerCase == "azure") {
+            val envValues = DatrisEnvironment.current
+            val auth = AzureEntraSupport.resolveAuth(apiKey, envValues.environment, envValues.multiTenant)
+            AzureEntraSupport.authHeaders(auth).foreach { case (name, value) => httpPost.addHeader(name, value) }
+        } else if (apiKey != null && apiKey.nonEmpty)
+            httpPost.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+        httpPost.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        httpPost.setEntity(new StringEntity(requestObj.toString, StandardCharsets.UTF_8))
+        executeProbe(httpPost, timeoutMs)
+    }
+
+    private def executeProbe(httpPost: HttpPost, timeoutMs: Int): (Int, String) = {
+        val cfg = RequestConfig.copy(probeRequestConfig).setConnectTimeout(timeoutMs).setSocketTimeout(timeoutMs).build()
+        val client = HttpClients.custom().setDefaultRequestConfig(cfg).build()
+        try {
+            val response = client.execute(httpPost)
+            try {
+                val status = response.getStatusLine.getStatusCode
+                val body = Option(response.getEntity).map(e => EntityUtils.toString(e, StandardCharsets.UTF_8)).getOrElse("")
+                (status, body.take(600))
+            } finally response.close()
+        } finally client.close()
+    }
 }

--- a/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/auth/MCPToolRoutesSpec.scala
@@ -33,7 +33,7 @@ class MCPToolRoutesSpec extends AnyFunSuite {
     )
 
     test("catalog has one row per MCP tool, no duplicates") {
-        assert(MCPToolRoutes.allToolNames.size == 73)
+        assert(MCPToolRoutes.allToolNames.size == 74)
         assert(MCPToolRoutes.allToolNames.distinct.size == MCPToolRoutes.allToolNames.size)
     }
 
@@ -42,6 +42,12 @@ class MCPToolRoutesSpec extends AnyFunSuite {
         assert(CapabilityRoutes.lookup("GET", "/api/v1/lineage") == RouteCheck.Require("metadata", "read"))
         assert(CapabilityRoutes.lookup("GET", "/api/v1/lineage/pipeline/example") == RouteCheck.Require("metadata", "read"))
         assert(CapabilityRoutes.lookup("GET", "/api/v1/catalog/find") == RouteCheck.Require("metadata", "read"))
+    }
+
+    test("doctor route is capability-mapped as config:read, not public") {
+        assert(CapabilityRoutes.lookup("GET", "/api/v1/doctor") == RouteCheck.Require("config", "read"))
+        assert(MCPToolRoutes.allowedTools(key("config:read")).contains("run_doctor"))
+        assert(!MCPToolRoutes.allowedTools(ragBuilder).contains("run_doctor"))
     }
 
     test("drift guard: every Mapped row resolves in CapabilityRoutes") {

--- a/datrisserver/src/test/scala/ai/datris/util/DoctorServiceSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/DoctorServiceSpec.scala
@@ -60,6 +60,12 @@ class DoctorServiceSpec extends AnyFunSuite {
         assert(r.remediation.contains("--force-recreate vault"))
     }
 
+    test("vault.token_ttl: a token freshly clamped to Vault's 768h default ceiling is a warn") {
+        val r = new VaultTokenTtlCheck(new FakeProbes(lookup = Some(Map("ttl" -> "2764800", "period" -> "315360000")))).run()
+        assert(r.status == "warn")
+        assert(r.detail.contains("clamped"))
+    }
+
     test("vault.token_ttl: under seven days is an error") {
         val r = new VaultTokenTtlCheck(new FakeProbes(lookup = Some(Map("ttl" -> "300000", "period" -> "315360000")))).run()
         assert(r.status == "error")

--- a/datrisserver/src/test/scala/ai/datris/util/DoctorServiceSpec.scala
+++ b/datrisserver/src/test/scala/ai/datris/util/DoctorServiceSpec.scala
@@ -1,0 +1,230 @@
+package ai.datris.util
+
+/*
+Datris
+Copyright (C) 2026 Datris (https://datris.ai)
+ */
+
+import ai.datris.model.AIConfig
+import ai.datris.util.DoctorService._
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Each doctor check against a fake probe: the rule that fires, the status it
+  * fires at, and the remediation text an operator will actually see. */
+class DoctorServiceSpec extends AnyFunSuite {
+
+    private val slots = Slots("oss/ai-primary", "oss/codegen", "oss/embedding")
+
+    private val goodPrimary =
+        Map("provider" -> "anthropic", "endpoint" -> "https://api.anthropic.com/v1/messages", "model" -> "claude-fable-5-1", "apiKey" -> "sk-ant")
+    private val goodCodegen =
+        Map("provider" -> "anthropic", "endpoint" -> "https://api.anthropic.com/v1/messages", "model" -> "claude-opus-5", "apiKey" -> "sk-ant")
+    private val teiEmbedding = Map("provider" -> "tei", "endpoint" -> "http://tei:80/v1/embeddings", "model" -> "bge-m3")
+
+    /** A probe where everything is healthy; tests override one field. */
+    class FakeProbes(
+        var lookup: Option[Map[String, String]] = Some(Map("ttl" -> "315000000", "period" -> "315360000")),
+        var secrets: Map[String, Map[String, String]] = Map("oss/ai-primary" -> goodPrimary, "oss/codegen" -> goodCodegen, "oss/embedding" -> teiEmbedding),
+        var classes: Set[String] = Set.empty,
+        var pipelines: List[(String, String)] = Nil,
+        var http: Map[String, (Int, String)] = Map(
+            "http://tei:80/health" -> (200, "{}"),
+            "http://tei:80/info" -> (200, "{\"model_id\":\"BAAI/bge-m3\"}")
+        ),
+        var disk: Map[String, (Long, Long)] = Map("/srv" -> (100L, 50L)),
+        var chat: Seq[(String, AIConfig)] = Nil,
+        var chatResponses: Map[String, (Int, String)] = Map.empty,
+        var keyStoreResolves: Boolean = false
+    ) extends Probes {
+        def vaultLookupSelf(): Option[Map[String, String]] = lookup
+        def secret(name: String): Option[Map[String, String]] = secrets.get(name)
+        def apiKeyResolves(provider: String, rawKey: String): Boolean = keyStoreResolves
+        def classPresent(className: String): Boolean = classes.contains(className)
+        def pipelineSources(): List[(String, String)] = pipelines
+        def httpGet(url: String, timeoutMs: Int): (Int, String) =
+            http.getOrElse(url, throw new java.net.ConnectException("Connection refused: " + url))
+        def diskUsage(path: String): Option[(Long, Long)] = disk.get(path)
+        def envSeen(names: Seq[String]): Map[String, Boolean] = names.map(n => n -> (n == "DATRIS_ENV")).toMap
+        def chatSlots(): Seq[(String, AIConfig)] = chat
+        def probeChat(config: AIConfig, timeoutMs: Int): (Int, String) =
+            chatResponses.getOrElse(config.model, throw new java.net.SocketTimeoutException("read timed out"))
+        def probeEmbedding(provider: String, endpoint: String, model: String, apiKey: String, timeoutMs: Int): (Int, String) = (200, "{}")
+    }
+
+    // 1. vault.token_ttl
+    test("vault.token_ttl: 10y period with 28d ttl is the clamp — warn") {
+        val r = new VaultTokenTtlCheck(new FakeProbes(lookup = Some(Map("ttl" -> "2419200", "period" -> "315360000")))).run()
+        assert(r.status == "warn")
+        assert(r.detail.contains("clamped"))
+        assert(r.remediation.contains("max_lease_ttl"))
+        assert(r.remediation.contains("--force-recreate vault"))
+    }
+
+    test("vault.token_ttl: under seven days is an error") {
+        val r = new VaultTokenTtlCheck(new FakeProbes(lookup = Some(Map("ttl" -> "300000", "period" -> "315360000")))).run()
+        assert(r.status == "error")
+        assert(r.detail.contains("expires in 3d"))
+    }
+
+    test("vault.token_ttl: ttl spanning the period is ok; no lookup is a skip; root token has no expiry") {
+        assert(new VaultTokenTtlCheck(new FakeProbes()).run().status == "ok")
+        assert(new VaultTokenTtlCheck(new FakeProbes(lookup = None)).run().status == "skip")
+        val root = new VaultTokenTtlCheck(new FakeProbes(lookup = Some(Map("ttl" -> "0", "period" -> "0")))).run()
+        assert(root.status == "ok" && root.detail.contains("no expiry"))
+    }
+
+    // 2. vault.ai_slots
+    test("vault.ai_slots: missing oss/codegen is an error naming the vault kv put fix") {
+        val p = new FakeProbes()
+        p.secrets = p.secrets - "oss/codegen"
+        val r = new VaultAiSlotsCheck(p, slots).run()
+        assert(r.status == "error")
+        assert(r.detail.contains("oss/codegen"))
+        assert(r.remediation.contains("vault kv put secret/oss/codegen"))
+    }
+
+    test("vault.ai_slots: present but empty model names the field") {
+        val p = new FakeProbes()
+        p.secrets = p.secrets + ("oss/codegen" -> (goodCodegen + ("model" -> "")))
+        val r = new VaultAiSlotsCheck(p, slots).run()
+        assert(r.status == "error")
+        assert(r.detail.contains("'model'"))
+        assert(r.detail.contains("oss/codegen"))
+    }
+
+    test("vault.ai_slots: keyless providers and a key resolved from the shared store are fine") {
+        val p = new FakeProbes()
+        p.secrets = p.secrets + ("oss/ai-primary" -> (goodPrimary - "apiKey"))
+        assert(new VaultAiSlotsCheck(p, slots).run().status == "error")
+        p.keyStoreResolves = true
+        val r = new VaultAiSlotsCheck(p, slots).run()
+        assert(r.status == "ok", r.detail)
+        assert(r.detail.contains("embedding (tei/bge-m3)"))
+    }
+
+    // 3. jdbc.mssql_driver
+    test("jdbc.mssql_driver: absent driver is ok until a pipeline uses type: mssql") {
+        val p = new FakeProbes()
+        assert(new JdbcMssqlDriverCheck(p).run().status == "ok")
+        p.pipelines = List(("orders", "postgres"), ("legacy_erp", "mssql"))
+        val r = new JdbcMssqlDriverCheck(p).run()
+        assert(r.status == "error")
+        assert(r.detail.contains("legacy_erp"))
+        assert(!r.detail.contains("orders"))
+        p.classes = Set("com.microsoft.sqlserver.jdbc.SQLServerDriver")
+        assert(new JdbcMssqlDriverCheck(p).run().status == "ok")
+    }
+
+    // 4. ai.embedding_model
+    test("ai.embedding_model: TEI serving the configured model is ok; a different model is an error") {
+        val p = new FakeProbes()
+        assert(new AiEmbeddingModelCheck(p, slots).run().status == "ok")
+        p.http = p.http + ("http://tei:80/info" -> (200, "{\"model_id\":\"BAAI/bge-large-en\"}"))
+        val r = new AiEmbeddingModelCheck(p, slots).run()
+        assert(r.status == "error")
+        assert(r.detail.contains("serving `BAAI/bge-large-en`"))
+        assert(r.detail.contains("`bge-m3`"))
+    }
+
+    test("ai.embedding_model: Ollama without the model pulled is an error with the pull command") {
+        val p = new FakeProbes()
+        p.secrets = p.secrets + ("oss/embedding" -> Map("provider" -> "ollama", "endpoint" -> "http://ollama:11434/v1/embeddings", "model" -> "bge-m3"))
+        p.http = Map("http://ollama:11434/api/tags" -> (200, "{\"models\":[{\"name\":\"llama3:latest\"}]}"))
+        val r = new AiEmbeddingModelCheck(p, slots).run()
+        assert(r.status == "error")
+        assert(r.remediation == "docker compose exec ollama ollama pull bge-m3")
+        p.http = Map("http://ollama:11434/api/tags" -> (200, "{\"models\":[{\"name\":\"bge-m3:latest\"}]}"))
+        assert(new AiEmbeddingModelCheck(p, slots).run().status == "ok")
+    }
+
+    test("ai.embedding_model: unreachable service is an error on demand but a skip at startup") {
+        val p = new FakeProbes(http = Map.empty)
+        assert(new AiEmbeddingModelCheck(p, slots).run().status == "error")
+        assert(new AiEmbeddingModelCheck(p, slots, startup = true).run().status == "skip")
+    }
+
+    // 5. disk.usage
+    test("disk.usage: 84% ok, 85% warn, 95% error") {
+        def at(pct: Long) = new DiskUsageCheck(new FakeProbes(disk = Map("/srv" -> (100L, 100L - pct))), Seq("/srv")).run()
+        assert(at(84).status == "ok")
+        assert(at(85).status == "warn")
+        assert(at(95).status == "error")
+        assert(at(85).detail.contains("85% used"))
+    }
+
+    // version.skew
+    test("version.skew: same major.minor ok, patch drift ok, minor drift warn, unknown warn") {
+        assert(new VersionSkewCheck("1.28.2", Map.empty).run().status == "ok")
+        assert(new VersionSkewCheck("1.28.2", Map("cli" -> "1.28.1")).run().status == "ok")
+        val r = new VersionSkewCheck("1.28.2", Map("cli" -> "1.28.2", "mcp" -> "1.27.0")).run()
+        assert(r.status == "warn")
+        assert(r.detail.contains("mcp differ"))
+        val u = new VersionSkewCheck("1.28.2", Map("ui" -> "unknown")).run()
+        assert(u.status == "warn")
+        assert(u.detail.contains("ui version unknown"))
+    }
+
+    // ai.model_reachable (opt-in)
+    test("ai.model_reachable: 404 is a model error, 401 a key error, timeout a warn, 200 ok") {
+        val cfg = AIConfig("anthropic", "https://api.anthropic.com/v1/messages", "claude-fable-5-1", "k")
+        val p = new FakeProbes(chat = Seq(("ai-primary", cfg)), chatResponses = Map("claude-fable-5-1" -> (404, "model not found")))
+        val notFound = new AiModelReachableCheck(p, slots).run()
+        assert(notFound.status == "error")
+        assert(notFound.detail.contains("model not found"))
+        p.chatResponses = Map("claude-fable-5-1" -> (401, "invalid x-api-key"))
+        assert(new AiModelReachableCheck(p, slots).run().detail.contains("rejected the API key"))
+        p.chatResponses = Map.empty
+        val timeout = new AiModelReachableCheck(p, slots).run()
+        assert(timeout.status == "warn")
+        assert(timeout.detail.contains("no response within 10s"))
+        p.chatResponses = Map("claude-fable-5-1" -> (200, "{}"))
+        assert(new AiModelReachableCheck(p, slots).run().status == "ok")
+    }
+
+    // 6. runStartup with a throwing check
+    test("runOne: a check that throws becomes an error row, not a failed report") {
+        val boom = new Check {
+            val id = "test.boom"
+            val startupSafe = true
+            def run(): CheckResult = throw new IllegalStateException("kaboom")
+        }
+        val r = DoctorService.runOne(boom)
+        assert(r.status == "error")
+        assert(r.detail.contains("kaboom"))
+    }
+
+    test("runStartup: never runs the opt-in AI probe and survives a probe that throws") {
+        val p = new FakeProbes(chat = Seq(("ai-primary", AIConfig("anthropic", "e", "m", "k")))) {
+            override def diskUsage(path: String): Option[(Long, Long)] = throw new RuntimeException("disk exploded")
+        }
+        val results = DoctorService.runStartup(p, slots, "1.28.2")
+        assert(results.nonEmpty)
+        assert(!results.exists(_.id == "ai.model_reachable"))
+        assert(results.find(_.id == "disk.usage").exists(_.status == "error"))
+    }
+
+    // 7. report shape
+    test("run: full mode includes every non-opt-in check, quick mode only the startup subset, ?probes=ai adds the AI probe") {
+        val p = new FakeProbes()
+        val full = DoctorService.run("full", Set.empty, Map("cli" -> "1.28.2"), p, slots, "1.28.2")
+        assert(full.checks.map(_.id) == Seq(
+            "vault.token_ttl",
+            "vault.ai_slots",
+            "jdbc.mssql_driver",
+            "ai.embedding_model",
+            "disk.usage",
+            "version.skew",
+            "env.seen"
+        ))
+        val withAi = DoctorService.run("full", Set("ai"), Map.empty, p, slots, "1.28.2")
+        assert(withAi.checks.map(_.id).contains("ai.model_reachable"))
+        val quick = DoctorService.run("quick", Set.empty, Map.empty, p, slots, "1.28.2")
+        assert(quick.mode == "quick")
+        assert(quick.checks.forall(_.id != "ai.model_reachable"))
+        val json = full.toJson
+        assert(json.contains("\"doctorVersion\":1"))
+        assert(json.contains("\"surface\":{\"server\":\"1.28.2\",\"cli\":\"1.28.2\"}"))
+        assert(json.contains("\"summary\":{\"ok\":"))
+        assert(!json.contains("sk-ant"), "secret values must never appear in the report")
+    }
+}

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -427,6 +427,31 @@ Get the server version.
 datris version
 ```
 
+---
+
+### `datris doctor`
+
+Operational self-check: the server's own checks (Vault token expiry, AI slot secrets, embedding model loaded, disk, version skew) plus host checks that need Docker (anonymous volumes, container env drift, orphaned containers, stale source build). Every finding prints the command that fixes it; nothing is changed. See [Doctor](/doctor) for the full check list.
+
+```bash
+datris doctor                   # human-readable report
+datris doctor --json            # the same report as JSON
+datris doctor --probes ai       # also confirm each AI model answers (spends a few tokens)
+datris doctor --pre-upgrade     # host checks only — run before every upgrade
+```
+
+| Option | Description |
+|---|---|
+| `--pre-upgrade` | Host checks plus the AI slot secrets via the vault container; works with the server stopped. Prints the upgrade command when clean. |
+| `--probes ai` | Opt in to the AI reachability probe |
+| `--json` | Print the merged report as JSON |
+| `--project-dir DIR` | Directory holding `docker-compose.yml` and `.env` (default: current directory) |
+| `--compose-file FILE` | Compose file to inspect (e.g. `docker-compose.standalone.yml`) |
+
+Unlike the other commands, `doctor` calls the server's REST API directly (`DATRIS_URL`, default `http://localhost:8080`; `DATRIS_API_KEY` when API keys are on) — a dead MCP server is itself a finding, not a reason to fail.
+
+Exit codes: `0` all ok, `1` any warning, `2` any error, `3` server unreachable (host checks still ran).
+
 ## Pipeline Name Auto-Detection
 
 When `--pipeline` is not specified, the CLI derives the pipeline name from the filename:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,7 @@
               "agent-policy",
               "incidents",
               "monitoring",
+              "doctor",
               "notifications"
             ]
           },

--- a/docs/doctor.mdx
+++ b/docs/doctor.mdx
@@ -1,0 +1,101 @@
+---
+title: "Doctor"
+description: "Operational self-check for a Datris deployment"
+---
+
+`datris doctor` checks a running deployment for the failure modes that are cheap to detect and expensive to miss: a Vault token about to expire, an AI slot secret missing so the server won't boot after an upgrade, an embedding model that was never pulled, a disk about to fill, data sitting on an anonymous Docker volume, a container still running with an old `.env`, a mixed-version stack. Every finding names the command that fixes it. Doctor never changes anything.
+
+## Where it runs
+
+| Surface | What it covers | When |
+|---|---|---|
+| Server log at boot | The cheap subset (Vault token, AI secrets, embedding model, disk) as `DOCTOR` warn lines | Every start; a fresh install logs nothing |
+| **Configuration → Doctor** | Every server-side check, with an optional AI probe | On demand |
+| `run_doctor` MCP tool | Same as the UI; for an agent diagnosing a failure | On demand — not part of the normal workflow |
+| `datris doctor` CLI | Server-side checks **plus** host checks that need Docker | On demand, and `--pre-upgrade` before every upgrade |
+
+The server-side report is also available at `GET /api/v1/doctor` for scripts. It is not a public endpoint — it names environment keys, Vault paths and model ids — so an API key with `config:read` is required when [API keys](/api-keys) are on.
+
+## The checks
+
+| Check | Fires when | Fix it prints |
+|---|---|---|
+| `vault.token_ttl` | The server's Vault token expires within 7 days (error), or a 10-year periodic token was clamped to Vault's default 32-day ceiling (warn) | Raise `max_lease_ttl` in the Vault config, recreate the vault container, restart the server |
+| `vault.ai_slots` | An AI slot secret is missing or lacks provider / endpoint / model / key | The exact `vault kv put` or `vault kv patch` |
+| `jdbc.mssql_driver` | A pipeline uses `type: mssql` but the driver is not bundled | Add the driver and rebuild, or change the source type |
+| `ai.embedding_model` | The bundled embedding service is serving a different model than the embedding slot names, or Ollama hasn't pulled it | `ollama pull …` or align the slot with the served model |
+| `ai.model_reachable` | **Opt-in.** A chat or embedding slot's key is rejected, the model id is unknown, or the endpoint doesn't answer within 10 s | Fix the key / pick a current model in Configuration → AI Providers |
+| `disk.usage` | The disk holding the server or Docker's data root is ≥ 85% full (warn) or ≥ 95% (error) | Prune images and builder cache; inspect the pip-cache and object-store volumes |
+| `version.skew` | Server, UI, MCP server and CLI differ in major.minor, or the UI image carries no version stamp | Pull all images; upgrade the CLI |
+| `env.seen` | Never — reports which hardening variables reached the server | — |
+| `volumes.anonymous` | A stateful service (postgres, mongodb, minio, vault, tei, kafka) stores data on an anonymous volume that `docker compose down` will orphan | Add a named volume and copy the data across |
+| `volumes.dangling` | A dangling anonymous volume holds a recognizable Postgres / MongoDB / MinIO data directory — data left behind by a container recreate | Inspect before pruning; copy into the named volume to recover |
+| `vault.hcl_drift` | `docker/vault.hcl` changed after the vault container started (Vault reads its config only at start) | `docker compose up -d --force-recreate vault` |
+| `env.not_forwarded` | `.env` sets a key that no service in the compose file references, so the value never reaches a container | Add it to the service's `environment:` block |
+| `env.container_drift` | A datris container was created with a different `.env` than the current one (`restart` does not reload env). Error when a credential-looking key differs | `docker compose up -d --force-recreate --no-deps <service>` |
+| `compose.orphans` | Containers from a previous compose file are still present and may hold ports | `docker compose up -d --remove-orphans` |
+| `build.stale_jar` | Building from source, and the running server's git commit or build time is behind the checkout | Rebuild with `--no-cache` |
+| `mcp.reachable` | The MCP server's SSE endpoint doesn't answer within 3 s | Check the `mcp-server` container |
+
+Checks below the line run only from the CLI on the machine running Docker; the UI and MCP surfaces report them as not applicable. Secret values never appear in any output — only key names.
+
+## CLI
+
+```bash
+datris doctor                      # server checks + host checks, human-readable
+datris doctor --json               # the same report as JSON
+datris doctor --probes ai          # also send a minimal request through each AI slot (spends a few tokens)
+datris doctor --pre-upgrade        # host checks only; safe with the server stopped
+```
+
+Run it from the directory that holds `docker-compose.yml` and `.env`, or point it there with `--project-dir` (and `--compose-file` for the standalone file). Unlike the other CLI commands, `doctor` talks to the server directly rather than through the MCP server — a dead MCP server is itself a finding. Set `DATRIS_URL` if the server is not on `http://localhost:8080`, and `DATRIS_API_KEY` when API keys are on.
+
+Exit codes make it scriptable:
+
+| Code | Meaning |
+|---|---|
+| 0 | Everything ok |
+| 1 | At least one warning |
+| 2 | At least one error |
+| 3 | Server unreachable — host checks ran, server checks skipped |
+
+Skipped checks (Docker not on this machine, a service not running) never affect the exit code.
+
+## Before an upgrade
+
+```bash
+datris doctor --pre-upgrade
+```
+
+This runs the host checks plus a read of the three AI slot secrets through the vault container, so a missing secret is caught **before** the new server crash-loops on it, and an anonymous volume is caught before `--remove-orphans` could drop it. When nothing is at error level it prints the upgrade command. See [Upgrading](/installation#upgrading).
+
+## Report format
+
+All surfaces produce the same JSON:
+
+```json
+{
+  "doctorVersion": 1,
+  "ranAt": "2026-09-10T14:00:00Z",
+  "mode": "full",
+  "surface": { "server": "1.29.0", "cli": "1.29.0" },
+  "summary": { "ok": 12, "warn": 1, "error": 0, "skip": 2 },
+  "checks": [
+    {
+      "id": "vault.token_ttl",
+      "status": "warn",
+      "severity": "warn",
+      "detail": "ttl 28d, period 3650d — clamped",
+      "remediation": "…",
+      "surface": "server",
+      "ms": 12
+    }
+  ]
+}
+```
+
+`status` is one of `ok`, `warn`, `error`, `skip`; `surface` is `server`, `host`, or `cli`.
+
+## Turning off the boot-time lines
+
+The startup subset only logs; it never blocks a start. To silence it, set `DOCTOR_ONSTARTUP=false` in the datris service environment. The on-demand surfaces are unaffected.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -111,6 +111,18 @@ refreshing the Compose file itself, since a new release can rename, add, or drop
 services. How you do it depends on how you installed. In every case your data is
 preserved — it lives in Docker volumes that survive an upgrade.
 
+**Step 0 — check the deployment first.** From the directory holding your
+`docker-compose.yml` and `.env`, run the pre-upgrade self-check. It catches the
+things an upgrade turns into an outage: data on an anonymous volume that
+`--remove-orphans` would drop, a missing AI slot secret the new server would
+crash-loop on, a disk too full to pull images, a container still running with a
+stale `.env`. Nothing is changed; it prints the fix for each finding and the
+upgrade command when the deployment is clean. See [Doctor](/doctor).
+
+```bash
+datris doctor --pre-upgrade
+```
+
 **Installer (the `curl … | sh` Quick Start):** just re-run the install command.
 It re-downloads the latest compose file and runtime scripts, leaves your `.env`
 and data untouched, pulls the new images, and restarts.

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -39,6 +39,7 @@ The MCP server exposes resources that agents can read on demand for detailed doc
 | `apply_dest_types` | Apply destination column types to an all-string pipeline (requires explicit user approval). `fields` must list every destination column with its intended type (`string`, `boolean`, `int`, `bigint`, `float`, `double`, `date`, `timestamp`); landed data is migrated first and any value that will not cast fails the whole apply with nothing changed |
 | `get_version` | Get pipeline server version |
 | `check_service_health` | Check which backend services are up, down, or not configured (slow — use for diagnostics only) |
+| `run_doctor` | Operational self-check: Vault token expiry, AI slot secrets, embedding model, disk, version skew, optional AI probe — each finding with its fix (diagnostics only; see [Doctor](/doctor)) |
 
 ### Vector Database Search
 

--- a/mcp-server/cli.py
+++ b/mcp-server/cli.py
@@ -22,6 +22,7 @@ import httpx
 from httpx_sse import aconnect_sse
 
 MCP_URL = os.getenv("MCP_SERVER_URL", "http://localhost:3000/sse")
+CLI_VERSION = "1.28.2"
 
 # ── MCP Client (lightweight, sync-wrapped) ────────────────────────────
 
@@ -76,7 +77,7 @@ async def _connect():
     await _post_client.post(_endpoint, json={
         "jsonrpc": "2.0", "id": init_id,
         "method": "initialize",
-        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "datris-cli", "version": "1.28.2"}},
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "datris-cli", "version": CLI_VERSION}},
     })
     await asyncio.wait_for(_responses.get(), 10)
     await _post_client.post(_endpoint, json={"jsonrpc": "2.0", "method": "notifications/initialized"})
@@ -139,7 +140,7 @@ def b64_file(path):
 # ── CLI Commands ──────────────────────────────────────────────────────
 
 @click.group()
-@click.version_option(version="1.28.2")
+@click.version_option(version=CLI_VERSION)
 def cli():
     """Datris CLI — The Data Control Plane for AI Agents"""
     pass
@@ -819,6 +820,42 @@ def tap_update(name, enabled, cron, pipeline, description, endpoint_url, json_ou
 
 
 @cli.command()
+@click.option("--pre-upgrade", is_flag=True, default=False,
+              help="Host checks only (plus the AI slot secrets via the vault container); safe to run with the server stopped. Prints the upgrade command on success.")
+@click.option("--probes", default="", help="Opt-in probe groups, comma-separated. `ai` sends a minimal request through each AI slot (spends a few tokens).")
+@click.option("--json", "json_output", is_flag=True, default=False, help="Print the merged report as JSON")
+@click.option("--compose-file", default=None, help="Compose file to inspect (default: docker-compose.yml in --project-dir)")
+@click.option("--project-dir", default=".", help="Directory holding docker-compose.yml and .env (default: current directory)")
+def doctor(pre_upgrade, probes, json_output, compose_file, project_dir):
+    """Operational self-check: server-side checks via the REST API plus host checks that need Docker.
+
+    Exit codes: 0 all ok, 1 any warning, 2 any error, 3 server unreachable (server checks skipped).
+    Unlike other commands this talks to the server directly (DATRIS_URL, DATRIS_API_KEY) — a dead
+    MCP server is itself a finding.
+    """
+    import doctor as doc
+    runner = doc.Runner(compose_file=compose_file, project_dir=os.path.abspath(project_dir))
+    datris_url = os.getenv("DATRIS_URL", "http://localhost:8080")
+    api_key = os.getenv("DATRIS_API_KEY", "")
+    server_report, version_info, server_error = None, None, None
+    if not pre_upgrade:
+        server_report, version_info, server_error = doc.fetch_server(datris_url, api_key, CLI_VERSION, probes=probes)
+    host = doc.run_host_checks(runner, MCP_URL, version_info=version_info, pre_upgrade=pre_upgrade)
+    report = doc.merge_report(server_report, host, CLI_VERSION, mode="pre-upgrade" if pre_upgrade else "full",
+                              server_error=server_error, datris_url=datris_url)
+    code = doc.exit_code(report, server_unreachable=(server_error is not None))
+    if json_output:
+        click.echo(json.dumps(report, indent=2))
+    else:
+        click.echo(doc.render_human(report))
+        if pre_upgrade and code in (0, 1):
+            click.echo("")
+            click.echo("  Ready to upgrade:")
+            click.echo("    docker compose pull && docker compose up -d --remove-orphans")
+    sys.exit(code)
+
+
+@cli.command()
 @click.option("--json", "json_output", is_flag=True, default=False, help="Return raw JSON")
 def version(json_output):
     """Get server version."""
@@ -827,7 +864,7 @@ def version(json_output):
         click.echo(json.dumps(result, indent=2))
         return
     click.echo(f"  Server: {result.get('text', result) if isinstance(result, dict) else result}")
-    click.echo(f"  CLI: 1.28.2")
+    click.echo(f"  CLI: {CLI_VERSION}")
 
 
 def main():

--- a/mcp-server/doctor.py
+++ b/mcp-server/doctor.py
@@ -1,0 +1,688 @@
+"""Host-side checks for `datris doctor`.
+
+The server answers `GET /api/v1/doctor` with the checks it can run from inside
+the JVM (Vault token TTL, AI slot secrets, embedding model, disk, version
+skew). This module runs the checks that need the Docker socket or the repo
+checkout — anonymous volumes, container env drift, compose orphans, a stale
+jar — and merges both halves into one report with the same shape.
+
+Every check is deterministic, read-only, and prints a remediation command; it
+never runs one. Values from `.env` / container env are never printed — only key
+names (and hashes where two values are compared).
+"""
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+
+DOCTOR_VERSION = 1
+
+# Compose services whose data lives on a volume, and the mount paths that
+# hold it. An anonymous volume at one of these is lost on `down` / container
+# removal (postgres orphaned 28M rows this way). Other anonymous mounts an
+# image declares (vault's /vault/logs) are not data and are ignored.
+STATEFUL_DATA_MOUNTS = {
+    "postgres": ["/var/lib/postgresql/data", "/var/lib/postgresql"],
+    "mongodb": ["/data/db", "/data/configdb"],
+    "minio": ["/data"],
+    "vault": ["/vault/file", "/vault/data"],
+    "tei": ["/data"],
+    "zookeeper": ["/var/lib/zookeeper/data", "/var/lib/zookeeper/log"],
+    "kafka": ["/var/lib/kafka/data"],
+}
+STATEFUL_CONTAINERS = list(STATEFUL_DATA_MOUNTS)
+
+# Services whose container env is compared with the current compose rendering
+# (service name -> default container_name). `restart` does not reload env; a
+# rotated MONGO_PASSWORD kept failing auth every minute until recreate.
+ENV_DRIFT_SERVICES = ["datris", "mcp-server", "datris-tap-runner"]
+
+# Vault slots checked from the host before an upgrade (server may be down).
+AI_SLOT_SECRETS = [("ai-primary", "oss/ai-primary"), ("codegen", "oss/codegen"), ("embedding", "oss/embedding")]
+
+CREDENTIAL_KEY = re.compile(r"(PASSWORD|PASSWD|TOKEN|SECRET|_KEY\b|APIKEY|API_KEY)", re.I)
+ANON_VOLUME = re.compile(r"^[0-9a-f]{64}$")
+
+# Keys `.env` may hold that no compose service is expected to forward.
+ENV_KEYS_NOT_FORWARDED = re.compile(r"^(COMPOSE_|DOCKER_)")
+
+STATUS_ICON = {"ok": "✓", "warn": "!", "error": "✗", "skip": "○"}
+
+
+def result(check_id, status, detail, remediation="", surface="host", ms=0):
+    severity = status if status in ("warn", "error") else "ok"
+    return {
+        "id": check_id,
+        "status": status,
+        "severity": severity,
+        "detail": detail,
+        "remediation": remediation,
+        "surface": surface,
+        "ms": ms,
+    }
+
+
+def _sha(value):
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:8]
+
+
+class Runner:
+    """Thin subprocess wrapper so tests can fake docker/git/df."""
+
+    def __init__(self, compose_file=None, project_dir=None):
+        self.compose_file = compose_file
+        self.project_dir = project_dir or os.getcwd()
+
+    def has_docker(self):
+        return shutil.which("docker") is not None
+
+    def run(self, args, timeout=60, input_text=None):
+        """Return (returncode, stdout, stderr); never raises on a non-zero exit."""
+        try:
+            p = subprocess.run(
+                args, capture_output=True, text=True, timeout=timeout, cwd=self.project_dir, input=input_text
+            )
+            return p.returncode, p.stdout, p.stderr
+        except FileNotFoundError as e:
+            return 127, "", str(e)
+        except subprocess.TimeoutExpired:
+            return 124, "", f"timed out after {timeout}s: {' '.join(args)}"
+
+    def compose(self, args, timeout=60, input_text=None):
+        base = ["docker", "compose"]
+        if self.compose_file:
+            base += ["-f", self.compose_file]
+        return self.run(base + list(args), timeout=timeout, input_text=input_text)
+
+    def compose_file_path(self):
+        if self.compose_file:
+            return self.compose_file
+        for name in ("docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"):
+            p = os.path.join(self.project_dir, name)
+            if os.path.isfile(p):
+                return p
+        return None
+
+
+# ----------------------------------------------------------------- helpers
+
+def parse_dotenv(path):
+    """KEY=VALUE pairs from a .env file; comments and blanks skipped, quotes stripped."""
+    env = {}
+    if not path or not os.path.isfile(path):
+        return env
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                env[key] = value
+    return env
+
+
+def compose_config_json(runner):
+    rc, out, err = runner.compose(["config", "--format", "json"])
+    if rc != 0 or not out.strip():
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def _container_env(runner, container):
+    rc, out, _ = runner.run(["docker", "inspect", "-f", "{{json .Config.Env}}", container])
+    if rc != 0 or not out.strip():
+        return None
+    try:
+        items = json.loads(out.strip()) or []
+    except json.JSONDecodeError:
+        return None
+    env = {}
+    for item in items:
+        k, _, v = item.partition("=")
+        env[k] = v
+    return env
+
+
+def _parse_ps_json(text):
+    """`docker compose ps --format json` prints one object per line on newer
+    Compose and a JSON array on older ones."""
+    text = text.strip()
+    if not text:
+        return []
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, list) else [data]
+    except json.JSONDecodeError:
+        rows = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return rows
+
+
+# ------------------------------------------------------------------ checks
+
+def check_volumes_anonymous(runner):
+    offenders = []
+    seen = []
+    for name in STATEFUL_CONTAINERS:
+        rc, out, _ = runner.run(["docker", "inspect", "-f", "{{json .Mounts}}", name])
+        if rc != 0:
+            continue
+        seen.append(name)
+        try:
+            mounts = json.loads(out.strip()) or []
+        except json.JSONDecodeError:
+            continue
+        data_paths = STATEFUL_DATA_MOUNTS.get(name, [])
+        for m in mounts:
+            dest = (m.get("Destination") or "").rstrip("/")
+            if m.get("Type") == "volume" and ANON_VOLUME.match(m.get("Name", "")) and dest in data_paths:
+                offenders.append(f"{name} ({dest} on {m['Name'][:12]}…)")
+    if not seen:
+        return result("volumes.anonymous", "skip", "no stateful containers found (stack not running?)")
+    if offenders:
+        return result(
+            "volumes.anonymous", "error",
+            "stateful service(s) store data on an anonymous volume; `docker compose down` or a container removal will orphan it: "
+            + "; ".join(offenders),
+            "Add a named volume for the service in docker-compose.yml (see the top-level `volumes:` block), then copy the data across: "
+            "`docker run --rm -v <old>:/src:ro -v <new>:/dst alpine cp -a /src/. /dst/`.",
+        )
+    return result("volumes.anonymous", "ok", f"named volumes on {', '.join(seen)}")
+
+
+def check_volumes_dangling(runner, limit=15):
+    rc, out, err = runner.run(["docker", "volume", "ls", "-qf", "dangling=true"])
+    if rc != 0:
+        return result("volumes.dangling", "skip", f"docker volume ls failed: {err.strip()[:120]}")
+    anon = [v for v in out.split() if ANON_VOLUME.match(v)]
+    if not anon:
+        return result("volumes.dangling", "ok", "no dangling anonymous volumes")
+    found = []
+    for vol in anon[:limit]:
+        rc, listing, _ = runner.run(["docker", "run", "--rm", "-v", f"{vol}:/v:ro", "alpine", "ls", "-A", "/v"], timeout=120)
+        if rc != 0:
+            continue
+        names = set(listing.split())
+        kind = None
+        if "PG_VERSION" in names:
+            kind = "postgres"
+        elif "WiredTiger" in names or "WiredTiger.wt" in names:
+            kind = "mongodb"
+        elif ".minio.sys" in names:
+            kind = "minio"
+        if kind:
+            found.append(f"{vol[:12]}… looks like a {kind} data dir")
+    if found:
+        return result(
+            "volumes.dangling", "warn",
+            f"{len(found)} dangling volume(s) hold recognizable data — possibly orphaned by a container recreate: " + "; ".join(found),
+            "Inspect before pruning: `docker run --rm -v <volume>:/v:ro alpine ls -la /v`. To recover, copy into the service's named volume: "
+            "`docker run --rm -v <old>:/src:ro -v <new>:/dst alpine cp -a /src/. /dst/`.",
+        )
+    return result("volumes.dangling", "ok", f"{len(anon)} dangling anonymous volume(s), none holding recognizable data")
+
+
+def check_vault_hcl_drift(runner):
+    path = os.path.join(runner.project_dir, "docker", "vault.hcl")
+    if not os.path.isfile(path):
+        return result("vault.hcl_drift", "skip", "docker/vault.hcl not in this directory (standalone install?)")
+    rc, started, _ = runner.run(["docker", "inspect", "-f", "{{.State.StartedAt}}", "vault"])
+    if rc != 0:
+        return result("vault.hcl_drift", "skip", "vault container not found")
+    with open(path, "rb") as f:
+        local = f.read()
+    rc, inside, _ = runner.compose(["exec", "-T", "vault", "cat", "/vault/config/vault.hcl"])
+    remediation = "docker compose up -d --force-recreate vault   # then restart datris so it re-mints its token"
+    if rc == 0 and inside and hashlib.sha256(inside.encode("utf-8")).hexdigest() != hashlib.sha256(local).hexdigest():
+        return result(
+            "vault.hcl_drift", "warn",
+            "docker/vault.hcl differs from the file the vault container is running with",
+            remediation,
+        )
+    started_at = _parse_docker_time(started.strip())
+    mtime = os.path.getmtime(path)
+    if started_at and mtime > started_at:
+        return result(
+            "vault.hcl_drift", "warn",
+            "docker/vault.hcl changed after the vault container started; Vault only reads its config at start "
+            "(a raised max_lease_ttl is not in effect until the container is recreated)",
+            remediation,
+        )
+    return result("vault.hcl_drift", "ok", "vault container started after the last change to docker/vault.hcl")
+
+
+def _parse_docker_time(text):
+    """Docker's RFC3339 timestamps carry nanoseconds; trim to what fromisoformat accepts."""
+    if not text or text.startswith("0001-"):
+        return None
+    m = re.match(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})?$", text)
+    if not m:
+        return None
+    frac = (m.group(2) or "")[:6].ljust(6, "0")
+    tz = m.group(3) or "Z"
+    iso = f"{m.group(1)}.{frac}{'+00:00' if tz == 'Z' else tz}"
+    try:
+        return datetime.fromisoformat(iso).timestamp()
+    except ValueError:
+        return None
+
+
+def check_env_not_forwarded(runner):
+    env_path = os.path.join(runner.project_dir, ".env")
+    if not os.path.isfile(env_path):
+        return result("env.not_forwarded", "skip", "no .env in this directory")
+    compose_path = runner.compose_file_path()
+    if not compose_path or not os.path.isfile(compose_path):
+        return result("env.not_forwarded", "skip", "no compose file in this directory")
+    texts = []
+    with open(compose_path, encoding="utf-8", errors="replace") as f:
+        texts.append(f.read())
+    for extra in ("docker-compose.override.yml", "docker-compose.override.yaml"):
+        p = os.path.join(runner.project_dir, extra)
+        if os.path.isfile(p):
+            with open(p, encoding="utf-8", errors="replace") as f:
+                texts.append(f.read())
+    compose_text = "\n".join(texts)
+    env = parse_dotenv(env_path)
+    unreferenced = []
+    for key, value in env.items():
+        if not value or ENV_KEYS_NOT_FORWARDED.match(key):
+            continue
+        if re.search(r"\$\{" + re.escape(key) + r"[:}?-]", compose_text) or re.search(r"\$" + re.escape(key) + r"\b", compose_text):
+            continue
+        unreferenced.append(key)
+    if unreferenced:
+        return result(
+            "env.not_forwarded", "warn",
+            ".env sets " + ", ".join(sorted(unreferenced)) + " but no service in the compose file reads it, so the value never reaches a container",
+            "Add the variable to the right service's `environment:` block in docker-compose.yml (the datris service for DATRIS_* / TAP_* switches), "
+            "then regenerate docker-compose.standalone.yml with `python3 scripts/build-standalone-compose.py`. "
+            "If the key is obsolete, remove it from .env.",
+        )
+    return result("env.not_forwarded", "ok", f"every non-empty .env key ({len(env)} total) is referenced by the compose file")
+
+
+def check_env_container_drift(runner):
+    config = compose_config_json(runner)
+    if not config:
+        return result("env.container_drift", "skip", "docker compose config unavailable (not in a compose project directory?)")
+    services = config.get("services", {})
+    drifted = []
+    compared = []
+    credential_drift = False
+    for svc in ENV_DRIFT_SERVICES:
+        spec = services.get(svc)
+        if not spec:
+            continue
+        container = spec.get("container_name") or svc
+        actual = _container_env(runner, container)
+        if actual is None:
+            continue
+        compared.append(container)
+        expected = spec.get("environment") or {}
+        if isinstance(expected, list):
+            expected = dict(item.partition("=")[::2] for item in expected)
+        keys = []
+        for key, value in expected.items():
+            if value is None:
+                continue
+            want = str(value).lower() if isinstance(value, bool) else str(value)
+            have = actual.get(key)
+            if have is None or have != want:
+                keys.append(key)
+                if CREDENTIAL_KEY.search(key):
+                    credential_drift = True
+        if keys:
+            drifted.append((container, sorted(keys)))
+    if not compared:
+        return result("env.container_drift", "skip", "none of the datris containers are running")
+    if drifted:
+        detail = "; ".join(f"{c} was created with different env than .env/compose now say (keys: {', '.join(k)})" for c, k in drifted)
+        cmd = " ".join(c for c, _ in drifted)
+        return result(
+            "env.container_drift", "error" if credential_drift else "warn",
+            detail + " — `docker compose restart` does not reload env",
+            f"docker compose up -d --force-recreate --no-deps {cmd}",
+        )
+    return result("env.container_drift", "ok", f"container env matches compose for {', '.join(compared)}")
+
+
+def check_compose_orphans(runner):
+    rc, services_out, err = runner.compose(["config", "--services"])
+    if rc != 0:
+        return result("compose.orphans", "skip", f"docker compose config failed: {err.strip()[:120]}")
+    defined = set(services_out.split())
+    rc, ps_out, err = runner.compose(["ps", "-a", "--format", "json"])
+    if rc != 0:
+        return result("compose.orphans", "skip", f"docker compose ps failed: {err.strip()[:120]}")
+    rows = _parse_ps_json(ps_out)
+    orphans = sorted({(r.get("Service") or r.get("Name") or "?") for r in rows if r.get("Service") not in defined})
+    if orphans:
+        return result(
+            "compose.orphans", "warn",
+            "container(s) from a previous compose file are still present and may hold ports: " + ", ".join(orphans),
+            "docker compose up -d --remove-orphans",
+        )
+    return result("compose.orphans", "ok", f"{len(rows)} container(s), all defined in the current compose file")
+
+
+def check_mcp_reachable(mcp_url, timeout=3):
+    import requests
+    try:
+        resp = requests.get(mcp_url, timeout=timeout, stream=True)
+        try:
+            status = resp.status_code
+        finally:
+            resp.close()
+    except requests.RequestException as e:
+        return result(
+            "mcp.reachable", "error",
+            f"MCP server at {mcp_url} unreachable: {e.__class__.__name__}",
+            "docker compose ps mcp-server   # then `docker compose logs mcp-server`",
+        )
+    if status in (401, 403):
+        # Reachable — it wants an API key on the SSE URL (USE_API_KEYS=true).
+        return result("mcp.reachable", "ok", f"MCP server at {mcp_url} answered HTTP {status} (up; API key required on the SSE URL)")
+    if status >= 500:
+        return result("mcp.reachable", "error", f"MCP server at {mcp_url} answered HTTP {status}", "docker compose logs mcp-server")
+    return result("mcp.reachable", "ok", f"MCP server at {mcp_url} answered HTTP {status}")
+
+
+def check_disk_usage_host(runner):
+    rc, root, _ = runner.run(["docker", "info", "--format", "{{.DockerRootDir}}"])
+    root = root.strip()
+    total = free = None
+    where = root or "docker root"
+    if root and os.path.isdir(root):
+        try:
+            usage = shutil.disk_usage(root)
+            total, free = usage.total, usage.free
+        except OSError:
+            pass
+    if total is None:
+        # Docker Desktop: the data root lives inside the VM. df from a
+        # throwaway container reports that disk.
+        rc, out, _ = runner.run(["docker", "run", "--rm", "alpine", "df", "-Pk", "/"], timeout=120)
+        if rc == 0:
+            lines = [l for l in out.splitlines() if l.strip()]
+            if len(lines) >= 2:
+                parts = lines[-1].split()
+                if len(parts) >= 4:
+                    try:
+                        total = int(parts[1]) * 1024
+                        free = int(parts[3]) * 1024
+                        where = "docker VM disk"
+                    except ValueError:
+                        pass
+    if total is None or total <= 0:
+        return result("disk.usage", "skip", "could not measure the disk holding Docker's data root")
+    pct = (total - free) * 100.0 / total
+    rc, sysdf, _ = runner.run(["docker", "system", "df", "--format", "{{.Type}}: {{.Reclaimable}}"])
+    reclaim = "; ".join(l.strip() for l in sysdf.splitlines() if l.strip()) if rc == 0 else ""
+    detail = f"{where} {pct:.0f}% used ({free / 1073741824:.1f} GB free)" + (f" — reclaimable: {reclaim}" if reclaim else "")
+    remediation = "Free space before pulling images: `docker image prune`, `docker builder prune`, and check the pip-cache and object-store volumes. " \
+                  "`docker compose pull` on a nearly full disk half-writes layers."
+    if pct >= 95:
+        return result("disk.usage", "error", detail, remediation)
+    if pct >= 85:
+        return result("disk.usage", "warn", detail, remediation)
+    return result("disk.usage", "ok", detail)
+
+
+def check_build_stale_jar(runner, version_info):
+    compose_path = runner.compose_file_path()
+    if not compose_path or not os.path.isfile(compose_path):
+        return result("build.stale_jar", "skip", "no compose file in this directory")
+    with open(compose_path, encoding="utf-8", errors="replace") as f:
+        text = f.read()
+    if not re.search(r"^\s*build:\s*\.\s*(#.*)?$", text, re.M):
+        return result("build.stale_jar", "skip", "server image is pulled, not built from source")
+    if not os.path.isdir(os.path.join(runner.project_dir, ".git")):
+        return result("build.stale_jar", "skip", "not a git checkout")
+    if not version_info:
+        return result("build.stale_jar", "skip", "server version info unavailable")
+    jar_sha = (version_info.get("gitHeadCommit") or "unknown").strip()
+    built_at = version_info.get("builtAtMillis")
+    rc, head, _ = runner.run(["git", "rev-parse", "HEAD"])
+    head = head.strip()
+    remediation = "sbt clean assembly && docker compose build --no-cache datris && docker compose up -d datris"
+    if jar_sha == "unknown" or not jar_sha:
+        return result("build.stale_jar", "warn", "running jar carries no git commit stamp (built before this check existed)", remediation)
+    if rc == 0 and head and head != jar_sha:
+        built = _fmt_millis(built_at)
+        return result(
+            "build.stale_jar", "warn",
+            f"running server was built from {jar_sha[:12]} at {built}; checkout is at {head[:12]}",
+            remediation,
+        )
+    try:
+        built_secs = int(built_at) / 1000.0
+    except (TypeError, ValueError):
+        built_secs = None
+    newest = _newest_mtime(os.path.join(runner.project_dir, "datrisserver", "src"))
+    if built_secs and newest and newest > built_secs:
+        return result(
+            "build.stale_jar", "warn",
+            f"datrisserver/src has files newer ({_fmt_secs(newest)}) than the running jar ({_fmt_millis(built_at)})",
+            remediation,
+        )
+    return result("build.stale_jar", "ok", f"running jar matches checkout {head[:12]}" if head else f"jar built from {jar_sha[:12]}")
+
+
+def _newest_mtime(root):
+    newest = 0.0
+    if not os.path.isdir(root):
+        return None
+    for dirpath, _, files in os.walk(root):
+        for name in files:
+            try:
+                newest = max(newest, os.path.getmtime(os.path.join(dirpath, name)))
+            except OSError:
+                continue
+    return newest or None
+
+
+def _fmt_millis(ms):
+    try:
+        return _fmt_secs(int(ms) / 1000.0)
+    except (TypeError, ValueError):
+        return "unknown time"
+
+
+def _fmt_secs(secs):
+    return datetime.fromtimestamp(secs, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def check_vault_ai_slots_host(runner):
+    """Pre-upgrade: read the AI slot secrets through the vault container so a
+    missing `oss/codegen` is caught before the new server crash-loops on it."""
+    rc, token, err = runner.compose(["exec", "-T", "datris", "cat", "/vault-token/token"])
+    token = token.strip()
+    if rc != 0 or not token:
+        return result("vault.ai_slots", "skip", "could not read the server's Vault token (datris container not running)")
+    problems, fixes, fine = [], [], []
+    for label, name in AI_SLOT_SECRETS:
+        # The vault image's CLI defaults to https://127.0.0.1:8200; the
+        # compose listener is plain HTTP, so point it explicitly.
+        rc, out, err = runner.compose([
+            "exec", "-T", "-e", f"VAULT_TOKEN={token}", "-e", "VAULT_ADDR=http://127.0.0.1:8200",
+            "vault", "vault", "kv", "get", "-format=json", f"secret/{name}",
+        ])
+        if rc != 0 and "No value found" not in (out + err):
+            return result("vault.ai_slots", "skip", f"vault CLI failed inside the container: {(err or out).strip()[:160]}")
+        if rc != 0:
+            problems.append(f"Vault secret `{name}` ({label}) missing" + ("; the server will refuse to start" if label == "ai-primary" else ""))
+            fixes.append(f"vault kv put secret/{name} provider=<anthropic|openai|azure|bedrock|grok|ollama> endpoint=<url> model=<model> apiKey=<key>")
+            continue
+        try:
+            data = json.loads(out).get("data", {}).get("data", {}) or {}
+        except (json.JSONDecodeError, AttributeError):
+            data = {}
+        provider = (data.get("provider") or "").strip().lower()
+        missing = [f for f in ("provider", "model") if not (data.get(f) or "").strip()]
+        if not (data.get("endpoint") or "").strip() and provider != "bedrock":
+            missing.append("endpoint")
+        if missing:
+            problems.append(f"secret `{name}` ({label}) is missing " + ", ".join(f"'{m}'" for m in missing))
+            fixes.append(f"vault kv patch secret/{name} " + " ".join(f"{m}=<value>" for m in missing))
+        else:
+            fine.append(f"{label} ({provider}/{data.get('model')})")
+    if problems:
+        return result("vault.ai_slots", "error", "; ".join(problems), "; ".join(fixes))
+    return result("vault.ai_slots", "ok", ", ".join(fine))
+
+
+# ------------------------------------------------------------ orchestration
+
+def _timed(fn, *args, **kwargs):
+    start = time.time()
+    try:
+        r = fn(*args, **kwargs)
+    except Exception as e:  # a doctor bug must never take the report down
+        name = getattr(fn, "__name__", "check").replace("check_", "").replace("_", ".", 1)
+        r = result(name, "error", f"check failed: {e.__class__.__name__}: {e}", "This is a doctor bug — report it with the CLI output.")
+    r["ms"] = int((time.time() - start) * 1000)
+    return r
+
+
+def run_host_checks(runner, mcp_url, version_info=None, pre_upgrade=False):
+    """Every host-side check, in report order. Without Docker on PATH every
+    check is a skip that says so."""
+    if not runner.has_docker():
+        ids = ["volumes.anonymous", "volumes.dangling", "vault.hcl_drift", "env.not_forwarded", "env.container_drift",
+               "compose.orphans", "build.stale_jar", "disk.usage"]
+        if pre_upgrade:
+            ids.append("vault.ai_slots")
+        rows = [result(i, "skip", "docker not on PATH — run `datris doctor` on the machine running Docker") for i in ids]
+        if not pre_upgrade:
+            rows.append(_timed(check_mcp_reachable, mcp_url))
+        return rows
+    rows = [
+        _timed(check_volumes_anonymous, runner),
+        _timed(check_volumes_dangling, runner),
+        _timed(check_vault_hcl_drift, runner),
+        _timed(check_env_not_forwarded, runner),
+        _timed(check_env_container_drift, runner),
+        _timed(check_compose_orphans, runner),
+        _timed(check_disk_usage_host, runner),
+    ]
+    if pre_upgrade:
+        rows.append(_timed(check_vault_ai_slots_host, runner))
+    else:
+        rows.append(_timed(check_build_stale_jar, runner, version_info))
+        rows.append(_timed(check_mcp_reachable, mcp_url))
+    return rows
+
+
+def fetch_server(datris_url, api_key, cli_version, probes="", timeout=60):
+    """Return (doctor_report, version_info, error). `error` is a short reason
+    when the server could not be reached; an auth failure comes back as a
+    report-shaped error row instead (the server IS reachable)."""
+    import requests
+    headers = {"x-api-key": api_key} if api_key else {}
+    params = {"cli": cli_version}
+    if probes:
+        params["probes"] = probes
+    try:
+        resp = requests.get(f"{datris_url}/api/v1/doctor", headers=headers, params=params, timeout=timeout)
+    except requests.RequestException as e:
+        return None, None, f"{e.__class__.__name__}: {e}"
+    version_info = None
+    try:
+        v = requests.get(f"{datris_url}/api/v1/version", headers=headers, timeout=10)
+        if v.status_code == 200:
+            version_info = v.json()
+    except (requests.RequestException, ValueError):
+        pass
+    if resp.status_code in (401, 403):
+        report = {
+            "checks": [result(
+                "server.auth", "error",
+                f"server at {datris_url} rejected the request (HTTP {resp.status_code})",
+                "Set DATRIS_API_KEY to a key holding config:read (Configuration → API-Keys) and re-run.",
+                surface="server",
+            )]
+        }
+        return report, version_info, None
+    if resp.status_code != 200:
+        report = {"checks": [result("server.doctor", "error", f"GET /api/v1/doctor returned HTTP {resp.status_code}: {resp.text[:200]}",
+                                    "Upgrade the server — this check needs a release that ships the doctor endpoint.", surface="server")]}
+        return report, version_info, None
+    try:
+        return resp.json(), version_info, None
+    except ValueError:
+        return None, version_info, "server returned a non-JSON doctor response"
+
+
+def merge_report(server_report, host_checks, cli_version, mode="full", server_error=None, datris_url=""):
+    checks = []
+    surface = {"cli": cli_version}
+    if server_report:
+        surface.update(server_report.get("surface") or {})
+        checks.extend(server_report.get("checks") or [])
+    elif server_error is not None:
+        checks.append(result(
+            "server.reachable", "error",
+            f"Datris server at {datris_url} unreachable ({server_error}); server-side checks skipped",
+            "docker compose ps datris   # then `docker compose logs datris`; set DATRIS_URL if the server is elsewhere",
+            surface="cli",
+        ))
+    checks.extend(host_checks)
+    summary = {s: sum(1 for c in checks if c.get("status") == s) for s in ("ok", "warn", "error", "skip")}
+    return {
+        "doctorVersion": DOCTOR_VERSION,
+        "ranAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "mode": mode,
+        "surface": surface,
+        "summary": summary,
+        "checks": checks,
+    }
+
+
+def exit_code(report, server_unreachable=False):
+    """0 all ok, 1 any warn, 2 any error, 3 server unreachable (server checks skipped)."""
+    if server_unreachable:
+        return 3
+    statuses = {c.get("status") for c in report.get("checks", [])}
+    if "error" in statuses:
+        return 2
+    if "warn" in statuses:
+        return 1
+    return 0
+
+
+def render_human(report):
+    lines = []
+    width = max((len(c["id"]) for c in report.get("checks", [])), default=10)
+    for c in report.get("checks", []):
+        icon = STATUS_ICON.get(c.get("status"), "?")
+        lines.append(f"  {icon} {c['id'].ljust(width)}  {c.get('detail', '')}")
+        if c.get("status") in ("warn", "error") and c.get("remediation"):
+            lines.append(f"      ↳ {c['remediation']}")
+    s = report.get("summary", {})
+    surface = report.get("surface", {})
+    versions = ", ".join(f"{k} {v}" for k, v in surface.items())
+    lines.append("")
+    lines.append(f"  {s.get('ok', 0)} ok, {s.get('warn', 0)} warn, {s.get('error', 0)} error, {s.get('skip', 0)} skipped   ({versions})")
+    return "\n".join(lines)

--- a/mcp-server/doctor.py
+++ b/mcp-server/doctor.py
@@ -211,7 +211,7 @@ def check_volumes_anonymous(runner):
     return result("volumes.anonymous", "ok", f"named volumes on {', '.join(seen)}")
 
 
-def check_volumes_dangling(runner, limit=15):
+def check_volumes_dangling(runner, limit=100):
     rc, out, err = runner.run(["docker", "volume", "ls", "-qf", "dangling=true"])
     if rc != 0:
         return result("volumes.dangling", "skip", f"docker volume ls failed: {err.strip()[:120]}")
@@ -219,7 +219,9 @@ def check_volumes_dangling(runner, limit=15):
     if not anon:
         return result("volumes.dangling", "ok", "no dangling anonymous volumes")
     found = []
-    for vol in anon[:limit]:
+    if len(anon) > limit:
+        anon = anon[:limit]
+    for vol in anon:
         rc, listing, _ = runner.run(["docker", "run", "--rm", "-v", f"{vol}:/v:ro", "alpine", "ls", "-A", "/v"], timeout=120)
         if rc != 0:
             continue
@@ -240,7 +242,7 @@ def check_volumes_dangling(runner, limit=15):
             "Inspect before pruning: `docker run --rm -v <volume>:/v:ro alpine ls -la /v`. To recover, copy into the service's named volume: "
             "`docker run --rm -v <old>:/src:ro -v <new>:/dst alpine cp -a /src/. /dst/`.",
         )
-    return result("volumes.dangling", "ok", f"{len(anon)} dangling anonymous volume(s), none holding recognizable data")
+    return result("volumes.dangling", "ok", f"{len(anon)} dangling anonymous volume(s), none holding recognizable data (empty ones are safe to `docker volume prune`)")
 
 
 def check_vault_hcl_drift(runner):

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -49,8 +49,8 @@ datris-mcp-server = "server:main"
 datris = "cli:main"
 
 [tool.hatch.build.targets.wheel]
-only-include = ["server.py", "cli.py"]
+only-include = ["server.py", "cli.py", "doctor.py"]
 sources = ["."]
 
 [tool.hatch.build.targets.sdist]
-only-include = ["server.py", "cli.py", "pyproject.toml", "README.md"]
+only-include = ["server.py", "cli.py", "doctor.py", "pyproject.toml", "README.md"]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -510,6 +510,27 @@ def _headers():
     return h
 
 
+def _mcp_server_version():
+    """datris-mcp-server version: the installed package (pip / Homebrew), else
+    the pyproject.toml beside this file (the Docker image copies the tree
+    rather than installing it), else 'unknown'."""
+    try:
+        from importlib.metadata import version as _pkg_version
+        return _pkg_version("datris-mcp-server")
+    except Exception:
+        pass
+    try:
+        import re as _re
+        pyproject = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pyproject.toml")
+        with open(pyproject, encoding="utf-8") as f:
+            m = _re.search(r'^version\s*=\s*"([^"]+)"', f.read(), _re.M)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    return "unknown"
+
+
 def _call(method, path, timeout=300, **kwargs):
     """Make an HTTP request to the pipeline API.
 
@@ -1829,6 +1850,30 @@ def _base_tools():
             inputSchema={
                 "type": "object",
                 "properties": {},
+            }
+        ),
+        Tool(
+            name="run_doctor",
+            description=(
+                "Run the platform's operational self-check and return a report: Vault token expiry, AI slot secrets complete, "
+                "embedding model actually loaded, disk usage, component version skew, and (opt-in) whether each AI model answers. "
+                "Each non-ok check carries a remediation command for the operator; nothing is changed. "
+                "Do NOT call run_doctor as part of the normal workflow — it is slow. Only use it for diagnostics when something fails "
+                "or the user asks about the deployment's health. Host-level checks (Docker volumes, container env drift) need "
+                "`datris doctor` on the machine running Docker and are not included here."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "include_ai_probes": {
+                        "type": "boolean",
+                        "description": "Also send a minimal request through each configured AI slot to confirm the key and model work (spends a few tokens). Default false."
+                    },
+                    "mode": {
+                        "type": "string",
+                        "description": "`full` (default) or `quick` (only the cheap startup-safe subset)."
+                    }
+                },
             }
         ),
         # --- Vector Database Search Tools ---
@@ -3285,7 +3330,23 @@ def _dispatch(name: str, args: dict) -> str:
                      json={"pipeline": args["pipeline"], "fields": args["fields"]})
 
     elif name == "get_version":
-        return _call("get", "/api/v1/version")
+        raw = _call("get", "/api/v1/version")
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                data["mcpServerVersion"] = _mcp_server_version()
+                return json.dumps(data)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return raw
+
+    elif name == "run_doctor":
+        params = {"mcp": _mcp_server_version()}
+        if args.get("include_ai_probes"):
+            params["probes"] = "ai"
+        if args.get("mode") in ("quick", "full"):
+            params["mode"] = args["mode"]
+        return _call("get", "/api/v1/doctor", params=params)
 
     elif name == "check_service_health":
         return _call("get", "/api/v1/health/services")

--- a/mcp-server/tests/test_doctor.py
+++ b/mcp-server/tests/test_doctor.py
@@ -1,0 +1,287 @@
+"""Host-side doctor checks against a faked subprocess runner.
+
+Pins: the rule each check fires on, its status, the remediation text, exit
+codes, and that secret VALUES never reach the report (only key names)."""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import doctor as doc  # noqa: E402
+
+
+class FakeRunner(doc.Runner):
+    """Answers subprocess calls from a table keyed by the joined argv.
+    Unknown commands fail like a missing container would."""
+
+    def __init__(self, responses, project_dir, compose_file=None, docker=True):
+        super().__init__(compose_file=compose_file, project_dir=project_dir)
+        self.responses = responses
+        self.docker = docker
+        self.calls = []
+
+    def has_docker(self):
+        return self.docker
+
+    def run(self, args, timeout=60, input_text=None):
+        key = " ".join(args)
+        self.calls.append(key)
+        for prefix, resp in self.responses.items():
+            if key == prefix or key.startswith(prefix + " ") or key.endswith(" " + prefix):
+                if isinstance(resp, tuple):
+                    return resp
+                return 0, resp, ""
+        return 1, "", f"no fake for: {key}"
+
+
+ANON = "a" * 64
+
+
+def mounts(*entries):
+    return json.dumps([{"Type": "volume", "Name": n, "Destination": d} for n, d in entries])
+
+
+# 8. volumes.anonymous
+def test_volumes_anonymous_flags_64_hex_volume(tmp_path):
+    r = FakeRunner({
+        "docker inspect -f {{json .Mounts}} postgres": mounts((ANON, "/var/lib/postgresql/data")),
+        "docker inspect -f {{json .Mounts}} mongodb": mounts(("datris_mongodb-data", "/data/db")),
+    }, str(tmp_path))
+    res = doc.check_volumes_anonymous(r)
+    assert res["status"] == "error"
+    assert "postgres" in res["detail"]
+    assert "mongodb" not in res["detail"]
+    assert "cp -a /src/. /dst/" in res["remediation"]
+
+
+def test_volumes_anonymous_ok_when_named(tmp_path):
+    r = FakeRunner({
+        "docker inspect -f {{json .Mounts}} postgres": mounts(("datris_postgres-data", "/var/lib/postgresql/data")),
+    }, str(tmp_path))
+    res = doc.check_volumes_anonymous(r)
+    assert res["status"] == "ok"
+    assert "postgres" in res["detail"]
+
+
+def test_volumes_anonymous_ignores_non_data_mounts(tmp_path):
+    # The vault image declares VOLUME /vault/logs — anonymous by design, not data.
+    r = FakeRunner({
+        "docker inspect -f {{json .Mounts}} vault": mounts(("datris_vault-data", "/vault/file"), (ANON, "/vault/logs")),
+    }, str(tmp_path))
+    assert doc.check_volumes_anonymous(r)["status"] == "ok"
+
+
+def test_mcp_reachable_treats_auth_challenge_as_up(monkeypatch):
+    import requests
+
+    class Resp:
+        def __init__(self, code):
+            self.status_code = code
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp(401))
+    assert doc.check_mcp_reachable("http://x/sse")["status"] == "ok"
+    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp(502))
+    assert doc.check_mcp_reachable("http://x/sse")["status"] == "error"
+
+    def boom(*a, **k):
+        raise requests.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "get", boom)
+    res = doc.check_mcp_reachable("http://x/sse")
+    assert res["status"] == "error" and "docker compose ps mcp-server" in res["remediation"]
+
+
+def test_volumes_dangling_recognizes_postgres_dir(tmp_path):
+    r = FakeRunner({
+        "docker volume ls -qf dangling=true": ANON + "\nnamed-vol\n",
+        f"docker run --rm -v {ANON}:/v:ro alpine ls -A /v": "PG_VERSION\nbase\nglobal\n",
+    }, str(tmp_path))
+    res = doc.check_volumes_dangling(r)
+    assert res["status"] == "warn"
+    assert "postgres data dir" in res["detail"]
+    # named dangling volumes (a disabled service's data) are not probed
+    assert not any("named-vol" in c for c in r.calls)
+
+
+# 9. env.not_forwarded
+def test_env_not_forwarded_warns_on_unreferenced_key(tmp_path):
+    (tmp_path / ".env").write_text("DATRIS_ENV=production\nOPENAI_API_KEY=sk-secret\nCOMPOSE_PROFILES=kafka\nEMPTY=\n")
+    (tmp_path / "docker-compose.yml").write_text("services:\n  datris:\n    environment:\n      OPENAI_API_KEY: ${OPENAI_API_KEY:-}\n")
+    r = FakeRunner({}, str(tmp_path))
+    res = doc.check_env_not_forwarded(r)
+    assert res["status"] == "warn"
+    assert "DATRIS_ENV" in res["detail"]
+    assert "OPENAI_API_KEY" not in res["detail"]
+    assert "COMPOSE_PROFILES" not in res["detail"]
+    assert "sk-secret" not in json.dumps(res)
+    assert "build-standalone-compose.py" in res["remediation"]
+
+
+def test_env_not_forwarded_ok_when_referenced(tmp_path):
+    (tmp_path / ".env").write_text("DATRIS_ENV=production\n")
+    (tmp_path / "docker-compose.yml").write_text('services:\n  datris:\n    environment:\n      DATRIS_ENV: "${DATRIS_ENV:-}"\n')
+    assert doc.check_env_not_forwarded(FakeRunner({}, str(tmp_path)))["status"] == "ok"
+
+
+# 10. env.container_drift
+def _compose_config(env):
+    return json.dumps({"services": {"datris": {"container_name": "datris", "environment": env}}})
+
+
+def test_env_container_drift_credential_key_is_error_and_value_hidden(tmp_path):
+    r = FakeRunner({
+        "docker compose config --format json": _compose_config({"MONGO_PASSWORD": "new-secret", "USEUSERAUTH": "false"}),
+        "docker inspect -f {{json .Config.Env}} datris": json.dumps(["MONGO_PASSWORD=old-secret", "USEUSERAUTH=false", "PATH=/usr/bin"]),
+    }, str(tmp_path))
+    res = doc.check_env_container_drift(r)
+    assert res["status"] == "error"
+    assert "MONGO_PASSWORD" in res["detail"]
+    assert "USEUSERAUTH" not in res["detail"]
+    assert "force-recreate --no-deps datris" in res["remediation"]
+    assert "old-secret" not in json.dumps(res) and "new-secret" not in json.dumps(res)
+
+
+def test_env_container_drift_non_credential_is_warn_and_match_is_ok(tmp_path):
+    r = FakeRunner({
+        "docker compose config --format json": _compose_config({"TAPMAXOUTPUTMB": "200"}),
+        "docker inspect -f {{json .Config.Env}} datris": json.dumps(["TAPMAXOUTPUTMB=100"]),
+    }, str(tmp_path))
+    assert doc.check_env_container_drift(r)["status"] == "warn"
+    r = FakeRunner({
+        "docker compose config --format json": _compose_config({"TAPMAXOUTPUTMB": "100", "PASSTHROUGH": None}),
+        "docker inspect -f {{json .Config.Env}} datris": json.dumps(["TAPMAXOUTPUTMB=100"]),
+    }, str(tmp_path))
+    assert doc.check_env_container_drift(r)["status"] == "ok"
+
+
+def test_compose_orphans_handles_both_ps_json_shapes(tmp_path):
+    for ps in (
+        json.dumps([{"Service": "datris"}, {"Service": "ollama"}]),
+        '{"Service": "datris"}\n{"Service": "ollama"}\n',
+    ):
+        r = FakeRunner({
+            "docker compose config --services": "datris\nmongodb\n",
+            "docker compose ps -a --format json": ps,
+        }, str(tmp_path))
+        res = doc.check_compose_orphans(r)
+        assert res["status"] == "warn"
+        assert "ollama" in res["detail"]
+        assert res["remediation"] == "docker compose up -d --remove-orphans"
+
+
+def test_vault_hcl_drift_uses_container_start_vs_file_mtime(tmp_path):
+    hcl = tmp_path / "docker" / "vault.hcl"
+    hcl.parent.mkdir()
+    hcl.write_text('max_lease_ttl = "87600h"\n')
+    os.utime(hcl, (1_800_000_000, 1_800_000_000))  # 2027 — after the container started
+    r = FakeRunner({
+        "docker inspect -f {{.State.StartedAt}} vault": "2026-09-01T10:00:00.123456789Z\n",
+        "docker compose exec -T vault cat /vault/config/vault.hcl": 'max_lease_ttl = "87600h"\n',
+    }, str(tmp_path))
+    res = doc.check_vault_hcl_drift(r)
+    assert res["status"] == "warn"
+    assert "changed after the vault container started" in res["detail"]
+    assert "--force-recreate vault" in res["remediation"]
+    os.utime(hcl, (1_700_000_000, 1_700_000_000))  # 2023 — before
+    assert doc.check_vault_hcl_drift(r)["status"] == "ok"
+    r.responses["docker compose exec -T vault cat /vault/config/vault.hcl"] = 'max_lease_ttl = "768h"\n'
+    assert doc.check_vault_hcl_drift(r)["status"] == "warn"
+
+
+def test_build_stale_jar_compares_git_head(tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services:\n  datris:\n    build: .\n")
+    (tmp_path / ".git").mkdir()
+    r = FakeRunner({"git rev-parse HEAD": "abcdef1234567890\n"}, str(tmp_path))
+    res = doc.check_build_stale_jar(r, {"gitHeadCommit": "1234567890abcdef", "builtAtMillis": "1700000000000"})
+    assert res["status"] == "warn"
+    assert "abcdef123456" in res["detail"]
+    assert "sbt clean assembly" in res["remediation"]
+    assert doc.check_build_stale_jar(r, {"gitHeadCommit": "abcdef1234567890", "builtAtMillis": str(2_000_000_000_000)})["status"] == "ok"
+    (tmp_path / "docker-compose.yml").write_text("services:\n  datris:\n    image: datrisai/datris-server:latest\n    #build: .\n")
+    assert doc.check_build_stale_jar(r, {"gitHeadCommit": "x"})["status"] == "skip"
+
+
+def test_vault_ai_slots_host_flags_missing_codegen(tmp_path):
+    good = json.dumps({"data": {"data": {"provider": "anthropic", "endpoint": "https://x", "model": "m", "apiKey": "k"}}})
+    r = FakeRunner({
+        "docker compose exec -T datris cat /vault-token/token": "hvs.token\n",
+        "docker compose exec -T -e VAULT_TOKEN=hvs.token -e VAULT_ADDR=http://127.0.0.1:8200 vault vault kv get -format=json secret/oss/ai-primary": good,
+        "docker compose exec -T -e VAULT_TOKEN=hvs.token -e VAULT_ADDR=http://127.0.0.1:8200 vault vault kv get -format=json secret/oss/embedding": good,
+        "docker compose exec -T -e VAULT_TOKEN=hvs.token -e VAULT_ADDR=http://127.0.0.1:8200 vault vault kv get -format=json secret/oss/codegen": (2, "", "No value found at secret/data/oss/codegen"),
+    }, str(tmp_path))
+    res = doc.check_vault_ai_slots_host(r)
+    assert res["status"] == "error"
+    assert "oss/codegen" in res["detail"]
+    assert "vault kv put secret/oss/codegen" in res["remediation"]
+    # A vault CLI that cannot talk to Vault at all is a skip, not "everything missing".
+    r.responses = {"docker compose exec -T datris cat /vault-token/token": "hvs.token\n"}
+    assert doc.check_vault_ai_slots_host(r)["status"] == "skip"
+
+
+# 11. docker missing → all host checks skip; skips don't affect the exit code
+def test_no_docker_all_host_checks_skip(tmp_path, monkeypatch):
+    r = FakeRunner({}, str(tmp_path), docker=False)
+    monkeypatch.setattr(doc, "check_mcp_reachable", lambda url, timeout=3: doc.result("mcp.reachable", "ok", "up"))
+    rows = doc.run_host_checks(r, "http://localhost:3000/sse")
+    host_only = [row for row in rows if row["id"] != "mcp.reachable"]
+    assert host_only and all(row["status"] == "skip" for row in host_only)
+    assert all("docker not on PATH" in row["detail"] for row in host_only)
+    report = doc.merge_report({"surface": {"server": "1.28.2"}, "checks": [doc.result("vault.token_ttl", "ok", "fine", surface="server")]}, rows, "1.28.2")
+    assert doc.exit_code(report) == 0
+
+
+# 12. exit codes
+def test_exit_codes():
+    ok = doc.merge_report({"checks": [doc.result("a", "ok", "")]}, [doc.result("b", "skip", "")], "1")
+    warn = doc.merge_report({"checks": [doc.result("a", "warn", "", "fix")]}, [], "1")
+    err = doc.merge_report({"checks": [doc.result("a", "ok", "")]}, [doc.result("b", "error", "", "fix")], "1")
+    down = doc.merge_report(None, [doc.result("b", "ok", "")], "1", server_error="ConnectionError", datris_url="http://x")
+    assert doc.exit_code(ok) == 0
+    assert doc.exit_code(warn) == 1
+    assert doc.exit_code(err) == 2
+    assert doc.exit_code(down, server_unreachable=True) == 3
+    assert down["checks"][0]["id"] == "server.reachable" and down["checks"][0]["status"] == "error"
+
+
+# 13. report shape and pre-upgrade never touching the server
+def test_merge_report_shape_and_summary():
+    server = {"doctorVersion": 1, "surface": {"server": "1.28.2", "cli": "1.28.2"},
+              "checks": [doc.result("vault.token_ttl", "warn", "ttl 28d", "fix", surface="server", ms=12)]}
+    report = doc.merge_report(server, [doc.result("volumes.anonymous", "ok", "named")], "1.28.2")
+    assert set(report) == {"doctorVersion", "ranAt", "mode", "surface", "summary", "checks"}
+    assert report["summary"] == {"ok": 1, "warn": 1, "error": 0, "skip": 0}
+    assert report["surface"] == {"cli": "1.28.2", "server": "1.28.2"}
+    for c in report["checks"]:
+        assert set(c) == {"id", "status", "severity", "detail", "remediation", "surface", "ms"}
+    text = doc.render_human(report)
+    assert "! vault.token_ttl" in text and "↳ fix" in text
+    assert "✓ volumes.anonymous" in text
+    assert "1 ok, 1 warn, 0 error, 0 skipped" in text
+
+
+def test_pre_upgrade_runs_vault_slots_not_server_dependent_checks(tmp_path, monkeypatch):
+    r = FakeRunner({}, str(tmp_path))
+    called = []
+    monkeypatch.setattr(doc, "check_mcp_reachable", lambda *a, **k: called.append("mcp") or doc.result("mcp.reachable", "ok", ""))
+    rows = doc.run_host_checks(r, "http://localhost:3000/sse", pre_upgrade=True)
+    ids = [row["id"] for row in rows]
+    assert "vault.ai_slots" in ids
+    assert "build.stale_jar" not in ids and "mcp.reachable" not in ids
+    assert called == []
+
+
+def test_parse_dotenv_strips_quotes_and_comments(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text('# comment\nA=1\nB="two words"\nexport C=\'x\'\nbad line\n')
+    assert doc.parse_dotenv(str(p)) == {"A": "1", "B": "two words", "C": "x"}
+
+
+def test_parse_docker_time():
+    assert doc._parse_docker_time("2026-09-01T10:00:00.123456789Z") == pytest.approx(1_788_256_800.123456, abs=1)
+    assert doc._parse_docker_time("0001-01-01T00:00:00Z") is None

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,6 +6,12 @@ COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
+# Version stamp read by the Doctor panel and `datris doctor` (version.skew).
+# The release workflow passes the tag; a from-source build without it reports
+# "unknown", which doctor flags as a warning rather than an error. Written
+# here (build stage) because the nginx stage runs unprivileged.
+ARG APP_VERSION=unknown
+RUN printf '{"version":"%s"}\n' "$APP_VERSION" > /app/dist/pipeline-ui/browser/version.json
 
 # Stage 2: Serve (non-root nginx, listens on 8080)
 FROM nginxinc/nginx-unprivileged:alpine@sha256:d9083fe47768377ef55dedafd67d4da7c2f2bc2bece7554954f29359deb0dce9

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { UsersComponent } from './configuration/users/users.component';
 import { KeysComponent } from './configuration/keys/keys.component';
 import { AuditLogComponent } from './configuration/audit-log/audit-log.component';
 import { AgentPolicyComponent } from './configuration/agent-policy/agent-policy.component';
+import { DoctorComponent } from './configuration/doctor/doctor.component';
 import { VersionHistoryComponent } from './version-history/version-history.component';
 import { AppRoutingModule } from './app-routing.module';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -85,6 +86,7 @@ import { NgxEchartsModule } from 'ngx-echarts';
     KeysComponent,
     AuditLogComponent,
     AgentPolicyComponent,
+    DoctorComponent,
     VersionHistoryComponent
   ],
   imports: [

--- a/ui/src/app/configuration/configuration.component.html
+++ b/ui/src/app/configuration/configuration.component.html
@@ -23,6 +23,9 @@
     <button class="sub-tab" [class.sub-tab-active]="activeTab === 'agent-policy'"
             *ngIf="canSeeAgentPolicy"
             (click)="activeTab = 'agent-policy'">Agent Policy</button>
+    <button class="sub-tab" [class.sub-tab-active]="activeTab === 'doctor'"
+            *ngIf="canSeeDoctor"
+            (click)="activeTab = 'doctor'">Doctor</button>
   </div>
 
   <app-users *ngIf="activeTab === 'users' && useUserAuth"></app-users>
@@ -30,6 +33,7 @@
   <app-keys *ngIf="activeTab === 'keys' && canSeeKeys"></app-keys>
   <app-audit-log *ngIf="activeTab === 'audit-log' && canSeeAuditLog"></app-audit-log>
   <app-agent-policy *ngIf="activeTab === 'agent-policy' && canSeeAgentPolicy"></app-agent-policy>
+  <app-doctor *ngIf="activeTab === 'doctor' && canSeeDoctor"></app-doctor>
   <app-data-sources *ngIf="activeTab === 'data-sources'"></app-data-sources>
   <app-code-repo *ngIf="activeTab === 'code-repo'"></app-code-repo>
 

--- a/ui/src/app/configuration/configuration.component.ts
+++ b/ui/src/app/configuration/configuration.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ModelCatalogService, ModelOption } from '../model-catalog.service';
 import { AuthService } from '../auth.service';
 
-type ConfigTab = 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log' | 'agent-policy';
+type ConfigTab = 'ai-providers' | 'users' | 'secrets' | 'keys' | 'data-sources' | 'code-repo' | 'audit-log' | 'agent-policy' | 'doctor';
 
 @Component({
     selector: 'app-configuration',
@@ -170,13 +170,19 @@ export class ConfigurationComponent implements OnInit {
     return !this.isTrial && (!this.useUserAuth || this.isAdmin());
   }
 
+  /** Admin-only like Audit Log — the report names env keys, Vault paths and
+   *  model ids. */
+  get canSeeDoctor(): boolean {
+    return !this.isTrial && (!this.useUserAuth || this.isAdmin());
+  }
+
   ngOnInit(): void {
     // Honor ?tab=<name> for deep-links (e.g. the redirect from /secrets).
     this.route.queryParamMap.subscribe(p => {
       const t = p.get('tab');
       if (t === 'ai-providers' ||
           t === 'users' || t === 'secrets' || t === 'keys' || t === 'data-sources' || t === 'audit-log' ||
-          t === 'agent-policy') {
+          t === 'agent-policy' || t === 'doctor') {
         this.activeTab = t;
       }
     });
@@ -207,6 +213,9 @@ export class ConfigurationComponent implements OnInit {
           this.activeTab = 'ai-providers';
         }
         if (this.activeTab === 'agent-policy' && !this.canSeeAgentPolicy) {
+          this.activeTab = 'ai-providers';
+        }
+        if (this.activeTab === 'doctor' && !this.canSeeDoctor) {
           this.activeTab = 'ai-providers';
         }
         // Load the model catalog before reading secrets so maybeAddExtraModel compares

--- a/ui/src/app/configuration/doctor/doctor.component.css
+++ b/ui/src/app/configuration/doctor/doctor.component.css
@@ -1,0 +1,180 @@
+.doctor-pane {
+  padding: 24px;
+  color: #f0f4ff;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.hint {
+  margin: 4px 0 0;
+  color: #8b9dc3;
+  font-size: 0.8rem;
+  max-width: 640px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: #8b9dc3;
+  cursor: pointer;
+}
+
+.error {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+.empty {
+  padding: 14px 16px;
+  background: #0a0e1a;
+  border: 1px solid rgba(99, 179, 237, 0.15);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: #8b9dc3;
+}
+
+.empty p { margin: 0; }
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  background: #0a0e1a;
+  border: 1px solid rgba(0, 229, 160, 0.3);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.summary-problems {
+  border-color: rgba(255, 191, 0, 0.4);
+}
+
+.count { font-weight: 600; }
+.count-ok { color: #00e5a0; }
+.count-warn { color: #ffbf00; }
+.count-error { color: #f87171; }
+.count-skip { color: #8b9dc3; }
+
+.meta {
+  margin-left: auto;
+  color: #8b9dc3;
+  font-size: 0.75rem;
+}
+
+.checks {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  background: #0a0e1a;
+  border: 1px solid rgba(99, 179, 237, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.checks th {
+  text-align: left;
+  padding: 8px 10px;
+  color: #8b9dc3;
+  font-weight: 600;
+  font-size: 0.75rem;
+  border-bottom: 1px solid rgba(99, 179, 237, 0.15);
+}
+
+.checks td {
+  padding: 8px 10px;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(99, 179, 237, 0.08);
+}
+
+.col-status { width: 28px; text-align: center; }
+.col-id { width: 180px; white-space: nowrap; }
+.col-ms { width: 56px; text-align: right; color: #8b9dc3; font-variant-numeric: tabular-nums; }
+
+.checks code {
+  color: #00b4ff;
+  font-size: 0.8rem;
+}
+
+.detail { color: #d5deef; }
+
+.icon {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  line-height: 18px;
+  border-radius: 50%;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.icon-ok { background: rgba(0, 229, 160, 0.15); color: #00e5a0; }
+.icon-warn { background: rgba(255, 191, 0, 0.15); color: #ffbf00; }
+.icon-error { background: rgba(248, 113, 113, 0.15); color: #f87171; }
+.icon-skip { background: rgba(139, 157, 195, 0.15); color: #8b9dc3; }
+
+.row-error .detail { color: #f87171; }
+.row-warn .detail { color: #ffbf00; }
+.row-skip .detail { color: #8b9dc3; }
+
+.remediation-row td { border-bottom: 1px solid rgba(99, 179, 237, 0.08); }
+.remediation {
+  padding-top: 0 !important;
+  color: #00e5a0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
+.footer {
+  margin-top: 14px;
+  color: #8b9dc3;
+  font-size: 0.78rem;
+}
+
+.footer code { color: #00e5a0; }
+
+.btn-primary {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #00b4ff, #00e5a0);
+  color: #000;
+}
+
+.btn-primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (max-width: 900px) {
+  .header { flex-direction: column; }
+  .col-id { width: auto; white-space: normal; }
+}

--- a/ui/src/app/configuration/doctor/doctor.component.html
+++ b/ui/src/app/configuration/doctor/doctor.component.html
@@ -1,0 +1,61 @@
+<div class="doctor-pane">
+  <div class="header">
+    <div>
+      <h3>Doctor</h3>
+      <p class="hint">Operational self-check: Vault token expiry, AI slot secrets, embedding model loaded, disk usage, version skew. Every finding comes with the command that fixes it; nothing is changed.</p>
+    </div>
+    <div class="header-actions">
+      <label class="toggle" title="Send a minimal request through each configured AI slot to confirm the key and model work. Spends a few tokens.">
+        <input type="checkbox" [(ngModel)]="includeAiProbes" name="includeAiProbes" [disabled]="loading" />
+        Include AI probes
+      </label>
+      <button class="btn-primary" (click)="run()" [disabled]="loading">{{ loading ? 'Running…' : (report ? 'Run again' : 'Run checks') }}</button>
+    </div>
+  </div>
+
+  <p class="error" *ngIf="error">{{ error }}</p>
+
+  <div class="empty" *ngIf="!report && !loading && !error">
+    <p>Nothing has run yet. Checks run only when you ask — the AI probe costs tokens, so it is off by default.</p>
+  </div>
+
+  <ng-container *ngIf="report">
+    <div class="summary" [class.summary-problems]="hasProblems">
+      <span class="count count-ok">{{ report.summary.ok }} ok</span>
+      <span class="count count-warn">{{ report.summary.warn }} warn</span>
+      <span class="count count-error">{{ report.summary.error }} error</span>
+      <span class="count count-skip">{{ report.summary.skip }} skipped</span>
+      <span class="meta">{{ surfaceLine }} · {{ report.ranAt }}</span>
+    </div>
+
+    <table class="checks">
+      <thead>
+        <tr>
+          <th class="col-status"></th>
+          <th class="col-id">Check</th>
+          <th>Detail</th>
+          <th class="col-ms">ms</th>
+        </tr>
+      </thead>
+      <tbody>
+        <ng-container *ngFor="let c of report.checks">
+          <tr [class]="'row-' + c.status">
+            <td class="col-status"><span class="icon" [class]="'icon icon-' + c.status">{{ icon(c.status) }}</span></td>
+            <td class="col-id"><code>{{ c.id }}</code></td>
+            <td class="detail">{{ c.detail }}</td>
+            <td class="col-ms">{{ c.ms }}</td>
+          </tr>
+          <tr class="remediation-row" *ngIf="(c.status === 'warn' || c.status === 'error') && c.remediation">
+            <td></td>
+            <td colspan="3" class="remediation">↳ {{ c.remediation }}</td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
+  </ng-container>
+
+  <p class="footer">
+    Host checks (anonymous Docker volumes, container env drift, orphaned containers, disk on the host) need
+    <code>datris doctor</code> on the machine running Docker. Before an upgrade, run <code>datris doctor --pre-upgrade</code> there.
+  </p>
+</div>

--- a/ui/src/app/configuration/doctor/doctor.component.ts
+++ b/ui/src/app/configuration/doctor/doctor.component.ts
@@ -1,0 +1,91 @@
+import { Component } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export interface DoctorCheck {
+  id: string;
+  status: 'ok' | 'warn' | 'error' | 'skip';
+  severity: string;
+  detail: string;
+  remediation: string;
+  surface: string;
+  ms: number;
+}
+
+export interface DoctorReport {
+  doctorVersion: number;
+  ranAt: string;
+  mode: string;
+  surface: Record<string, string>;
+  summary: { ok: number; warn: number; error: number; skip: number };
+  checks: DoctorCheck[];
+}
+
+/** Admin-only Doctor sub-tab inside Configuration.
+ *
+ *  Runs the server's operational self-check (GET /api/v1/doctor) on demand —
+ *  never on load: the AI probe spends tokens and the report is only useful
+ *  when someone is looking at it. Host-level checks (Docker volumes,
+ *  container env drift) need `datris doctor` on the machine running Docker;
+ *  the footer says so. */
+@Component({
+    selector: 'app-doctor',
+    templateUrl: './doctor.component.html',
+    styleUrl: './doctor.component.css',
+    standalone: false
+})
+export class DoctorComponent {
+  report: DoctorReport | null = null;
+  loading = false;
+  error = '';
+  includeAiProbes = false;
+  /** Stamped into the UI image at build time (/version.json); 'unknown' when
+   *  built from source without APP_VERSION. Sent to the server so the
+   *  version-skew check can compare it. */
+  uiVersion = '';
+
+  constructor(private http: HttpClient) {}
+
+  async run(): Promise<void> {
+    this.loading = true;
+    this.error = '';
+    try {
+      if (!this.uiVersion) this.uiVersion = await this.loadUiVersion();
+      let params = new HttpParams().set('mode', 'full').set('ui', this.uiVersion);
+      if (this.includeAiProbes) params = params.set('probes', 'ai');
+      this.report = await firstValueFrom(this.http.get<DoctorReport>('/api/v1/doctor', { params }));
+    } catch (err: any) {
+      this.report = null;
+      this.error = err?.error?.error || err?.message || 'Doctor request failed';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async loadUiVersion(): Promise<string> {
+    try {
+      const v = await firstValueFrom(this.http.get<{ version?: string }>('/version.json'));
+      return (v?.version || 'unknown').trim();
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  icon(status: string): string {
+    switch (status) {
+      case 'ok': return '✓';
+      case 'warn': return '!';
+      case 'error': return '✗';
+      default: return '○';
+    }
+  }
+
+  get surfaceLine(): string {
+    if (!this.report) return '';
+    return Object.entries(this.report.surface).map(([k, v]) => `${k} ${v}`).join(', ');
+  }
+
+  get hasProblems(): boolean {
+    return !!this.report && (this.report.summary.warn > 0 || this.report.summary.error > 0);
+  }
+}

--- a/ui/src/app/mcp/mcp.component.ts
+++ b/ui/src/app/mcp/mcp.component.ts
@@ -63,7 +63,7 @@ export class McpComponent implements OnInit {
 
   // Full tool catalog.
   // KEEP IN SYNC with mcp-server/server.py's _base_tools() and the server's
-  // auth/MCPToolRoutes.scala — one entry here per MCP tool (72 as of v1.26).
+  // auth/MCPToolRoutes.scala — one entry here per MCP tool (74 as of v1.29).
   toolCatalog: McpTool[] = [
     // --- System ---
     {
@@ -78,6 +78,16 @@ export class McpComponent implements OnInit {
       description: 'Check which backend services are up, down, or not configured. Returns status of PostgreSQL, MongoDB, MinIO, ActiveMQ, Kafka, and vector databases.',
       category: 'System',
       parameters: [],
+      playgroundEnabled: true
+    },
+    {
+      name: 'run_doctor',
+      description: 'Run the operational self-check: Vault token expiry, AI slot secrets, embedding model loaded, disk usage, version skew, and (opt-in) whether each AI model answers. Diagnostics only — slow; not part of the normal workflow.',
+      category: 'System',
+      parameters: [
+        { name: 'include_ai_probes', type: 'boolean', description: 'Also send a minimal request through each AI slot (spends a few tokens). Default false.', required: false, inputType: 'checkbox' },
+        { name: 'mode', type: 'string', description: '`full` (default) or `quick` (cheap startup-safe subset only).', required: false, inputType: 'text' }
+      ],
       playgroundEnabled: true
     },
     {


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the doctor plan. One place for the deterministic probes behind the incidents that used to be diagnosed by hand from the logs (anonymous volumes, Vault token TTL clamp, missing `oss/codegen`, stale jar, env not forwarded, embedding model not pulled, disk full, version skew). Every finding carries the command that fixes it; nothing is ever changed, and nothing spends money unless asked.

**Surfaces**

- **Boot log:** the cheap subset runs at startup (`doctor.onStartup`, default true) as `DOCTOR` lines, before the AI-secret hard failures so a missing secret gets its fix printed ahead of the stack trace. Wrapped so a doctor bug never blocks boot. A healthy install logs zero warnings.
- **`GET /api/v1/doctor`** (`?mode=quick|full&probes=ai&cli=&mcp=&ui=`), capability `config:read`. Not public: the report names env keys, Vault paths and model ids.
- **`run_doctor` MCP tool** on all three catalog surfaces (74 tools); `get_version` gains `mcpServerVersion`.
- **`datris doctor` CLI** adds the host checks that need Docker (anonymous data volumes, dangling data volumes, container env drift, compose orphans, `vault.hcl` drift, stale source build, MCP reachability), merges them with the server report, and exits 0/1/2/3. `--pre-upgrade` works with the server stopped and reads the AI slot secrets through the vault container. Talks to the server REST directly: a dead MCP server is itself a finding.
- **Configuration → Doctor** sub-tab, on demand only, with an AI-probe toggle. The UI image now stamps `/version.json` from `APP_VERSION` so version skew can see it.

**Server checks:** `vault.token_ttl`, `vault.ai_slots`, `jdbc.mssql_driver`, `ai.embedding_model` (TEI `/info`, Ollama `/api/tags`), `disk.usage`, `version.skew`, `env.seen`, and the opt-in `ai.model_reachable` (minimal request per slot, 10 s, no retry, never at boot).

**Deviations from the plan, on purpose:** version skew is client-reported rather than probed; `env.not_forwarded` scans the raw compose text for `${KEY` references since the rendered config loses them; an unreachable embedding service is a skip at boot (TEI still loading) but an error on demand; `volumes.anonymous` only fires on a service's data mount paths (Vault's image declares a throwaway logs volume); an MCP server answering 401 counts as reachable; the token clamp rule is "ttl under a tenth of the period" because a freshly clamped token sits at 768h, above the plan's 720h threshold.

Also: BuildInfo gains `gitHeadCommit` and `builtAtMillis`, exposed on `/api/v1/version`; new docs page `docs/doctor.mdx`, a step 0 in the upgrade guide, CLI and MCP reference entries; a pytest job for the host checks in CI.

## Backward compatibility

- No existing endpoint changes shape; `/api/v1/version` and `get_version` gain additive keys only.
- `doctor.onStartup` only logs. Installs that boot today boot identically.
- The new route reuses `config:read`; no new capability. MCP profiles without it see the standard denial.
- `docker-compose.yml` untouched. The UI image built from source without `APP_VERSION` reports `unknown`, which doctor treats as a warning, not an error.

## Test plan

- [x] Scala: `DoctorServiceSpec` (17), `MCPToolRoutesSpec` catalog at 74 and doctor route mapped; full suite 434 green, scalafmt clean
- [x] Python: `mcp-server/tests/test_doctor.py` (19) against a faked docker/git runner; wired into CI
- [x] `scripts/check-mcp-tool-catalog.py` in sync; UI builds
- [x] Live on a rebuilt local stack: boot log shows the subset with zero warnings; `/doctor` 401 without a key; with key and `probes=ai` all three slots answer; CLI full, `--pre-upgrade` and `--json` runs; `run_doctor` via the MCP server
- [x] Live reproductions: `.env` edit + `restart` → `env.container_drift` warn, cleared by `force-recreate`; `oss/codegen` deleted → error on host and server paths, restored; Vault ceiling 768h + fresh mint → clamp warning at boot and in the CLI, reverted
- [ ] Ollama-backed embedding slot (only TEI and OpenAI exercised live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)